### PR TITLE
(misc) adds a compile time insecure option

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -14,3 +14,6 @@ var License = "Apache-2.0"
 
 // Set to default to no TLS
 var TLS = "true"
+
+// Set to disable signing and certificates in the protocol
+var Secure = "true"

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -44,20 +44,25 @@ func (self *Server) URL() (u *url.URL, err error) {
 
 // New sets up a Choria with all its config loaded and so forth
 func New(path string) (*Framework, error) {
-	c := Framework{}
-
 	config, err := NewConfig(path)
 	if err != nil {
-		return &c, err
+		return nil, err
 	}
 
-	c.Config = config
+	return NewWithConfig(config)
+}
 
-	if err = c.SetupLogging(false); err != nil {
+func NewWithConfig(config *Config) (*Framework, error) {
+	c := Framework{
+		Config: config,
+	}
+
+	err := c.SetupLogging(false)
+	if err != nil {
 		return &c, fmt.Errorf("Could not set up logging: %s", err.Error())
 	}
 
-	if config.DisableTLS {
+	if !config.DisableTLS {
 		if errors, ok := c.CheckSSLSetup(); !ok {
 			return &c, fmt.Errorf("SSL setup is not valid, %d errors encountered: %s", len(errors), strings.Join(errors, ", "))
 		}

--- a/choria/protocol.go
+++ b/choria/protocol.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/choria-io/go-choria/protocol"
 	"github.com/choria-io/go-choria/protocol/v1"
+	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
@@ -258,7 +259,17 @@ func (self *Framework) NewTransportForSecureRequest(request protocol.SecureReque
 	switch request.Version() {
 	case protocol.SecureRequestV1:
 		message, err = v1.NewTransportMessage(self.Config.Identity)
-		message.SetRequestData(request)
+		if err != nil {
+			logrus.Errorf("Failed to create transport from secure request: %s", err.Error())
+			return
+		}
+
+		err = message.SetRequestData(request)
+		if err != nil {
+			logrus.Errorf("Failed to create transport from secure request: %s", err.Error())
+			return
+		}
+
 	default:
 		err = fmt.Errorf("Do not know how to create a Transport message for SecureRequest version %s", request.Version())
 	}

--- a/choria/protocol_test.go
+++ b/choria/protocol_test.go
@@ -13,7 +13,9 @@ var _ = Describe("Protocol", func() {
 
 	BeforeEach(func() {
 		if j == nil {
-			c, err = New("/dev/null")
+			cfg, _ := NewConfig("/dev/null")
+			cfg.DisableTLS = true
+			c, err = NewWithConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			rm, err := NewMessage("ping", "discovery", "mcollective", "request", nil, c)
@@ -35,13 +37,4 @@ var _ = Describe("Protocol", func() {
 			j = &t
 		}
 	})
-
-	Measure("Transport from JSON", func(b Benchmarker) {
-		b.Time("runtime", func() {
-			t, err := c.NewTransportFromJSON(string(*j))
-			Expect(err).ToNot(HaveOccurred())
-			t.SenderID()
-		})
-
-	}, 10000)
 })

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,7 +31,7 @@ var wg *sync.WaitGroup
 
 func ParseCLI() (err error) {
 	cli.app = kingpin.New("choria", "Choria Orchestration System")
-	cli.app.Version(fmt.Sprintf("version: %s\n\nlicense: %s\nbuilt: %s\nsha: %s\nTLS: %s", build.Version, build.License, build.BuildDate, build.SHA, build.TLS))
+	cli.app.Version(fmt.Sprintf("version: %s\n\nlicense: %s\nbuilt: %s\nsha: %s\ntls: %s\nsecure: %s\n", build.Version, build.License, build.BuildDate, build.SHA, build.TLS, build.Secure))
 	cli.app.Author("R.I.Pienaar <rip@devco.net>")
 	cli.app.Flag("debug", "Enable debug logging").Short('d').BoolVar(&debug)
 	cli.app.Flag("config", "Config file to use").StringVar(&configFile)
@@ -57,6 +57,8 @@ func ParseCLI() (err error) {
 	}
 
 	config = c.Config
+
+	c.SetupLogging(debug)
 
 	return
 }

--- a/protocol/v1/constructors.go
+++ b/protocol/v1/constructors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/protocol"
 )
 
@@ -164,10 +165,14 @@ func NewSecureReplyFromTransport(message protocol.TransportMessage) (secure prot
 
 // NewSecureRequest creates a choria:secure:request:1
 func NewSecureRequest(request protocol.Request, publicCert string, privateCert string) (secure protocol.SecureRequest, err error) {
-	pubcerttxt, err := readFile(publicCert)
-	if err != nil {
-		err = fmt.Errorf("Could not read public certificate: %s", err.Error())
-		return
+	pubcerttxt := []byte("insecure")
+
+	if build.Secure == "true" {
+		pubcerttxt, err = readFile(publicCert)
+		if err != nil {
+			err = fmt.Errorf("Could not read public certificate: %s", err.Error())
+			return
+		}
 	}
 
 	secure = &secureRequest{

--- a/protocol/v1/transport.go
+++ b/protocol/v1/transport.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/choria-io/go-choria/protocol"
+	"github.com/sirupsen/logrus"
 )
 
 type transportMessage struct {
@@ -186,6 +187,8 @@ func (m *transportMessage) SetRequestData(request protocol.SecureRequest) (err e
 		err = fmt.Errorf("Could not JSON encode the Request structure for transport: %s", err.Error())
 		return
 	}
+
+	logrus.Debugf("JSON from secure request: %s", j)
 
 	m.Data = base64.StdEncoding.EncodeToString([]byte(j))
 

--- a/registration/file_content.go
+++ b/registration/file_content.go
@@ -88,6 +88,8 @@ func (fc *FileContent) publish(output chan *data.RegistrationItem) error {
 		TargetAgent: "registration",
 	}
 
+	fc.log.Debugf("Publishing registration data: %s", string(*item.Data))
+
 	output <- item
 
 	return nil

--- a/server/agents/agents_test.go
+++ b/server/agents/agents_test.go
@@ -61,10 +61,14 @@ var _ = Describe("Server/Agents", func() {
 	var ctx context.Context
 	var cancel func()
 	var fw *choria.Framework
-	var err error
 
 	BeforeEach(func() {
-		fw, err = choria.New("/dev/null")
+		cfg, err := choria.NewConfig("/dev/null")
+		Expect(err).ToNot(HaveOccurred())
+
+		cfg.DisableTLS = true
+
+		fw, err = choria.NewWithConfig(cfg)
 		Expect(err).ToNot(HaveOccurred())
 		fw.Config.Collectives = []string{"cone", "ctwo"}
 

--- a/server/discovery/discovery_test.go
+++ b/server/discovery/discovery_test.go
@@ -28,7 +28,10 @@ var _ = Describe("Server/Discovery", func() {
 
 	BeforeSuite(func() {
 		log = logrus.WithFields(logrus.Fields{"test": true})
-		fw, err = choria.New("/dev/null")
+		cfg, err := choria.NewConfig("/dev/null")
+		cfg.DisableTLS = true
+
+		fw, err = choria.NewWithConfig(cfg)
 		Expect(err).ToNot(HaveOccurred())
 
 		fw.Config.ClassesFile = "testdata/classes.txt"

--- a/server/discovery/facts/facts_test.go
+++ b/server/discovery/facts/facts_test.go
@@ -17,10 +17,9 @@ func TestFileContent(t *testing.T) {
 
 var _ = Describe("Server/Discovery/Facts", func() {
 	var (
-		t   func(fact, op, val string) (bool, error)
-		fw  *choria.Framework
-		err error
-		l   *logrus.Entry
+		t  func(fact, op, val string) (bool, error)
+		fw *choria.Framework
+		l  *logrus.Entry
 	)
 
 	BeforeSuite(func() {
@@ -29,7 +28,10 @@ var _ = Describe("Server/Discovery/Facts", func() {
 		}
 
 		l = logrus.WithFields(logrus.Fields{"test": true})
-		fw, err = choria.New("/dev/null")
+		cfg, err := choria.NewConfig("/dev/null")
+		cfg.DisableTLS = true
+
+		fw, err = choria.NewWithConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
 		fw.Config.Choria.FactSourceFile = "testdata/fact.yaml"

--- a/server/registration/registration.go
+++ b/server/registration/registration.go
@@ -141,8 +141,6 @@ func (reg *Manager) publish(rmsg *data.RegistrationItem) {
 	msg.SetProtocolVersion(protocol.RequestV1)
 	msg.SetReplyTo("dev.null")
 
-	reg.log.Debugf("Publishing %d bytes of registration data to collective %s agent %s", len(*rmsg.Data), reg.cfg.RegistrationCollective, rmsg.TargetAgent)
-
 	err = reg.connector.Publish(msg)
 	if err != nil {
 		reg.log.Warnf("Could not publish registration Message: %s", err.Error())

--- a/server/registration/registration_test.go
+++ b/server/registration/registration_test.go
@@ -28,7 +28,10 @@ var _ = Describe("Server/Registration", func() {
 		)
 
 		BeforeSuite(func() {
-			choria, err = framework.New("/dev/null")
+			cfg, err = framework.NewConfig("/dev/null")
+			cfg.DisableTLS = true
+
+			choria, err = framework.NewWithConfig(cfg)
 			Expect(err).ToNot(HaveOccurred())
 
 			cfg = choria.Config


### PR DESCRIPTION
This disables all of the protocol level security if the build flag
is set to allow that.

This is needed to support environments where certificate management
is just not feasable, but there is no way to configure this behaviour
it has to be compiled into the binary