### PR TITLE
(#108) copytruncate log files

### DIFF
--- a/contrib/dist/choria-logrotate
+++ b/contrib/dist/choria-logrotate
@@ -1,4 +1,5 @@
 /var/log/{{pkgname}}.log {
   daily
   rotate 10
+  copytruncate
 }


### PR DESCRIPTION
Logrotation with logrus is a bit of a pain, copytruncate is about
the best we can do for now