### PR TITLE
(#80) SRV Record Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2017/12/14|80    |When doing SRV lookups employ a cache to speed things up                                                 |
+|2017/12/14|92    |When shutting down daemons on rhel6 wait for them to exit and then KILL them after 5 seconds             |
 |2017/12/14|91    |Avoid race condition while determining if the network broker started                                     |
 |2017/12/14|90    |Emit build info on `/choria/`                                                                            | 
 |2017/12/13|      |Release 0.0.3                                                                                            |

--- a/Rakefile
+++ b/Rakefile
@@ -34,9 +34,16 @@ task :build do
     end
   end
 
-  sh "go build -race -o %s -ldflags '%s'" % [
-    output_name(version), flags.join(" ")
+  args = [
+    "-o %s" % output_name(version),
+    "-ldflags '%s'" % flags.join(" ")
   ]
+
+  args << "-race" if version == "development"
+
+  cmd = "go build %s" % args.join(" ")
+
+  sh cmd % [output_name(version), flags.join(" ")]
 end
 
 desc "Builds a Linux binary"

--- a/broker/federation/federation.go
+++ b/broker/federation/federation.go
@@ -80,6 +80,7 @@ func (self *FederationBroker) Start(ctx context.Context, wg *sync.WaitGroup) {
 
 	select {
 	case <-ctx.Done():
+		log.Warn("Choria Federation Broker shutting down")
 		return
 	}
 }

--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -90,7 +90,7 @@ func (s *Server) Start(ctx context.Context, wg *sync.WaitGroup) {
 		s.gnatsd.Shutdown()
 	}
 
-	log.Warn("Choria Network Broker has been shut down")
+	log.Warn("Choria Network Broker shutting down")
 }
 
 func (s *Server) setupCluster() (err error) {

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/choria-io/go-choria/srvcache"
 	uuid "github.com/satori/go.uuid"
 	log "github.com/sirupsen/logrus"
 )
@@ -266,13 +267,16 @@ func (self *Framework) QuerySrvRecords(records []string) ([]Server, error) {
 		if err != nil {
 			return servers, err
 		}
+
+		// cache the result to speed things up
+		self.Config.Choria.SRVDomain = domain
 	}
 
 	for _, q := range records {
 		record := q + "." + domain
 		log.Debugf("Attempting SRV lookup for %s", record)
 
-		cname, addrs, err := net.LookupSRV("", "", record)
+		cname, addrs, err := srvcache.LookupSRV("", "", record, net.LookupSRV)
 		if err != nil {
 			log.Debugf("Failed to resolve %s: %s", record, err.Error())
 			continue

--- a/srvcache/srvcache.go
+++ b/srvcache/srvcache.go
@@ -1,0 +1,100 @@
+package srvcache
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type query struct {
+	service string
+	proto   string
+	name    string
+}
+
+type entry struct {
+	cname string
+	addrs []*net.SRV
+	time  time.Time
+}
+
+var cache = make(map[query]entry)
+var mu = &sync.Mutex{}
+var MaxAge = time.Duration(5 * time.Second)
+
+var srvctr = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "choria_dns_srv_lookups",
+	Help: "Number of SRV queries performed",
+})
+
+var srvhit = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "choria_dns_srv_cachehits",
+	Help: "Number of SRV lookups served from the cache",
+})
+
+var srvmiss = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "choria_dns_srv_cachemiss",
+	Help: "Number of SRV cache lookup misses",
+})
+
+func init() {
+	prometheus.MustRegister(srvctr)
+	prometheus.MustRegister(srvhit)
+	prometheus.MustRegister(srvmiss)
+}
+
+// LookupSRV is a wrapper around net.LookupSRV that does a 5 second cache
+func LookupSRV(service string, proto string, name string, resolver func(string, string, string) (string, []*net.SRV, error)) (string, []*net.SRV, error) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	var err error
+
+	q := query{service, proto, name}
+
+	cname, addrs := retrieve(q)
+	if addrs == nil {
+		cname, addrs, err = resolver("", "", name)
+	}
+
+	store(q, cname, addrs)
+
+	srvctr.Inc()
+
+	return cname, addrs, err
+}
+
+func store(q query, cname string, addrs []*net.SRV) {
+	cache[q] = entry{
+		cname: cname,
+		addrs: addrs,
+		time:  time.Now(),
+	}
+}
+
+func retrieve(q query) (string, []*net.SRV) {
+	entry, found := cache[q]
+	if !found {
+		log.Debugf("SRV cache miss on SRV record %#v in cache", q, cache)
+		srvmiss.Inc()
+		return "", nil
+	}
+
+	if time.Now().Before(entry.time.Add(MaxAge)) {
+		log.Debugf("SRV cache hit on SRV record %#v", q)
+		srvhit.Inc()
+		return entry.cname, entry.addrs
+	}
+
+	log.Debugf("SRV cache miss on SRV record %#v due to age of the record", q)
+
+	delete(cache, q)
+
+	srvmiss.Inc()
+
+	return "", nil
+}

--- a/srvcache/srvcache_test.go
+++ b/srvcache/srvcache_test.go
@@ -1,0 +1,66 @@
+package srvcache
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMCollective(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SRVCache")
+}
+
+var _ = Describe("LookupSRV", func() {
+	var ctr = 1
+	var resolver = func(service string, proto string, name string) (cname string, addrs []*net.SRV, err error) {
+		a := &net.SRV{
+			Target:   fmt.Sprintf("1.2.3.%d", ctr),
+			Priority: 1,
+			Weight:   1,
+			Port:     5222,
+		}
+
+		ctr++
+
+		return "test.example.net", []*net.SRV{a}, nil
+	}
+
+	It("Should do a lookup and cache it and serve from the cache", func() {
+		ctr = 1
+
+		cname, addrs, err := LookupSRV("", "", "test.example.net", resolver)
+		Expect(cname).To(Equal("test.example.net"))
+		Expect(addrs[0].Target).To(Equal("1.2.3.1"))
+		Expect(err).ToNot(HaveOccurred())
+
+		cname, addrs, err = LookupSRV("", "", "test.example.net", resolver)
+		Expect(cname).To(Equal("test.example.net"))
+		Expect(addrs[0].Target).To(Equal("1.2.3.1"))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should age entries out of the cache", func() {
+		ctr = 1
+
+		_, addrs, _ := LookupSRV("", "", "another.example.net", resolver)
+		Expect(addrs[0].Target).To(Equal("1.2.3.1"))
+		_, addrs, _ = LookupSRV("", "", "another.example.net", resolver)
+		Expect(addrs[0].Target).To(Equal("1.2.3.1"))
+
+		_, found := cache[query{"", "", "another.example.net"}]
+		Expect(found).To(BeTrue())
+
+		MaxAge = time.Duration(-1 * time.Second)
+
+		_, addrs = retrieve(query{"", "", "another.example.net"})
+		Expect(addrs).To(BeNil())
+
+		_, found = cache[query{"", "", "another.example.net"}]
+		Expect(found).To(BeFalse())
+	})
+})


### PR DESCRIPTION
This creates a little global SRV cache where lookups are funneled
through and cached for 5 seconds.

Go would typically do no caching at all and the LookupSRV isn't going
to tell me the TTL on these things, so I am mking it 5 seconds which
for the typical problem - lookup storm during startup or big
disconnects - will solve the problem handily

It exposes prometheus stats about efficiency