### PR TITLE
(misc) Allow TLS disabling and unverified

### DIFF
--- a/broker/federation/federation_test.go
+++ b/broker/federation/federation_test.go
@@ -53,6 +53,10 @@ type stubConnection struct {
 	mu          *sync.Mutex
 }
 
+func (s *stubConnection) Receive() *mcollective.ConnectorMessage {
+	return nil
+}
+
 func (s *stubConnection) PublishToQueueSub(name string, msg *mcollective.ConnectorMessage) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -32,9 +32,12 @@ func NewServer(c *mcollective.Choria, debug bool) (s *Server, err error) {
 		s.opts.Debug = true
 	}
 
-	err = s.setupTLS()
-	if err != nil {
-		return s, fmt.Errorf("Could not setup TLS: %s", err.Error())
+	if c.Config.DisableTLS {
+		log.Warn("Disabling TLS on the NATS broker")
+		err = s.setupTLS()
+		if err != nil {
+			return s, fmt.Errorf("Could not setup TLS: %s", err.Error())
+		}
 	}
 
 	err = s.setupCluster()

--- a/mcollective/config.go
+++ b/mcollective/config.go
@@ -109,6 +109,12 @@ type MCOConfig struct {
 	setOptions []string
 
 	Choria *ChoriaPluginConfig
+
+	// options that are not user configurable via config files but can be
+	// used by things like the emulator to set up a TLS free setup
+	DisableTLS       bool
+	DisableTLSVerify bool
+	OverrideCertname string
 }
 
 // HasOption determines if a specific option was set from a config key.

--- a/mcollective/ssl.go
+++ b/mcollective/ssl.go
@@ -80,6 +80,10 @@ func (c *Choria) SignString(str []byte) (signature []byte, err error) {
 
 // Certname determines the choria certname
 func (c *Choria) Certname() string {
+	if c.Config.OverrideCertname != "" {
+		return c.Config.OverrideCertname
+	}
+
 	if certname, ok := os.LookupEnv("MCOLLECTIVE_CERTNAME"); ok {
 		return certname
 	}
@@ -241,6 +245,10 @@ func (c *Choria) TLSConfig() (tlsc *tls.Config, err error) {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
+	}
+
+	if c.Config.DisableTLSVerify {
+		tlsc.InsecureSkipVerify = true
 	}
 
 	tlsc.BuildNameToCertificate()

--- a/protocol/v1/constructors.go
+++ b/protocol/v1/constructors.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/choria-io/go-choria/protocol"
-	log "github.com/sirupsen/logrus"
 )
 
 // NewRequest creates a choria:request:1
@@ -31,7 +30,7 @@ func NewRequest(agent string, senderid string, callerid string, ttl int, request
 }
 
 // NewReply creates a choria:reply:1 based on a previous Request
-func NewReply(request protocol.Request) (rep protocol.Reply, err error) {
+func NewReply(request protocol.Request, certname string) (rep protocol.Reply, err error) {
 	if request.Version() != protocol.RequestV1 {
 		err = fmt.Errorf("Cannot create a version 1 Reply from a %s request", request.Version())
 		return
@@ -41,7 +40,7 @@ func NewReply(request protocol.Request) (rep protocol.Reply, err error) {
 		Protocol: protocol.ReplyV1,
 		Envelope: &replyEnvelope{
 			RequestID: request.RequestID(),
-			SenderID:  request.SenderID(),
+			SenderID:  certname,
 			Agent:     request.Agent(),
 			Time:      time.Now().UTC().Unix(),
 		},
@@ -99,7 +98,6 @@ func NewRequestFromSecureRequest(sr protocol.SecureRequest) (req protocol.Reques
 		Envelope: &requestEnvelope{},
 	}
 
-	log.Debug(sr.Message())
 	err = r.IsValidJSON(sr.Message())
 	if err != nil {
 		err = fmt.Errorf("The JSON body from the SecureRequest is not a valid Request message: %s", err.Error())

--- a/protocol/v1/reply_test.go
+++ b/protocol/v1/reply_test.go
@@ -13,7 +13,7 @@ import (
 var _ = Describe("Reply", func() {
 	It("should create the correct reply from a request", func() {
 		request, _ := NewRequest("test", "go.tests", "choria=test", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
-		reply, _ := NewReply(request)
+		reply, _ := NewReply(request, "testing")
 
 		reply.SetMessage("hello world")
 
@@ -22,7 +22,7 @@ var _ = Describe("Reply", func() {
 		Expect(gjson.Get(j, "protocol").String()).To(Equal(protocol.ReplyV1))
 		Expect(reply.Message()).To(Equal("hello world"))
 		Expect(len(reply.RequestID())).To(Equal(32))
-		Expect(reply.SenderID()).To(Equal("go.tests"))
+		Expect(reply.SenderID()).To(Equal("testing"))
 		Expect(reply.Agent()).To(Equal("test"))
 		Expect(reply.Time()).To(BeTemporally("~", time.Now(), time.Second))
 	})

--- a/protocol/v1/security_test.go
+++ b/protocol/v1/security_test.go
@@ -21,7 +21,7 @@ var _ = Describe("SecureReply", func() {
 		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		request.SetMessage(`{"test":1}`)
 
-		reply, err := NewReply(request)
+		reply, err := NewReply(request, "testing")
 		Expect(err).ToNot(HaveOccurred())
 
 		rj, err := reply.JSON()

--- a/protocol/v1/transport.go
+++ b/protocol/v1/transport.go
@@ -26,7 +26,7 @@ type transportHeaders struct {
 }
 
 type federationTransportHeader struct {
-	RequestID string   `json:"req",omitempty`
+	RequestID string   `json:"req,omitempty"`
 	ReplyTo   string   `json:"reply-to,omitempty"`
 	Targets   []string `json:"target,omitempty"`
 }

--- a/protocol/v1/transport_test.go
+++ b/protocol/v1/transport_test.go
@@ -11,7 +11,7 @@ var _ = Describe("TransportMessage", func() {
 	It("Should support reply data", func() {
 		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		request.SetMessage(`{"message":1}`)
-		reply, _ := NewReply(request)
+		reply, _ := NewReply(request, "testing")
 		sreply, _ := NewSecureReply(reply)
 		treply, _ := NewTransportMessage("rip.mcollective")
 		treply.SetReplyData(sreply)


### PR DESCRIPTION
This adds Configuration options to disable TLS and to disable SSL
verification.

These are not desirable options for end users but handy to build testing
suites, load testers and custom solutions so they can only be set
programatically and not from any config file