### PR TITLE
(#73) federation brokers are always subscribing to mcollective

### DIFF
--- a/broker/federation/choria_nats_egest.go
+++ b/broker/federation/choria_nats_egest.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/choria-io/go-choria/choria"
@@ -38,11 +39,12 @@ func NewChoriaNatsEgest(workers int, mode int, capacity int, broker *FederationB
 
 			logger.Debugf("Publishing message '%s' to %d target(s)", cm.RequestID, len(cm.Targets))
 
-			cm.Seen = append(cm.Seen, self.Name())
+			cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
 			cm.Seen = append(cm.Seen, nc.ConnectedServer())
 
 			if len(cm.Seen) >= 3 {
-				cm.Message.RecordNetworkHop(cm.Seen[0], strings.Join(cm.Seen[1:len(cm.Seen)-1], ", "), cm.Seen[len(cm.Seen)-1])
+				mid := fmt.Sprintf("%s (%s)", self.choria.Config.Identity, strings.Join(cm.Seen[1:len(cm.Seen)-1], ", "))
+				cm.Message.RecordNetworkHop(cm.Seen[0], mid, cm.Seen[len(cm.Seen)-1])
 			}
 
 			j, err := cm.Message.JSON()

--- a/broker/federation/choria_nats_ingest.go
+++ b/broker/federation/choria_nats_ingest.go
@@ -60,7 +60,7 @@ func NewChoriaNatsIngest(workers int, mode int, capacity int, broker *Federation
 			cm := chainmessage{
 				Message:   message,
 				RequestID: reqid,
-				Seen:      []string{nc.ConnectedServer(), self.Name()},
+				Seen:      []string{nc.ConnectedServer(), fmt.Sprintf("%s:%d", self.Name(), i)},
 			}
 
 			logger.Debugf("Received message %s via %s", reqid, message.SenderID())

--- a/broker/federation/choria_nats_ingest_test.go
+++ b/broker/federation/choria_nats_ingest_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Choria NATS Ingest", func() {
 
 		Expect(out.Message).To(Equal(transport))
 		Expect(out.RequestID).To(Equal(request.RequestID()))
-		Expect(out.Seen).To(Equal([]string{"nats://stub:4222", "choria_nats_ingest"}))
+		Expect(out.Seen).To(Equal([]string{"nats://stub:4222", "choria_nats_ingest:0"}))
 	}, 1)
 
 })

--- a/broker/federation/reply_transformer.go
+++ b/broker/federation/reply_transformer.go
@@ -2,6 +2,7 @@ package federation
 
 import (
 	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -32,7 +33,7 @@ func NewChoriaReplyTransformer(workers int, capacity int, broker *FederationBrok
 				continue
 			}
 
-			cm.Seen = append(cm.Seen, self.Name())
+			cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
 			cm.Targets = []string{replyto}
 			cm.RequestID = req
 

--- a/broker/federation/request_transformer.go
+++ b/broker/federation/request_transformer.go
@@ -39,7 +39,7 @@ func NewChoriaRequestTransformer(workers int, capacity int, broker *FederationBr
 				continue
 			}
 
-			cm.Seen = append(cm.Seen, self.Name())
+			cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
 			cm.RequestID = req
 			cm.Targets = targets
 

--- a/choria/config.go
+++ b/choria/config.go
@@ -35,15 +35,17 @@ type ChoriaPluginConfig struct {
 	DiscoveryProxy bool   `confkey:"plugin.choria.discovery_proxy" default:"false"`
 
 	// federation
-	FederationCollectives []string `confkey:"plugin.choria.federation.collectives" type:"comma_split" environment:"CHORIA_FED_COLLECTIVE"`
-	StatsPort             int      `configkey:"plugin.choria.stats_port"`
+	FederationCollectives     []string `confkey:"plugin.choria.federation.collectives" type:"comma_split" environment:"CHORIA_FED_COLLECTIVE"`
+	FederationMiddlewareHosts []string `confkey:"plugin.choria.federation_middleware_hosts" type:"comma_split"`
+	FederationCluster         string   `confkey:"plugin.choria.federation.cluster" default:"mcollective"`
+
+	StatsPort int `configkey:"plugin.choria.stats_port"`
 
 	// nats connector
-	NatsUser                  string   `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`
-	NatsPass                  string   `confkey:"plugin.nats.pass" environment:"MCOLLECTIVE_NATS_PASSWORD"`
-	MiddlewareHosts           []string `confkey:"plugin.choria.middleware_hosts" type:"comma_split"`
-	FederationMiddlewareHosts []string `confkey:"plugin.choria.federation_middleware_hosts" type:"comma_split"`
-	RandomizeMiddlewareHosts  bool     `confkey:"plugin.choria.randomize_middleware_hosts" default:"false"`
+	NatsUser                 string   `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`
+	NatsPass                 string   `confkey:"plugin.nats.pass" environment:"MCOLLECTIVE_NATS_PASSWORD"`
+	MiddlewareHosts          []string `confkey:"plugin.choria.middleware_hosts" type:"comma_split"`
+	RandomizeMiddlewareHosts bool     `confkey:"plugin.choria.randomize_middleware_hosts" default:"false"`
 
 	// security plugin
 	PrivilegedUsers   []string `confkey:"plugin.choria.security.privileged_users" type:"comma_split" default:"\\.privileged.mcollective$"`
@@ -61,7 +63,6 @@ type ChoriaPluginConfig struct {
 	BrokerNetwork        bool     `confkey:"plugin.choria.broker_network" default:"false"`
 	BrokerDiscovery      bool     `confkey:"plugin.choria.broker_discovery" default:"false"`
 	BrokerFederation     bool     `confkey:"plugin.choria.broker_federation" default:"false"`
-	FederationCluster    string   `confkey:"plugin.choria.broker_federation_cluster" default:"mcollective"`
 
 	// discovery
 	FactSourceFile string `confkey:"plugin.yaml" default:"/etc/puppetlabs/mcollective/generated-facts.yaml"`

--- a/choria/connection.go
+++ b/choria/connection.go
@@ -181,6 +181,8 @@ func (self *Connection) ChanQueueSubscribe(name string, subject string, group st
 
 	self.chanSubscriptions[name] = s
 
+	self.logger.Debugf("Susbscribing to %s in group '%s' on server %s", subject, group, self.ConnectedServer())
+
 	s.subscription, err = self.nats.ChanQueueSubscribe(subject, group, s.in)
 	if err != nil {
 		return nil, fmt.Errorf("Could not subscribe to subscription %s: %s", name, err.Error())
@@ -205,6 +207,8 @@ func (self *Connection) QueueSubscribe(ctx context.Context, name string, subject
 	}
 
 	self.chanSubscriptions[name] = s
+
+	self.logger.Debugf("Susbscribing to %s in group '%s' on server %s", subject, group, self.ConnectedServer())
 
 	s.subscription, err = self.nats.ChanQueueSubscribe(subject, group, s.in)
 	if err != nil {
@@ -237,6 +241,8 @@ func (self *Connection) Subscribe(name string, subject string, group string) err
 	if ok {
 		return fmt.Errorf("Already have a subscription called '%s'", name)
 	}
+
+	self.logger.Debugf("Susbscribing to %s in group '%s' on server %s", subject, group, self.ConnectedServer())
 
 	sub, err := self.nats.ChanQueueSubscribe(subject, group, self.outbox)
 	if err != nil {

--- a/contrib/dist/el6/choria.spec
+++ b/contrib/dist/el6/choria.spec
@@ -18,7 +18,7 @@ The Choria Orchestrator Server and Broker
 %setup -q
 
 %build
-for i in server.init broker.init choria.conf choria-logrotate; do
+for i in server.init broker.init server.conf broker.conf choria-logrotate; do
   sed -i 's!{{pkgname}}!%{pkgname}!' dist/${i}
   sed -i 's!{{bindir}}!%{bindir}!' dist/${i}
   sed -i 's!{{etcdir}}!%{etcdir}!' dist/${i}
@@ -72,7 +72,8 @@ fi
 
 %files
 %if 0%{?manage_conf} > 0
-%config(noreplace)%{etcdir}/choria.conf
+%config(noreplace)%{etcdir}/broker.conf
+%config(noreplace)%{etcdir}/server.conf
 %endif
 %{bindir}/%{pkgname}
 /etc/logrotate.d/%{pkgname}

--- a/contrib/dist/el7/choria.spec
+++ b/contrib/dist/el7/choria.spec
@@ -18,7 +18,7 @@ The Choria Orchestrator Server and Broker
 %setup -q
 
 %build
-for i in server.service broker.service choria.conf choria-logrotate; do
+for i in server.service broker.service broker.conf server.conf choria-logrotate; do
   sed -i 's!{{pkgname}}!%{pkgname}!' dist/${i}
   sed -i 's!{{bindir}}!%{bindir}!' dist/${i}
   sed -i 's!{{etcdir}}!%{etcdir}!' dist/${i}
@@ -64,7 +64,8 @@ fi
 
 %files
 %if 0%{?manage_conf} > 0
-%config(noreplace)%{etcdir}/choria.conf
+%config(noreplace)%{etcdir}/broker.conf
+%config(noreplace)%{etcdir}/server.conf
 %endif
 %{bindir}/%{pkgname}
 /etc/logrotate.d/%{pkgname}


### PR DESCRIPTION
The choria.Config code was parsing plugin.choria.broker_federation_cluster
instead of plugin.choria.federation.cluster like the ruby ones

This fixes that and also add some quick improvement to the seen messages