### PR TITLE
(#101) add a backoff with jitter to initial connections

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,40 @@
+package backoff
+
+// https://blog.gopheracademy.com/advent-2014/backoff/
+
+import (
+	"math/rand"
+	"time"
+)
+
+// BackoffPolicy implements a backoff policy, randomizing its delays
+// and saturating at the final value in Millis.
+type BackoffPolicy struct {
+	Millis []int
+}
+
+// FiveSec is a backoff policy ranging up to 5 seconds.
+var FiveSec = BackoffPolicy{
+	[]int{500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000},
+}
+
+// Duration returns the time duration of the n'th wait cycle in a
+// backoff policy. This is b.Millis[n], randomized to avoid thundering
+// herds.
+func (b BackoffPolicy) Duration(n int) time.Duration {
+	if n >= len(b.Millis) {
+		n = len(b.Millis) - 1
+	}
+
+	return time.Duration(jitter(b.Millis[n])) * time.Millisecond
+}
+
+// jitter returns a random integer uniformly distributed in the range
+// [0.5 * millis .. 1.5 * millis]
+func jitter(millis int) int {
+	if millis == 0 {
+		return 0
+	}
+
+	return millis/2 + rand.Intn(millis)
+}


### PR DESCRIPTION
This adds a jittered random sleep in the reconnection cycle which
will sleep random durations between .5 and 5 seconds.  The jitter
avoids a thundering herd from the many workers we spawn