### PR TITLE
(#81) Add a prometheus exporter

### DIFF
--- a/choria/framework.go
+++ b/choria/framework.go
@@ -2,10 +2,8 @@ package choria
 
 import (
 	"errors"
-	"expvar"
 	"fmt"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -13,8 +11,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/choria-io/go-choria/build"
-	"github.com/choria-io/go-choria/statistics"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -423,36 +419,4 @@ func (self *Framework) HasCollective(collective string) bool {
 	}
 
 	return false
-}
-
-// StartStats starts serving exp stats and metrics on the configured statistics port
-func (self *Framework) StartStats(handler http.Handler) {
-	self.mu.Lock()
-	defer self.mu.Unlock()
-
-	port := self.Config.Choria.StatsPort
-
-	if port == 0 {
-		log.Infof("Statistics gathering disabled, set plugin.choria.stats_port")
-		return
-	}
-
-	if !self.stats {
-		log.Infof("Starting statistic reporting on port %d /choria/metrics", port)
-
-		expvar.NewString("version").Set(build.Version)
-		expvar.NewString("build_sha").Set(build.SHA)
-		expvar.NewString("build_date").Set(build.BuildDate)
-		expvar.NewString("config").Set(self.Config.ConfigFile)
-
-		if handler == nil {
-			http.Handle("/choria/metrics", statistics.HTTPHandler())
-			go http.ListenAndServe(fmt.Sprintf("%s:%d", self.Config.Choria.StatsListenAddress, port), nil)
-		} else {
-			hh := handler.(*http.ServeMux)
-			hh.Handle("/choria/metrics", statistics.HTTPHandler())
-		}
-
-		self.stats = true
-	}
 }

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/choria-io/go-choria/broker/federation"
 	"github.com/choria-io/go-choria/broker/network"
 	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/statistics"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -163,7 +164,7 @@ func (r *brokerRunCommand) startStats() {
 		handler = nil
 	}
 
-	c.StartStats(handler)
+	statistics.Start(c.Config, handler)
 }
 
 func init() {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 79743ff5727f48da929543bd872da17a36fbe5e196d19f991a7f8b9ee9e5f6b5
-updated: 2017-12-11T15:39:15.867979867+01:00
+hash: 11d6459db225fa39b23a692fba5e34784e7e613bb44d5c83b3bba06b8ecedcfb
+updated: 2017-12-12T11:29:31.358504652+01:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -7,6 +7,10 @@ imports:
   - parse
 - name: github.com/alecthomas/units
   version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/beorn7/perks
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+  subpackages:
+  - quantile
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
   subpackages:
@@ -18,6 +22,14 @@ imports:
   - gogoproto
   - proto
   - protoc-gen-gogo/descriptor
+- name: github.com/golang/protobuf
+  version: 1e59b77b52bf8e4b449a57e6f79f21226d571845
+  subpackages:
+  - proto
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
 - name: github.com/nats-io/gnatsd
   version: 12a5ced612f30aa511906c0de12a124233752f70
   subpackages:
@@ -73,8 +85,29 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/prometheus/client_golang
+  version: 661e31bf844dfca9aeba15f27ea8aa0d485ad212
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 2e54d0b93cba2fd133edc32211dcc32c06ef72ca
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
+  subpackages:
+  - xfs
 - name: github.com/rcrowley/go-metrics
   version: e181e095bae94582363434144c61a9653aff6e50
+  subpackages:
+  - exp
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
 - name: github.com/sirupsen/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,3 +29,4 @@ import:
   - encoders/builtin
   - util
 - package: github.com/rcrowley/go-metrics
+- package: github.com/prometheus/client_golang

--- a/statistics/prometheus.go
+++ b/statistics/prometheus.go
@@ -1,0 +1,104 @@
+package statistics
+
+import (
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rcrowley/go-metrics"
+)
+
+// Copied from https://github.com/deathowl/go-metrics-prometheus and modified
+// to set subsystem the way we like etc
+
+// PrometheusConfig provides a container with config parameters for the
+// Prometheus Exporter
+type PrometheusConfig struct {
+	namespace     string
+	Registry      metrics.Registry      // Registry to be exported
+	promRegistry  prometheus.Registerer //Prometheus registry
+	FlushInterval time.Duration         //interval to update prom metrics
+	gauges        map[string]prometheus.Gauge
+}
+
+// NewPrometheusProvider returns a Provider that produces Prometheus metrics.
+// Namespace and subsystem are applied to all produced metrics.
+func NewPrometheusProvider(r metrics.Registry, namespace string, promRegistry prometheus.Registerer, FlushInterval time.Duration) *PrometheusConfig {
+	return &PrometheusConfig{
+		namespace:     namespace,
+		Registry:      r,
+		promRegistry:  promRegistry,
+		FlushInterval: FlushInterval,
+		gauges:        make(map[string]prometheus.Gauge),
+	}
+}
+
+func (c *PrometheusConfig) flattenKey(key string) string {
+	key = strings.Replace(key, " ", "_", -1)
+	key = strings.Replace(key, ".", "_", -1)
+	key = strings.Replace(key, "-", "_", -1)
+	key = strings.Replace(key, "=", "_", -1)
+	return key
+}
+
+func (c *PrometheusConfig) subsystemFromKey(key string) string {
+	parts := strings.Split(key, ".")
+
+	return parts[0]
+}
+
+func (c *PrometheusConfig) metricFromKey(key string) string {
+	parts := strings.Split(key, ".")
+
+	return strings.Join(parts[1:], ".")
+}
+
+func (c *PrometheusConfig) gaugeFromNameAndValue(name string, val float64) {
+	key := c.metricFromKey(name)
+
+	g, ok := c.gauges[key]
+	if !ok {
+		g = prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: c.flattenKey(c.namespace),
+			Subsystem: c.subsystemFromKey(name),
+			Name:      c.flattenKey(key),
+			Help:      c.flattenKey(name),
+		})
+		c.promRegistry.MustRegister(g)
+		c.gauges[key] = g
+	}
+
+	g.Set(val)
+}
+
+func (c *PrometheusConfig) UpdatePrometheusMetrics() {
+	for _ = range time.Tick(c.FlushInterval) {
+		c.UpdatePrometheusMetricsOnce()
+	}
+}
+
+func (c *PrometheusConfig) UpdatePrometheusMetricsOnce() error {
+	c.Registry.Each(func(name string, i interface{}) {
+		switch metric := i.(type) {
+		case metrics.Counter:
+			c.gaugeFromNameAndValue(name, float64(metric.Count()))
+		case metrics.Gauge:
+			c.gaugeFromNameAndValue(name, float64(metric.Value()))
+		case metrics.GaugeFloat64:
+			c.gaugeFromNameAndValue(name, float64(metric.Value()))
+		case metrics.Histogram:
+			samples := metric.Snapshot().Sample().Values()
+			if len(samples) > 0 {
+				lastSample := samples[len(samples)-1]
+				c.gaugeFromNameAndValue(name, float64(lastSample))
+			}
+		case metrics.Meter:
+			lastSample := metric.Snapshot().Rate1()
+			c.gaugeFromNameAndValue(name, float64(lastSample))
+		case metrics.Timer:
+			lastSample := metric.Snapshot().Rate1()
+			c.gaugeFromNameAndValue(name, float64(lastSample))
+		}
+	})
+	return nil
+}

--- a/statistics/stats.go
+++ b/statistics/stats.go
@@ -1,8 +1,16 @@
 package statistics
 
 import (
+	"expvar"
+	"fmt"
 	"net/http"
 	"sync"
+	"time"
+
+	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
@@ -13,6 +21,7 @@ var registry = metrics.NewRegistry()
 var mu = &sync.Mutex{}
 var data = make(map[string]interface{})
 var log = logrus.WithFields(logrus.Fields{})
+var running = false
 
 func Counter(name string) metrics.Counter {
 	mu.Lock()
@@ -48,4 +57,43 @@ func getOrCreate(name string, create func() interface{}) interface{} {
 
 func HTTPHandler() http.Handler {
 	return exp.ExpHandler(registry)
+}
+
+// Start starts serving exp stats and metrics on the configured statistics port
+func Start(config *choria.Config, handler http.Handler) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	port := config.Choria.StatsPort
+
+	if port == 0 {
+		log.Infof("Statistics gathering disabled, set plugin.choria.stats_port")
+		return
+	}
+
+	if !running {
+		log.Infof("Starting statistic reporting on port %d /choria/metrics", port)
+
+		expvar.NewString("version").Set(build.Version)
+		expvar.NewString("build_sha").Set(build.SHA)
+		expvar.NewString("build_date").Set(build.BuildDate)
+		expvar.NewString("config").Set(config.ConfigFile)
+
+		pReg := prometheus.NewRegistry()
+		pClient := NewPrometheusProvider(registry, "choria", pReg, 1*time.Second)
+		go pClient.UpdatePrometheusMetrics()
+
+		if handler == nil {
+			http.Handle("/choria/metrics", HTTPHandler())
+			http.Handle("/choria/prometheus", promhttp.HandlerFor(pReg, promhttp.HandlerOpts{}))
+
+			go http.ListenAndServe(fmt.Sprintf("%s:%d", config.Choria.StatsListenAddress, port), nil)
+		} else {
+			hh := handler.(*http.ServeMux)
+			hh.Handle("/choria/prometheus", promhttp.HandlerFor(pReg, promhttp.HandlerOpts{}))
+			hh.Handle("/choria/metrics", HTTPHandler())
+		}
+
+		running = true
+	}
 }


### PR DESCRIPTION
This adds a exporter for prometheus on /choria/prometheus

Right now its a bit meh, there is no useful help and no labels, but
since the statistics package here has a intermediate map that stores
info the metrics instances we can there in future store additional
help text, labels etc and for systems that support it - like prom -
expose those.

Bit of a wip, but it's a good place to itterate from