### PR TITLE
(#114) create a logfile that matches the package name

### DIFF
--- a/contrib/dist/server.conf
+++ b/contrib/dist/server.conf
@@ -1,2 +1,2 @@
-logfile = /var/log/choria.log
+logfile = /var/log/{{pkgname}}.log
 loglevel = info


### PR DESCRIPTION
When someone builds acme-choria they should also get acme-choria log
file by default