### PR TITLE
(#4) add some CLI stuff to run a broker

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/choria-io/go-choria/network"
+	log "github.com/sirupsen/logrus"
+)
+
+type brokerCommand struct {
+	command
+}
+
+type brokerRunCommand struct {
+	command
+	server *network.Server
+}
+
+// broker
+func (b *brokerCommand) Setup() (err error) {
+	b.cmd = cli.app.Command("broker", "Choria Network Broker")
+
+	return
+}
+
+func (b *brokerCommand) Run() (err error) {
+	return
+}
+
+// broker run
+func (r *brokerRunCommand) Setup() (err error) {
+	if broker, ok := cmdWithFullCommand("broker"); ok {
+		r.cmd = broker.Cmd().Command("run", "Runs a Choria Network Broker instance").Default()
+	}
+
+	return
+}
+
+func (r *brokerRunCommand) Run() (err error) {
+	r.server, err = network.NewServer(Choria, debug)
+	if err != nil {
+		return fmt.Errorf("Could not set up Choria Network Broker: %s", err.Error())
+	}
+
+	log.Debug("Starting goroutine for the NATS broker")
+
+	go r.server.Start()
+
+	return
+}
+
+func init() {
+	cli.commands = append(cli.commands, &brokerCommand{})
+	cli.commands = append(cli.commands, &brokerRunCommand{})
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/choria-io/go-choria/choria"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type application struct {
+	app      *kingpin.Application
+	command  string
+	commands []runableCmd
+}
+
+const version = "0.0.1"
+
+var cli = application{}
+var debug = false
+var configFile = ""
+var Choria *choria.Choria
+
+func ParseCLI() (err error) {
+	cli.app = kingpin.New("choria", "Choria Orchestration System")
+	cli.app.Version(version)
+	cli.app.Author("R.I.Pienaar <rip@devco.net>")
+	cli.app.Flag("debug", "Enable debug logging").Short('d').BoolVar(&debug)
+	cli.app.Flag("config", "Config file to use").StringVar(&configFile)
+
+	for _, cmd := range cli.commands {
+		err = cmd.Setup()
+	}
+
+	cli.command = kingpin.MustParse(cli.app.Parse(os.Args[1:]))
+
+	if debug {
+		log.SetOutput(os.Stdout)
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Logging at debug level due to CLI override")
+	}
+
+	if configFile == "" {
+		configFile = choria.UserConfig()
+	}
+
+	Choria, err = choria.New(configFile)
+	if err != nil {
+		return fmt.Errorf("Could not initialize Choria: %s", err.Error())
+	}
+
+	if err = Choria.SetupLogging(debug); err != nil {
+		return fmt.Errorf("Could not set up logging: %s", err.Error())
+	}
+
+	return
+}
+
+func Run() (err error) {
+	ran := false
+
+	for _, cmd := range cli.commands {
+		if cmd.FullCommand() == cli.command {
+			err = cmd.Run()
+			ran = true
+		}
+	}
+
+	if !ran {
+		err = fmt.Errorf("Could not run the CLI: Invalid command %s", cli.command)
+	}
+
+	return
+}
+
+// digs in the application.commands structure looking for a entry with
+// the given command string
+func cmdWithFullCommand(command string) (cmd runableCmd, ok bool) {
+	for _, cmd := range cli.commands {
+		if cmd.FullCommand() == command {
+			return cmd, true
+		}
+	}
+
+	return cmd, false
+}

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+type command struct {
+	Run   func() error
+	Setup func() error
+
+	cmd *kingpin.CmdClause
+}
+
+type runableCmd interface {
+	Setup() error
+	Run() error
+	FullCommand() string
+	Cmd() *kingpin.CmdClause
+}
+
+func (c *command) FullCommand() string {
+	return c.Cmd().FullCommand()
+}
+
+func (c *command) Cmd() *kingpin.CmdClause {
+	return c.cmd
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,23 @@
-hash: 428c972481596a6f27fdd55355e04eeaa4cbeb270640ead0d871501b71902e45
-updated: 2017-06-12T13:24:04.118929419+02:00
+hash: f56c239bc79c3a56644e7dc5a254481b78904df3d010841dd001dfe5598a1681
+updated: 2017-06-13T09:10:14.097257094+02:00
 imports:
+- name: github.com/alecthomas/template
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
+  subpackages:
+  - parse
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
 - name: github.com/nats-io/gnatsd
   version: 5dcad241bcd7fff3aac6e9f8b47350f071f5fd38
+  subpackages:
+  - conf
+  - logger
+  - server
+  - server/pse
+  - util
+- name: github.com/nats-io/nuid
+  version: 289cccf02c178dc782430d534e3c1f5b72af807f
+  repo: https://github.com/nats-io/nuid
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: golang.org/x/crypto
@@ -13,6 +28,8 @@ imports:
   version: dbc2be9168a660ef302e04b6ff6406de6f967473
   subpackages:
   - unix
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 7f0871f2e17818990e4eed73f9b5c2f429501228
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,8 @@ import:
   - ssh/terminal
 - package: github.com/nats-io/gnatsd
   version: ^0.9.6
+- package: gopkg.in/alecthomas/kingpin.v2
+  version: ^2.2.4
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/main.go
+++ b/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/choria-io/go-choria/cmd"
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	err := cmd.ParseCLI()
+	if err != nil {
+		log.Fatalf("Could not configure Choria: %s", err.Error())
+		os.Exit(1)
+	}
+
+	err = cmd.Run()
+	if err != nil {
+		log.Fatalf("Could not run Choria: %s", err.Error())
+		os.Exit(1)
+	}
+
+	for {
+		time.Sleep(60 * time.Second)
+	}
+}

--- a/network/network.go
+++ b/network/network.go
@@ -17,8 +17,8 @@ type Server struct {
 }
 
 // NewServer creates a new instance of the Server struct with a fully configured NATS embedded
-func NewServer(c *choria.Choria) (s Server, err error) {
-	s = Server{
+func NewServer(c *choria.Choria, debug bool) (s *Server, err error) {
+	s = &Server{
 		choria: c,
 		opts:   &gnatsd.Options{},
 	}
@@ -27,7 +27,7 @@ func NewServer(c *choria.Choria) (s Server, err error) {
 	s.opts.Port = c.Config.Choria.NetworkClientPort
 	s.opts.Logtime = false
 
-	if c.Config.LogLevel == "debug" {
+	if debug || c.Config.LogLevel == "debug" {
 		s.opts.Debug = true
 	}
 


### PR DESCRIPTION
This will via `broker run` start a broker with routes and all.  Choria
got some utilities to set up logging based on mco configs which now only
support file and console logging