### PR TITLE
(#81) broker stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
-|2017/12/11|76    |Rename the `nats_stream` adapter to `natsstream`                                                         |
 |2017/12/10|73    |Federation brokers now correctly subscribe to the configured names                                       |
 |2017/12/10|71    |Fix TLS network cluster                                                                                  |
 |2017/12/10|      |Release 0.0.2                                                                                            |

--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ plugin.choria.network.peers = nats://choria1:5222, nats://choria2:5222, nats://c
 plugin.choria.network.peer_user = choria_cluster
 plugin.choria.network.peer_password = s£cret
 
-# enables the typical NATS stats/status port, default, set to 0 to disable
-plugin.choria.network.monitor_port = 8222
+# enables the typical NATS stats/status port, default is set to 0 and so disabled
+plugin.choria.stats_port = 8222
+
+# listens for stats to everyone, 127.0.0.1 by default
+plugin.choria.stats_address = 0.0.0.0
 ```
 
 ## Federation Broker

--- a/broker/federation/choria_nats_ingest.go
+++ b/broker/federation/choria_nats_ingest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/statistics"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,26 +36,23 @@ func NewChoriaNatsIngest(workers int, mode int, capacity int, broker *Federation
 			return
 		}
 
-		for {
-			var msg *choria.ConnectorMessage
+		ctr := statistics.Counter(fmt.Sprintf("federation.nats_ingest.%s.%d.received", grp, i))
+		ectr := statistics.Counter(fmt.Sprintf("federation.nats_ingest.%s.%d.err", grp, i))
+		timer := statistics.Timer(fmt.Sprintf("federation.nats_ingest.%s.%d.time", grp, i))
 
-			select {
-			case msg = <-natsch:
-			case <-ctx.Done():
-				logger.Infof("Worker routine %s exiting", self.Name())
-				return
-			}
-
+		handler := func(msg *choria.ConnectorMessage) {
 			message, err := self.choria.NewTransportFromJSON(string(msg.Data))
 			if err != nil {
 				logger.Warnf("Could not parse received message into a TransportMessage: %s", err.Error())
-				continue
+				ectr.Inc(1)
+				return
 			}
 
 			reqid, federated := message.FederationRequestID()
 			if !federated {
 				logger.Warnf("Received a message on %s that was not federated", msg.Subject)
-				continue
+				ectr.Inc(1)
+				return
 			}
 
 			cm := chainmessage{
@@ -66,8 +64,23 @@ func NewChoriaNatsIngest(workers int, mode int, capacity int, broker *Federation
 			logger.Debugf("Received message %s via %s", reqid, message.SenderID())
 
 			self.out <- cm
+			ctr.Inc(1)
 		}
 
+		for {
+			var msg *choria.ConnectorMessage
+
+			select {
+			case msg = <-natsch:
+				timer.Time(func() {
+					handler(msg)
+				})
+
+			case <-ctx.Done():
+				logger.Infof("Worker routine %s exiting", self.Name())
+				return
+			}
+		}
 	})
 
 	return worker, err

--- a/broker/federation/federation.go
+++ b/broker/federation/federation.go
@@ -77,4 +77,9 @@ func (self *FederationBroker) Start(ctx context.Context, wg *sync.WaitGroup) {
 	go self.requestT.Run(ctx)
 	go self.fedOut.Run(ctx)
 	go self.fedIn.Run(ctx)
+
+	select {
+	case <-ctx.Done():
+		return
+	}
 }

--- a/broker/federation/reply_transformer.go
+++ b/broker/federation/reply_transformer.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/choria-io/go-choria/statistics"
 	log "github.com/sirupsen/logrus"
 )
 
 func NewChoriaReplyTransformer(workers int, capacity int, broker *FederationBroker, logger *log.Entry) (*pooledWorker, error) {
 	worker, err := PooledWorkerFactory("choria_reply_transformer", workers, Unconnected, capacity, broker, logger, func(ctx context.Context, self *pooledWorker, i int, logger *log.Entry) {
 		defer self.wg.Done()
+
+		rctr := statistics.Counter(fmt.Sprintf("federation.choria_reply_transformer.%d.received", i))
+		ectr := statistics.Counter(fmt.Sprintf("federation.choria_reply_transformer.%d.err", i))
+		timer := statistics.Timer(fmt.Sprintf("federation.choria_reply_transformer.%d.time", i))
 
 		for {
 			var cm chainmessage
@@ -24,26 +29,31 @@ func NewChoriaReplyTransformer(workers int, capacity int, broker *FederationBrok
 			req, federated := cm.Message.FederationRequestID()
 			if !federated {
 				logger.Errorf("Received a message from %s that is not federated", cm.Message.SenderID())
+				ectr.Inc(1)
 				continue
 			}
 
 			replyto, _ := cm.Message.FederationReplyTo()
 			if replyto == "" {
 				logger.Errorf("Received message %s with no reply-to set", req)
+				ectr.Inc(1)
 				continue
 			}
 
-			cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
-			cm.Targets = []string{replyto}
-			cm.RequestID = req
+			timer.Time(func() {
+				cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
+				cm.Targets = []string{replyto}
+				cm.RequestID = req
 
-			cm.Message.SetUnfederated()
+				cm.Message.SetUnfederated()
 
-			logger.Infof("Received a reply message '%s' via %s", cm.RequestID, cm.Message.SenderID())
+				logger.Infof("Received a reply message '%s' via %s", cm.RequestID, cm.Message.SenderID())
 
-			self.out <- cm
+				self.out <- cm
+			})
+
+			rctr.Inc(1)
 		}
-
 	})
 
 	return worker, err

--- a/broker/federation/request_transformer.go
+++ b/broker/federation/request_transformer.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/choria-io/go-choria/statistics"
 	log "github.com/sirupsen/logrus"
 )
 
 func NewChoriaRequestTransformer(workers int, capacity int, broker *FederationBroker, logger *log.Entry) (*pooledWorker, error) {
 	worker, err := PooledWorkerFactory("choria_request_transformer", workers, Unconnected, capacity, broker, logger, func(ctx context.Context, self *pooledWorker, i int, logger *log.Entry) {
 		defer self.wg.Done()
+
+		rctr := statistics.Counter(fmt.Sprintf("federation.choria_request_transformer.%d.received", i))
+		ectr := statistics.Counter(fmt.Sprintf("federation.choria_request_transformer.%d.err", i))
+		timer := statistics.Timer(fmt.Sprintf("federation.choria_request_transformer.%d.time", i))
 
 		for {
 			var cm chainmessage
@@ -24,34 +29,40 @@ func NewChoriaRequestTransformer(workers int, capacity int, broker *FederationBr
 			req, federated := cm.Message.FederationRequestID()
 			if !federated {
 				logger.Errorf("Received a message from %s that is not federated", cm.Message.SenderID())
+				ectr.Inc(1)
 				continue
 			}
 
 			targets, _ := cm.Message.FederationTargets()
 			if len(targets) == 0 {
 				logger.Errorf("Received a message %s from %s that does not have any targets", req, cm.Message.SenderID())
+				ectr.Inc(1)
 				continue
 			}
 
 			replyto := cm.Message.ReplyTo()
 			if replyto == "" {
 				logger.Errorf("Received a message %s with no reply-to set", req)
+				ectr.Inc(1)
 				continue
 			}
 
-			cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
-			cm.RequestID = req
-			cm.Targets = targets
+			timer.Time(func() {
+				cm.Seen = append(cm.Seen, fmt.Sprintf("%s:%d", self.Name(), i))
+				cm.RequestID = req
+				cm.Targets = targets
 
-			cm.Message.SetFederationTargets([]string{})
-			cm.Message.SetFederationReplyTo(replyto)
-			cm.Message.SetReplyTo(fmt.Sprintf("choria.federation.%s.collective", self.broker.Name))
+				cm.Message.SetFederationTargets([]string{})
+				cm.Message.SetFederationReplyTo(replyto)
+				cm.Message.SetReplyTo(fmt.Sprintf("choria.federation.%s.collective", self.broker.Name))
 
-			logger.Infof("Received request message '%s' via %s with %d targets", cm.RequestID, cm.Message.SenderID(), len(cm.Targets))
+				logger.Infof("Received request message '%s' via %s with %d targets", cm.RequestID, cm.Message.SenderID(), len(cm.Targets))
 
-			self.out <- cm
+				self.out <- cm
+			})
+
+			rctr.Inc(1)
 		}
-
 	})
 
 	return worker, err

--- a/choria/config.go
+++ b/choria/config.go
@@ -39,7 +39,8 @@ type ChoriaPluginConfig struct {
 	FederationMiddlewareHosts []string `confkey:"plugin.choria.federation_middleware_hosts" type:"comma_split"`
 	FederationCluster         string   `confkey:"plugin.choria.federation.cluster" default:"mcollective"`
 
-	StatsPort int `confkey:"plugin.choria.stats_port" default:"0"`
+	StatsListenAddress string `confkey:"plugin.choria.stats_address" default:"127.0.0.1"`
+	StatsPort          int    `confkey:"plugin.choria.stats_port" default:"0"`
 
 	// nats connector
 	NatsUser                 string   `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`
@@ -56,7 +57,6 @@ type ChoriaPluginConfig struct {
 	NetworkListenAddress string   `confkey:"plugin.choria.network.listen_address" default:"::"`
 	NetworkClientPort    int      `confkey:"plugin.choria.network.client_port" default:"4222"`
 	NetworkPeerPort      int      `confkey:"plugin.choria.network.peer_port" default:"5222"`
-	NetworkMonitorPort   int      `confkey:"plugin.choria.network.monitor_port" default:"8222"`
 	NetworkPeerUser      string   `confkey:"plugin.choria.network.peer_user"`
 	NetworkPeerPassword  string   `confkey:"plugin.choria.network.peer_password"`
 	NetworkPeers         []string `confkey:"plugin.choria.network.peers" type:"comma_split"`

--- a/choria/config.go
+++ b/choria/config.go
@@ -39,7 +39,7 @@ type ChoriaPluginConfig struct {
 	FederationMiddlewareHosts []string `confkey:"plugin.choria.federation_middleware_hosts" type:"comma_split"`
 	FederationCluster         string   `confkey:"plugin.choria.federation.cluster" default:"mcollective"`
 
-	StatsPort int `configkey:"plugin.choria.stats_port"`
+	StatsPort int `confkey:"plugin.choria.stats_port" default:"0"`
 
 	// nats connector
 	NatsUser                 string   `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -438,7 +438,7 @@ func (self *Framework) StartStats(handler http.Handler) {
 	}
 
 	if !self.stats {
-		log.Infof("Starting statistic reporting on port %d /debug/metrics", port)
+		log.Infof("Starting statistic reporting on port %d /choria/metrics", port)
 
 		expvar.NewString("version").Set(build.Version)
 		expvar.NewString("build_sha").Set(build.SHA)
@@ -446,10 +446,11 @@ func (self *Framework) StartStats(handler http.Handler) {
 		expvar.NewString("config").Set(self.Config.ConfigFile)
 
 		if handler == nil {
+			http.Handle("/choria/metrics", statistics.HTTPHandler())
 			go http.ListenAndServe(fmt.Sprintf("%s:%d", self.Config.Choria.StatsListenAddress, port), nil)
 		} else {
 			hh := handler.(*http.ServeMux)
-			hh.Handle("/debug/metrics", statistics.HTTPHandler())
+			hh.Handle("/choria/metrics", statistics.HTTPHandler())
 		}
 
 		self.stats = true

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -84,6 +84,8 @@ func (r *brokerRunCommand) Run(wg *sync.WaitGroup) (err error) {
 		log.Warn("Running with TLS Verification disabled, not compatible with production use.")
 	}
 
+	c.StartStats()
+
 	if len(adapters) > 0 {
 		log.Info("Starting Protocol Adapters")
 
@@ -125,7 +127,7 @@ func (r *brokerRunCommand) runFederation(ctx context.Context, wg *sync.WaitGroup
 	}
 
 	wg.Add(1)
-	r.federation.Start(ctx, wg)
+	go r.federation.Start(ctx, wg)
 
 	return
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f9612b0fef27bfb20f0650753c13c8ee66f68e2bc69d884629eb7111573c5ec7
-updated: 2017-11-28T13:53:19.235399344+01:00
+hash: 79743ff5727f48da929543bd872da17a36fbe5e196d19f991a7f8b9ee9e5f6b5
+updated: 2017-12-11T15:39:15.867979867+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -13,7 +13,7 @@ imports:
   - encoders/builtin
   - util
 - name: github.com/gogo/protobuf
-  version: 971cbfd2e72b513a28c74af7462aee0800248d69
+  version: 41168f6614b7bb144818ec8967b8c702705df564
   subpackages:
   - gogoproto
   - proto
@@ -32,7 +32,7 @@ imports:
   - encoders/builtin
   - util
 - name: github.com/nats-io/go-nats-streaming
-  version: 88fd0ce51e45a3a711b737174fd951944c91f085
+  version: 43723aa09c43cec839e43583df07b1940c9f7651
   subpackages:
   - pb
 - name: github.com/nats-io/nats
@@ -73,10 +73,12 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/rcrowley/go-metrics
+  version: e181e095bae94582363434144c61a9653aff6e50
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus
-  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/tidwall/gjson
   version: be96719f990978a867f52c48f29d43f6b591da28
 - name: github.com/tidwall/match
@@ -94,7 +96,7 @@ imports:
   - blowfish
   - ssh/terminal
 - name: golang.org/x/net
-  version: fc492d2e106922eb3aa4bca863d55e882c087ae3
+  version: dc871a5d77e227f5bbf6545176ef3eeebf87e76e
   subpackages:
   - context
 - name: golang.org/x/sys
@@ -109,6 +111,6 @@ imports:
   - windows/svc/mgr
 - name: gopkg.in/alecthomas/kingpin.v2
   version: 1087e65c9441605df944fb12c33f0fe7072d18ca
-testImports:
 - name: gopkg.in/yaml.v2
   version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,3 +28,4 @@ import:
   subpackages:
   - encoders/builtin
   - util
+- package: github.com/rcrowley/go-metrics

--- a/statistics/stats.go
+++ b/statistics/stats.go
@@ -1,6 +1,7 @@
 package statistics
 
 import (
+	"net/http"
 	"sync"
 
 	metrics "github.com/rcrowley/go-metrics"
@@ -43,6 +44,10 @@ func getOrCreate(name string, create func() interface{}) interface{} {
 	registry.Register(name, m)
 
 	return m
+}
+
+func HTTPHandler() http.Handler {
+	return exp.ExpHandler(registry)
 }
 
 func init() {

--- a/statistics/stats.go
+++ b/statistics/stats.go
@@ -49,7 +49,3 @@ func getOrCreate(name string, create func() interface{}) interface{} {
 func HTTPHandler() http.Handler {
 	return exp.ExpHandler(registry)
 }
-
-func init() {
-	exp.Exp(registry)
-}

--- a/statistics/stats.go
+++ b/statistics/stats.go
@@ -1,0 +1,50 @@
+package statistics
+
+import (
+	"sync"
+
+	metrics "github.com/rcrowley/go-metrics"
+	"github.com/rcrowley/go-metrics/exp"
+	"github.com/sirupsen/logrus"
+)
+
+var registry = metrics.NewRegistry()
+var mu = &sync.Mutex{}
+var data = make(map[string]interface{})
+var log = logrus.WithFields(logrus.Fields{})
+
+func Counter(name string) metrics.Counter {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return getOrCreate(name, func() interface{} {
+		return metrics.NewCounter()
+	}).(metrics.Counter)
+}
+
+func Timer(name string) metrics.Timer {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return getOrCreate(name, func() interface{} {
+		return metrics.NewTimer()
+	}).(metrics.Timer)
+}
+
+func getOrCreate(name string, create func() interface{}) interface{} {
+	c, ok := data[name]
+	if ok {
+		return c
+	}
+
+	m := create()
+
+	data[name] = m
+	registry.Register(name, m)
+
+	return m
+}
+
+func init() {
+	exp.Exp(registry)
+}

--- a/statistics/stats_test.go
+++ b/statistics/stats_test.go
@@ -1,0 +1,26 @@
+package statistics
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestFileContent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Statistics")
+}
+
+var _ = Describe("Counter", func() {
+	It("Should create and retrieve counters", func() {
+		a := Counter("this.is.a.test")
+		a.Inc(1)
+		b := Counter("this.is.a.test")
+		c := Counter("other")
+		Expect(a).To(Equal(b))
+		Expect(b.Count()).To(Equal(int64(1)))
+		Expect(a).ToNot(Equal(c))
+		Expect(c.Count()).To(Equal(int64(0)))
+	})
+})


### PR DESCRIPTION
This adds a bunch of stats to federation, adapters and registration.

It's exposed on StatsPort which is off by default.

Need to find a way to share this with the stats NATS produce on the
same port