### PR TITLE
(misc) Add a Network Broker

### DIFF
--- a/choria/config.go
+++ b/choria/config.go
@@ -48,6 +48,13 @@ type ChoriaPluginConfig struct {
 	PrivilegedUsers   []string `confkey:"plugin.choria.security.privileged_users" type:"comma_split"`
 	CertnameWhitelist []string `confkey:"plugin.choria.security.certname_whitelist" type:"comma_split"`
 	Serializer        string   `confkey:"plugin.choria.security.serializer"` // TODO support enums
+
+	// network broker
+	NetworkClientPort   int      `confkey:"plugin.choria.network_client_port" default:"4222"`
+	NetworkPeerPort     int      `confkey:"plugin.choria.network_peer_port" default:"5222"`
+	NetworkPeerUser     string   `confkey:"plugin.choria.network_peer_user"`
+	NetworkPeerPassword string   `confkey:"plugin.choria.network_peer_password"`
+	NetworkPeers        []string `confkey:"plugin.choria.network_peers" type:"comma_split"`
 }
 
 // MCollectiveConfig represents MCollective configuration

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: bf70020a442b88e783f44a8b1aeb21c38c42feccc7cef651b9ad347917271ca8
-updated: 2017-06-12T13:18:46.38496313+02:00
+hash: 428c972481596a6f27fdd55355e04eeaa4cbeb270640ead0d871501b71902e45
+updated: 2017-06-12T13:24:04.118929419+02:00
 imports:
+- name: github.com/nats-io/gnatsd
+  version: 5dcad241bcd7fff3aac6e9f8b47350f071f5fd38
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/crypto

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,8 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ssh/terminal
+- package: github.com/nats-io/gnatsd
+  version: ^0.9.6
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/network/logger.go
+++ b/network/logger.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+// Logger is nats server.Logger compatible logging wrapper for logrus
+type Logger struct{}
+
+// Noticef logs at info level
+func (l Logger) Noticef(format string, v ...interface{}) {
+	log.Infof(format, v...)
+}
+
+// Fatalf logs at fatal level
+func (l Logger) Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
+}
+
+// Errorf logs at error lovel
+func (l Logger) Errorf(format string, v ...interface{}) {
+	log.Errorf(format, v...)
+}
+
+// Debugf logs at debug level
+func (l Logger) Debugf(format string, v ...interface{}) {
+	log.Debugf(format, v...)
+}
+
+// Tracef logs at debug level
+func (l Logger) Tracef(format string, v ...interface{}) {
+	log.Debugf(format, v...)
+}
+
+func newLogger() Logger {
+	return Logger{}
+}

--- a/network/network.go
+++ b/network/network.go
@@ -1,0 +1,117 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/choria-io/go-choria/choria"
+	log "github.com/sirupsen/logrus"
+
+	gnatsd "github.com/nats-io/gnatsd/server"
+)
+
+// Server represents the Choria network broker server
+type Server struct {
+	gnatsd *gnatsd.Server
+	opts   *gnatsd.Options
+	choria *choria.Choria
+}
+
+// NewServer creates a new instance of the Server struct with a fully configured NATS embedded
+func NewServer(c *choria.Choria) (s Server, err error) {
+	s = Server{
+		choria: c,
+		opts:   &gnatsd.Options{},
+	}
+
+	s.opts.Host = "::"
+	s.opts.Port = c.Config.Choria.NetworkClientPort
+	s.opts.Logtime = false
+
+	if c.Config.LogLevel == "debug" {
+		s.opts.Debug = true
+	}
+
+	err = s.setupTLS()
+	if err != nil {
+		return s, fmt.Errorf("Could not setup TLS: %s", err.Error())
+	}
+
+	err = s.setupCluster()
+	if err != nil {
+		return s, fmt.Errorf("Could not setup Clustering: %s", err.Error())
+	}
+
+	s.gnatsd = gnatsd.New(s.opts)
+	s.gnatsd.SetLogger(newLogger(), s.opts.Debug, false)
+
+	return
+}
+
+// Start the embedded NATS instance
+func (s *Server) Start() {
+	log.Infof("Starting new Network Broker with NATS version %s on %s:%d using config file %s", gnatsd.VERSION, s.opts.Host, s.opts.Port, choria.UserConfig())
+
+	s.gnatsd.Start()
+}
+
+func (s *Server) setupCluster() (err error) {
+	s.opts.Cluster.Host = "::"
+	s.opts.Cluster.NoAdvertise = true
+	s.opts.Cluster.Port = s.choria.Config.Choria.NetworkPeerPort
+	s.opts.Cluster.Username = s.choria.Config.Choria.NetworkPeerUser
+	s.opts.Cluster.Password = s.choria.Config.Choria.NetworkPeerPassword
+
+	peers, err := s.choria.NetworkBrokerPeers()
+	if err != nil {
+		return fmt.Errorf("Could not determine network broker peers: %s", err.Error())
+	}
+
+	for _, p := range peers {
+		u, err := p.URL()
+		if err != nil {
+			return fmt.Errorf("Could not parse Peer configuration: %s", err.Error())
+		}
+
+		s.opts.Routes = append(s.opts.Routes, u)
+	}
+
+	return
+}
+
+func (s *Server) setupTLS() (err error) {
+	s.opts.TLS = true
+	s.opts.TLSVerify = true
+
+	// seems weird to set all this when the thing that it cares for is TlsConfig
+	// but that's what gnatsd main also does, so sticking with that pattern
+	if p, err := s.choria.CAPath(); err == nil {
+		s.opts.TLSCaCert = p
+	} else {
+		return fmt.Errorf("Could not set the CA: %s", err.Error())
+	}
+
+	if p, err := s.choria.ClientPublicCert(); err == nil {
+		s.opts.TLSCert = p
+	} else {
+		return fmt.Errorf("Could not set the Public Cert: %s", err.Error())
+	}
+
+	if p, err := s.choria.ClientPrivateKey(); err == nil {
+		s.opts.TLSKey = p
+	}
+
+	tc := gnatsd.TLSConfigOpts{}
+	tc.CaFile = s.opts.TLSCaCert
+	tc.CertFile = s.opts.TLSCert
+	tc.KeyFile = s.opts.TLSKey
+	tc.Verify = true
+	tc.Timeout = 2
+
+	if s.opts.TLSConfig, err = gnatsd.GenTLSConfig(&tc); err != nil {
+		return
+	}
+
+	s.opts.Cluster.TLSConfig = s.opts.TLSConfig
+
+	return
+}


### PR DESCRIPTION
This is a embedded NATS broker that is configured using mcollective
config and SRV records.

Settings like SSL setup etc is taken from the usual Choria ssl setup
helpers and on by default and cannot be disabled.

Network broker peers are taken from SRV lookup _mcollective-broker._tcp
or from plugin.choria.network_peers which should be a comma sep list of
nats:// urls

Other options considered:

    plugin.choria.network_client_port
    plugin.choria.natwork_peer_port
    plugin.choria.network_peer_user
    plugin.choria.network_peer_password

This is not tested much at present