### PR TITLE
(#57, #59) Create SimpleRPC compat layer and choria_util

### DIFF
--- a/agents/choriautil/choriautil.go
+++ b/agents/choriautil/choriautil.go
@@ -1,0 +1,128 @@
+package choriautil
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/server/agents/mcorpc"
+	nats "github.com/nats-io/go-nats"
+	"github.com/sirupsen/logrus"
+)
+
+type info struct {
+	Security          string   `json:"security"`
+	Connector         string   `json:"connector"`
+	ClientVersion     string   `json:"client_version"`
+	ClientFlavour     string   `json:"client_flavour"`
+	ClientOptions     *copts   `json:"client_options"`
+	ClientStats       *cstats  `json:"client_stats"`
+	ConnectedServer   string   `json:"connected_server"`
+	FacterDomain      string   `json:"facter_domain"`
+	FacterCommand     string   `json:"facter_command"`
+	SrvDomain         string   `json:"srv_domain"`
+	UsingSrv          bool     `json:"using_srv"`
+	MiddlewareServers []string `json:"middleware_servers"`
+	Path              string   `json:"path"`
+	ChoriaVersion     string   `json:"choria_version"`
+}
+
+type copts struct {
+	Servers        []string `json:"servers"`
+	NoRandomize    bool     `json:"dont_randomize_servers"`
+	Name           string   `json:"name"`
+	Pedantic       bool     `json:"pedantic"`
+	Secure         bool     `json:"secure"`
+	AllowReconnect bool     `json:"allow_reconnect"`
+	MaxReconnect   int      `json:"max_reconnect_attempts"`
+	ReconnectWait  float64  `json:"reconnect_time_wait"`
+	Timeout        float64  `json:"connect_timeout"`
+	PingInterval   float64  `json:"ping_interval"`
+	MaxPingsOut    int      `json:"max_outstanding_pings"`
+}
+
+type cstats struct {
+	InMsgs     uint64 `json:"in_msgs"`
+	OutMsgs    uint64 `json:"out_msgs"`
+	InBytes    uint64 `json:"in_bytes"`
+	OutBytes   uint64 `json:"out_bytes"`
+	Reconnects uint64 `json:"reconnects"`
+}
+
+func New(fw *choria.Framework, log *logrus.Entry) (*mcorpc.Agent, error) {
+	metadata := &agents.Metadata{
+		Name:        "choria_util",
+		Description: "Choria Utilities",
+		Author:      "R.I.Pienaar <rip@devco.net>",
+		Version:     build.Version,
+		License:     build.License,
+		Timeout:     2,
+		URL:         "http://choria.io",
+	}
+
+	agent := mcorpc.New("choria_util", metadata, fw, log)
+
+	err := agent.RegisterAction("info", infoAction)
+	if err != nil {
+		return nil, fmt.Errorf("Could not register info action: %s", err.Error())
+	}
+
+	return agent, nil
+}
+
+func infoAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	c := agent.Config
+
+	domain, err := agent.Choria.FacterDomain()
+	if err != nil {
+		domain = ""
+	}
+
+	var mservers []string
+
+	servers, err := agent.Choria.MiddlewareServers()
+	for _, server := range servers {
+		mservers = append(mservers, fmt.Sprintf("%s:%d", server.Host, server.Port))
+	}
+
+	options := conn.ConnectionOptions()
+	stats := conn.ConnectionStats()
+
+	reply.Data = &info{
+		Security:          "choria",
+		Connector:         "choria",
+		ClientVersion:     nats.Version,
+		ClientFlavour:     fmt.Sprintf("go-nats %s", runtime.Version()),
+		ConnectedServer:   conn.ConnectedServer(),
+		FacterCommand:     agent.Choria.FacterCmd(),
+		FacterDomain:      domain,
+		SrvDomain:         c.Choria.SRVDomain,
+		MiddlewareServers: mservers,
+		Path:              os.Getenv("PATH"),
+		ChoriaVersion:     build.Version,
+		UsingSrv:          c.Choria.UseSRVRecords,
+		ClientStats: &cstats{
+			InMsgs:     stats.InMsgs,
+			InBytes:    stats.InBytes,
+			OutMsgs:    stats.OutMsgs,
+			OutBytes:   stats.OutBytes,
+			Reconnects: stats.Reconnects,
+		},
+		ClientOptions: &copts{
+			Servers:        options.Servers,
+			NoRandomize:    options.NoRandomize,
+			Name:           options.Name,
+			Pedantic:       options.Pedantic,
+			Secure:         options.Secure,
+			AllowReconnect: options.AllowReconnect,
+			MaxReconnect:   options.MaxReconnect,
+			ReconnectWait:  options.ReconnectWait.Seconds(),
+			Timeout:        options.Timeout.Seconds(),
+			PingInterval:   options.PingInterval.Seconds(),
+			MaxPingsOut:    options.MaxPingsOut,
+		},
+	}
+}

--- a/agents/discovery/discovery.go
+++ b/agents/discovery/discovery.go
@@ -42,7 +42,7 @@ func (da *Agent) Metadata() *agents.Metadata {
 	return da.meta
 }
 
-func (da *Agent) Handle(msg *choria.Message, request protocol.Request, result chan *agents.AgentReply) {
+func (da *Agent) HandleMessage(msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, result chan *agents.AgentReply) {
 	reply := &agents.AgentReply{
 		Message: msg,
 		Request: request,

--- a/broker/federation/federation_test.go
+++ b/broker/federation/federation_test.go
@@ -88,6 +88,14 @@ func (s *stubConnection) ConnectedServer() string {
 	return "nats://stub:4222"
 }
 
+func (s *stubConnection) ConnectionOptions() nats.Options {
+	return nats.Options{}
+}
+
+func (s *stubConnection) ConnectionStats() nats.Statistics {
+	return nats.Statistics{}
+}
+
 func (s *stubConnection) Subscribe(name string, subject string, group string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/choria/connectortest/agentconnector.go
+++ b/choria/connectortest/agentconnector.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/choria-io/go-choria/choria"
-	"github.com/nats-io/nats"
+	nats "github.com/nats-io/go-nats"
 )
 
 type AgentConnector struct {
@@ -81,4 +81,16 @@ func (a *AgentConnector) nexterr() error {
 	}
 
 	return err
+}
+
+func (a *AgentConnector) ConnectionOptions() nats.Options {
+	return nats.Options{}
+}
+
+func (a *AgentConnector) ConnectionStats() nats.Statistics {
+	return nats.Statistics{}
+}
+
+func (a *AgentConnector) ConnectedServer() string {
+	return "nats://nats.example.net:4222"
 }

--- a/choria/connectortest/connectorinfo.go
+++ b/choria/connectortest/connectorinfo.go
@@ -1,0 +1,23 @@
+package connectortest
+
+import (
+	nats "github.com/nats-io/go-nats"
+)
+
+type ConnectorInfo struct {
+	Server  string
+	Options nats.Options
+	Stats   nats.Statistics
+}
+
+func (i *ConnectorInfo) ConnectedServer() string {
+	return i.Server
+}
+
+func (i *ConnectorInfo) ConnectionOptions() nats.Options {
+	return i.Options
+}
+
+func (i *ConnectorInfo) ConnectionStats() nats.Statistics {
+	return i.Stats
+}

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -80,6 +80,11 @@ func (self *Framework) IsFederated() (result bool) {
 	return true
 }
 
+// Logger creates a new logrus entry
+func (self *Framework) Logger(component string) *log.Entry {
+	return log.WithFields(log.Fields{"component": component})
+}
+
 // FederationCollectives determines the known Federation Member
 // Collectives based on the CHORIA_FED_COLLECTIVE environment
 // variable or the choria.federation.collectives config item

--- a/server/agents.go
+++ b/server/agents.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/choria-io/go-choria/agents/choriautil"
 	"github.com/choria-io/go-choria/agents/discovery"
 )
 
@@ -14,6 +15,13 @@ func (srv *Instance) setupCoreAgents(ctx context.Context) error {
 	}
 
 	srv.agents.RegisterAgent(ctx, "discovery", da, srv.connector)
+
+	cu, err := choriautil.New(srv.fw, srv.log)
+	if err != nil {
+		return fmt.Errorf("Could not setup choria_util agent: %s", err.Error())
+	}
+
+	srv.agents.RegisterAgent(ctx, "choria_util", cu, srv.connector)
 
 	return nil
 }

--- a/server/agents/agents_test.go
+++ b/server/agents/agents_test.go
@@ -30,7 +30,7 @@ func (s *stubAgent) Name() string {
 	return "stub"
 }
 
-func (s *stubAgent) Handle(msg *choria.Message, request protocol.Request, result chan *AgentReply) {
+func (s *stubAgent) HandleMessage(msg *choria.Message, request protocol.Request, ci choria.ConnectorInfo, result chan *AgentReply) {
 	if msg.Payload == "sleep" {
 		time.Sleep(10 * time.Second)
 	}
@@ -76,7 +76,7 @@ var _ = Describe("Server/Agents", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		logrus.SetLevel(logrus.FatalLevel)
-		mgr = New(requests, fw, logrus.WithFields(logrus.Fields{"testing": true}))
+		mgr = New(requests, fw, conn, logrus.WithFields(logrus.Fields{"testing": true}))
 		conn = &connectortest.AgentConnector{}
 		conn.Init()
 

--- a/server/agents/mcorpc/mcorpc.go
+++ b/server/agents/mcorpc/mcorpc.go
@@ -1,0 +1,161 @@
+package mcorpc
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/protocol"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/sirupsen/logrus"
+)
+
+// StatusCode is a reply status as defined by MCollective SimpleRPC - integers 0 to 5
+//
+// See the constants OK, RPCAborted, UnknownRPCAction, MissingRPCData, InvalidRPCData and UnknownRPCError
+type StatusCode uint8
+
+const (
+	// OK is the reply status when all worked
+	OK = StatusCode(iota)
+
+	// Aborted is status for when the action could not run, most failures in an action should set this
+	Aborted
+
+	// UnknownAction is the status for unknown actions requested
+	UnknownAction
+
+	// MissingData is the status for missing input data
+	MissingData
+
+	// InvalidData is the status for invalid input data
+	InvalidData
+
+	// UnknownError is the status general failures in agents should set when things go bad
+	UnknownError
+)
+
+// Agent is an instance of the MCollective compatible RPC agents
+type Agent struct {
+	Log    *logrus.Entry
+	Config *choria.Config
+	Choria *choria.Framework
+
+	meta    *agents.Metadata
+	actions map[string]func(*Request, *Reply, *Agent, choria.ConnectorInfo)
+}
+
+// Reply is the reply data as stipulated by MCollective RPC system.  The Data
+// has to be something that can be turned into JSON using the normal Marshal system
+type Reply struct {
+	Statuscode StatusCode  `json:"statuscode"`
+	Statusmsg  string      `json:"statusmsg"`
+	Data       interface{} `json:"data"`
+}
+
+// Request is a request as defined by the MCollective RPC system
+// NOTE: input arguments not yet handled
+type Request struct {
+	Agent  string `json:"agent"`
+	Action string `json:"action"`
+}
+
+// New creates a new MCollective SimpleRPC compatible agent
+func New(name string, metadata *agents.Metadata, fw *choria.Framework, log *logrus.Entry) *Agent {
+	a := &Agent{
+		meta:    metadata,
+		Log:     logrus.WithFields(logrus.Fields{"agent": "name"}),
+		actions: make(map[string]func(*Request, *Reply, *Agent, choria.ConnectorInfo)),
+		Choria:  fw,
+		Config:  fw.Config,
+	}
+
+	return a
+}
+
+// RegisterAction registers an action into the agent
+func (a *Agent) RegisterAction(name string, f func(*Request, *Reply, *Agent, choria.ConnectorInfo)) error {
+	if _, ok := a.actions[name]; ok {
+		return fmt.Errorf("Cannot register action %s, it already exist", name)
+	}
+
+	a.actions[name] = f
+
+	return nil
+}
+
+// HandleMessage attempts to parse a choria.Message as a MCollective SimpleRPC request and calls
+// the agents and actions associated with it
+func (a *Agent) HandleMessage(msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, outbox chan *agents.AgentReply) {
+	var err error
+
+	reply := a.newReply()
+	defer a.publish(reply, msg, request, outbox)
+
+	rpcrequest, err := a.parseIncomingMessage(msg.Payload)
+	if err != nil {
+		reply.Statuscode = InvalidData
+		reply.Statusmsg = fmt.Sprintf("Could not process request: %s", err.Error())
+		return
+	}
+
+	action, found := a.actions[rpcrequest.Action]
+	if !found {
+		reply.Statuscode = UnknownAction
+		reply.Statusmsg = fmt.Sprintf("Unknown action %s for agent %s", rpcrequest.Action, a.Name())
+		return
+	}
+
+	// TODO:
+	//	authorize
+	//  audit
+
+	action(rpcrequest, reply, a, conn)
+}
+
+// Name retrieves the name of the agent
+func (a *Agent) Name() string {
+	return a.meta.Name
+}
+
+// Metadata retrieves the agent metadata
+func (a *Agent) Metadata() *agents.Metadata {
+	return a.meta
+}
+
+func (a *Agent) publish(rpcreply *Reply, msg *choria.Message, request protocol.Request, outbox chan *agents.AgentReply) {
+	reply := &agents.AgentReply{
+		Message: msg,
+		Request: request,
+	}
+
+	j, err := json.Marshal(rpcreply)
+	if err != nil {
+		logrus.Errorf("Could not JSON encode reply: %s", err.Error())
+		reply.Error = err
+	}
+
+	reply.Body = j
+
+	outbox <- reply
+}
+
+func (a *Agent) newReply() *Reply {
+	reply := &Reply{
+		Statuscode: OK,
+		Statusmsg:  "OK",
+	}
+
+	return reply
+}
+
+func (a *Agent) parseIncomingMessage(msg string) (*Request, error) {
+	r := &Request{}
+
+	err := json.Unmarshal([]byte(msg), r)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse incoming message as a MCollective SimpleRPC Request: %s", err.Error())
+	}
+
+	return r, nil
+}

--- a/server/agents/mcorpc/mcorpc_test.go
+++ b/server/agents/mcorpc/mcorpc_test.go
@@ -1,0 +1,129 @@
+package mcorpc
+
+import (
+	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/choria/connectortest"
+	"github.com/choria-io/go-choria/protocol"
+	"github.com/choria-io/go-choria/server/agents"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+
+	"testing"
+)
+
+func TestFileContent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server/Agents/McoRPC")
+}
+
+var _ = Describe("Server/Agents/McoRPC", func() {
+	var (
+		agent  *Agent
+		fw     *choria.Framework
+		msg    *choria.Message
+		req    protocol.Request
+		outbox = make(chan *agents.AgentReply, 1)
+		ci     = &connectortest.ConnectorInfo{}
+		err    error
+	)
+
+	BeforeEach(func() {
+		build.Secure = "false"
+		build.TLS = "false"
+		config, err := choria.NewConfig("/dev/null")
+		Expect(err).ToNot(HaveOccurred())
+		config.LogLevel = "fatal"
+		fw, err = choria.NewWithConfig(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		metadata := &agents.Metadata{Name: "test"}
+		agent = New("testing", metadata, fw, fw.Logger("test"))
+	})
+
+	It("Should have correct constants", func() {
+		Expect(OK).To(Equal(StatusCode(0)))
+		Expect(Aborted).To(Equal(StatusCode(1)))
+		Expect(UnknownAction).To(Equal(StatusCode(2)))
+		Expect(MissingData).To(Equal(StatusCode(3)))
+		Expect(InvalidData).To(Equal(StatusCode(4)))
+		Expect(UnknownError).To(Equal(StatusCode(5)))
+	})
+
+	var _ = Describe("RegisterAction", func() {
+		It("Should fail if the action already exist", func() {
+			action := func(req *Request, reply *Reply, agent *Agent, conn choria.ConnectorInfo) {}
+			err := agent.RegisterAction("test", action)
+			Expect(err).ToNot(HaveOccurred())
+			err = agent.RegisterAction("test", action)
+			Expect(err).To(MatchError("Cannot register action test, it already exist"))
+		})
+	})
+
+	var _ = Describe("HandleMessage", func() {
+		BeforeEach(func() {
+			req, err = fw.NewRequest(protocol.RequestV1, "test", "test.example.net", "choria=rip.mcollective", 60, fw.NewRequestID(), "mcollective")
+			Expect(err).ToNot(HaveOccurred())
+			msg, err = choria.NewMessageFromRequest(req, "dev.null", fw)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should handle bad incoming data", func() {
+			msg.Payload = ""
+			agent.HandleMessage(msg, req, ci, outbox)
+
+			reply := <-outbox
+			Expect(gjson.GetBytes(reply.Body, "statusmsg").String()).To(Equal("Could not process request: Could not parse incoming message as a MCollective SimpleRPC Request: unexpected end of JSON input"))
+			Expect(gjson.GetBytes(reply.Body, "statuscode").Int()).To(Equal(int64(4)))
+		})
+
+		It("Should handle unknown actions", func() {
+			msg.Payload = `{"agent":"test", "action":"nonexisting"}`
+			agent.HandleMessage(msg, req, ci, outbox)
+
+			reply := <-outbox
+			Expect(gjson.GetBytes(reply.Body, "statusmsg").String()).To(Equal("Unknown action nonexisting for agent test"))
+			Expect(gjson.GetBytes(reply.Body, "statuscode").Int()).To(Equal(int64(2)))
+		})
+
+		It("Should call the action", func() {
+			action := func(req *Request, reply *Reply, agent *Agent, conn choria.ConnectorInfo) {
+				d := make(map[string]string)
+				d["test"] = "hello world"
+				reply.Data = &d
+			}
+
+			agent.RegisterAction("test", action)
+			msg.Payload = `{"agent":"test", "action":"test"}`
+			agent.HandleMessage(msg, req, ci, outbox)
+
+			reply := <-outbox
+			Expect(gjson.GetBytes(reply.Body, "statusmsg").String()).To(Equal("OK"))
+			Expect(gjson.GetBytes(reply.Body, "statuscode").Int()).To(Equal(int64(0)))
+			Expect(gjson.GetBytes(reply.Body, "data.test").String()).To(Equal("hello world"))
+		})
+	})
+
+	var _ = Describe("publish", func() {
+		It("Should handle bad data", func() {
+			reply := &Reply{
+				Data: outbox,
+			}
+
+			agent.publish(reply, msg, req, outbox)
+			out := <-outbox
+			Expect(out.Error).To(MatchError("json: unsupported type: chan *agents.AgentReply"))
+		})
+
+		PIt("Should publish good messages")
+	})
+
+	var _ = Describe("newReply", func() {
+		It("Should set the correct starting code and message", func() {
+			r := agent.newReply()
+			Expect(r.Statuscode).To(Equal(OK))
+			Expect(r.Statusmsg).To(Equal("OK"))
+		})
+	})
+})

--- a/server/instance.go
+++ b/server/instance.go
@@ -29,6 +29,7 @@ type Instance struct {
 	agentmu *sync.Mutex
 }
 
+// NewInstance creates a new choria server instance
 func NewInstance(fw *choria.Framework) (i *Instance, err error) {
 	i = &Instance{
 		fw:       fw,
@@ -37,7 +38,6 @@ func NewInstance(fw *choria.Framework) (i *Instance, err error) {
 	}
 
 	i.log = log.WithFields(log.Fields{"identity": fw.Config.Identity, "component": "server"})
-	i.agents = agents.New(i.requests, fw, i.log)
 	i.discovery = discovery.New(fw, i.log)
 
 	return i, nil
@@ -51,6 +51,7 @@ func (srv *Instance) Run(ctx context.Context, wg *sync.WaitGroup) {
 		return
 	}
 
+	srv.agents = agents.New(srv.requests, srv.fw, srv.connector, srv.log)
 	srv.registration = registration.New(srv.fw, srv.connector, srv.log)
 
 	wg.Add(1)


### PR DESCRIPTION
This creates a basic MCollective RPC layer that can easily create
mcollective compatible RPC agents.  Right now its lacking in AAA and
request parameter handling but it's a good start

A ruby choria compatible choria_util agent is included that expose
internals in a matching way to the ruby one.