### PR TITLE
(#120) allow a provisioning mode default to be compiled in

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,3 @@
-require "securerandom"
-
-OWN_OS=`go env GOOS`.chomp
-OWN_ARCH=`go env GOARCH`.chomp
-
 task :default => [:test]
 
 desc "Run just tests no measurements"

--- a/agents/provision/provision.go
+++ b/agents/provision/provision.go
@@ -68,7 +68,7 @@ func reprovisionAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.A
 	mu.Lock()
 	defer mu.Unlock()
 
-	if agent.Config.Choria.Provision {
+	if agent.Choria.ProvisionMode() {
 		abort("Server is already in provisioning mode, cannot enable provisioning mode again", reply)
 		return
 	}
@@ -111,7 +111,7 @@ func configureAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Age
 	mu.Lock()
 	defer mu.Unlock()
 
-	if !agent.Config.Choria.Provision {
+	if !agent.Choria.ProvisionMode() {
 		abort("Cannot reconfigure a server that is not in provisioning mode", reply)
 		return
 	}
@@ -146,7 +146,7 @@ func restartAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent
 	mu.Lock()
 	defer mu.Unlock()
 
-	if !agent.Config.Choria.Provision {
+	if !agent.Choria.ProvisionMode() {
 		abort("Cannot restart a server that is not in provisioning mode", reply)
 		return
 	}

--- a/agents/provision/provision_test.go
+++ b/agents/provision/provision_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 
+	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/choria"
 	"github.com/choria-io/go-choria/mcorpc"
 	"github.com/choria-io/go-choria/server/agents"
@@ -47,6 +48,8 @@ var _ = Describe("Agent/Provision", func() {
 		logrus.SetLevel(logrus.FatalLevel)
 
 		allowRestart = false
+		build.ProvisionModeDefault = "false"
+		build.ProvisionBrokerURLs = "nats://n1:4222"
 	})
 
 	AfterEach(func() {
@@ -67,7 +70,7 @@ var _ = Describe("Agent/Provision", func() {
 		})
 
 		It("Should refuse to restart nodes that just goes back into provision mode", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			cfg.ConfigFile = "testdata/provisioning.cfg"
 
 			req := &mcorpc.Request{
@@ -83,7 +86,7 @@ var _ = Describe("Agent/Provision", func() {
 		})
 
 		It("Should restart with splay", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			cfg.ConfigFile = "testdata/default.cfg"
 
 			req := &mcorpc.Request{
@@ -101,7 +104,7 @@ var _ = Describe("Agent/Provision", func() {
 
 	var _ = Describe("reprovisionAction", func() {
 		It("Should only reprovision nodes not in provisioning mode", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 
 			reprovisionAction(&mcorpc.Request{}, reply, prov, nil)
 			Expect(reply.Statuscode).To(Equal(mcorpc.Aborted))
@@ -161,7 +164,7 @@ var _ = Describe("Agent/Provision", func() {
 		})
 
 		It("Should fail for unknown config files", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			cfg.ConfigFile = ""
 
 			configureAction(&mcorpc.Request{}, reply, prov, nil)
@@ -171,7 +174,7 @@ var _ = Describe("Agent/Provision", func() {
 		})
 
 		It("Should fail for empty configuration", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			cfg.ConfigFile = "/tmp/choria_test.cfg"
 
 			configureAction(&mcorpc.Request{Data: json.RawMessage("{}")}, reply, prov, nil)
@@ -181,7 +184,7 @@ var _ = Describe("Agent/Provision", func() {
 		})
 
 		It("Should write the configuration", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			cfg.ConfigFile = "/tmp/choria_test.cfg"
 
 			req := &mcorpc.Request{

--- a/build/build.go
+++ b/build/build.go
@@ -25,6 +25,10 @@ var maxBrokerClients = "50000"
 // ProvisionBrokerURLs defines where the daemon will connect when choria.server.provision is true
 var ProvisionBrokerURLs = ""
 
+// ProvisionModeDefault defines the value of plugin.choria.server.provision when it's not set
+// in the configuration file at all.
+var ProvisionModeDefault = "false"
+
 // HasTLS determines if TLS should be used on the wire
 func HasTLS() bool {
 	return TLS == "true"
@@ -38,4 +42,10 @@ func MaxBrokerClients() int {
 	}
 
 	return c
+}
+
+// ProvisionDefault defines the value of plugin.choria.server.provision when it's not set
+// in the configuration file at all.
+func ProvisionDefault() bool {
+	return ProvisionModeDefault == "true"
 }

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -64,7 +64,7 @@ func NewWithConfig(config *Config) (*Framework, error) {
 		mu:     &sync.Mutex{},
 	}
 
-	if config.Choria.Provision {
+	if c.ProvisionMode() {
 		c.ConfigureProvisioning()
 	}
 
@@ -80,6 +80,22 @@ func NewWithConfig(config *Config) (*Framework, error) {
 	}
 
 	return &c, nil
+}
+
+// ProvisionMode determines if this instance is in provisioning mode
+// if the setting `plugin.choria.server.provision` is set at all then
+// the value of that is returned, else it the build time property
+// ProvisionDefault is consulted
+func (self *Framework) ProvisionMode() bool {
+	if build.ProvisionBrokerURLs == "" {
+		return false
+	}
+
+	if self.Config.HasOption("plugin.choria.server.provision") {
+		return self.Config.Choria.Provision
+	}
+
+	return build.ProvisionDefault()
 }
 
 // ConfigureProvisioning adjusts the active configuration to match the

--- a/choria/framework_test.go
+++ b/choria/framework_test.go
@@ -3,6 +3,7 @@ package choria
 import (
 	"testing"
 
+	"github.com/choria-io/go-choria/build"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -19,6 +20,53 @@ var _ = Describe("Choria", func() {
 			Expect(c.DiscoveryHost).To(Equal("puppet"))
 			Expect(c.DiscoveryPort).To(Equal(8085))
 			Expect(c.UseSRVRecords).To(BeTrue())
+		})
+	})
+
+	var _ = Describe("ProvisionMode", func() {
+		It("Should use the default when not configured and brokers are compiled in", func() {
+			c, err := NewConfig("/dev/null")
+			Expect(err).ToNot(HaveOccurred())
+			c.DisableTLS = true
+
+			fw, err := NewWithConfig(c)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(fw.ProvisionMode()).To(Equal(false))
+
+			build.ProvisionBrokerURLs = "nats://n1:4222"
+			build.ProvisionModeDefault = "true"
+			Expect(fw.ProvisionMode()).To(Equal(true))
+		})
+
+		It("Should use the configured value when set and when brokers are compiled in", func() {
+			c, err := NewConfig("testdata/provision.cfg")
+			Expect(err).ToNot(HaveOccurred())
+			c.DisableTLS = true
+
+			fw, err := NewWithConfig(c)
+			Expect(err).ToNot(HaveOccurred())
+
+			build.ProvisionBrokerURLs = "nats://n1:4222"
+
+			Expect(fw.ProvisionMode()).To(Equal(true))
+
+			c.Choria.Provision = false
+			build.ProvisionModeDefault = "true"
+
+			Expect(fw.ProvisionMode()).To(Equal(false))
+		})
+
+		It("Should be false if there are no brokers", func() {
+			c, err := NewConfig("testdata/provision.cfg")
+			Expect(err).ToNot(HaveOccurred())
+			c.DisableTLS = true
+
+			fw, err := NewWithConfig(c)
+			Expect(err).ToNot(HaveOccurred())
+
+			build.ProvisionBrokerURLs = ""
+			Expect(fw.ProvisionMode()).To(Equal(false))
 		})
 	})
 })

--- a/choria/testdata/choria.cfg
+++ b/choria/testdata/choria.cfg
@@ -8,7 +8,7 @@ libdir = /dir3:/dir4
 default_discovery_options = one
 default_discovery_options = two
 
-plugin.choria.discovery_host = pdb.example.com 
+plugin.choria.discovery_host = pdb.example.com
 plugin.choria.discovery_port = 9292
 plugin.choria.ssl_dir = /nonexisting
 plugin.choria.use_srv = false

--- a/choria/testdata/provision.cfg
+++ b/choria/testdata/provision.cfg
@@ -1,0 +1,1 @@
+plugin.choria.server.provision = true

--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -34,6 +34,7 @@ func (b *buildinfoCommand) Run(wg *sync.WaitGroup) (err error) {
 	fmt.Println("")
 	fmt.Println("Server Settings:")
 	fmt.Printf("  Provisioning Brokers: %s\n", build.ProvisionBrokerURLs)
+	fmt.Printf("  Provisioning Default: %t\n", build.ProvisionDefault())
 	fmt.Println("")
 	fmt.Println("Security Defaults:")
 	fmt.Printf("            TLS: %s\n", build.TLS)

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -2,6 +2,7 @@ flags_map:
   TLS: github.com/choria-io/go-choria/build.TLS
   maxBrokerClients: github.com/choria-io/go-choria/build.maxBrokerClients
   ProvisionBrokerURLs: github.com/choria-io/go-choria/build.ProvisionBrokerURLs
+  ProvisionModeDefault: github.com/choria-io/go-choria/build.ProvisionModeDefault
   Secure: github.com/choria-io/go-choria/vendor/github.com/choria-io/go-protocol/protocol.Secure
   Version: github.com/choria-io/go-choria/build.Version
   SHA: github.com/choria-io/go-choria/build.SHA
@@ -31,7 +32,7 @@ foss:
       etcdir: /etc/choria
       release: 1
       manage_conf: 1
-      contact: rip@devco.net
+      contact: R.I.Pienaar <rip@devco.net>
 
     el5_32:
       template: el/el6

--- a/server/connection.go
+++ b/server/connection.go
@@ -31,7 +31,7 @@ func (srv *Instance) brokerUrls() ([]choria.Server, error) {
 	servers := []choria.Server{}
 	var err error
 
-	if srv.cfg.Choria.Provision {
+	if srv.fw.ProvisionMode() {
 		servers, err = srv.fw.ProvisioningServers()
 		if err != nil {
 			srv.log.Errorf("Could not determine provisioning broker urls while provisioning is configured: %s", err)

--- a/server/connection_test.go
+++ b/server/connection_test.go
@@ -34,7 +34,7 @@ var _ = Describe("ServerConnection", func() {
 		})
 
 		It("Should support provisioning", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			build.ProvisionBrokerURLs = "nats1:4222, nats2:4222"
 
 			servers, err := srv.brokerUrls()
@@ -49,7 +49,7 @@ var _ = Describe("ServerConnection", func() {
 		})
 
 		It("Should fail gracefully for incorrect format provisioning servers", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			build.ProvisionBrokerURLs = "invalid stuff"
 
 			servers, err := srv.brokerUrls()
@@ -64,7 +64,7 @@ var _ = Describe("ServerConnection", func() {
 		})
 
 		It("Should fail gracefully when no servers are compiled in but provisioning is on", func() {
-			cfg.Choria.Provision = true
+			build.ProvisionModeDefault = "true"
 			build.ProvisionBrokerURLs = ""
 
 			servers, err := srv.brokerUrls()


### PR DESCRIPTION
This adds build.ProvisionModeDefault which can be "true" or "false",
when "true" and ProvisionBrokerURLs are set then the new
choria.ProvisioningMode() will be true unless provisioning is specifically
set in the config file

This allows binaries to be built that unless provisioning is specifically
disabled will enable provisioning mode, handy for whne you do not control
the config file or just don't want the hassle of enabling it in the shipped
config by default