### PR TITLE
(#133) send the timeout context to actions

### DIFF
--- a/agents/choriautil/choriautil.go
+++ b/agents/choriautil/choriautil.go
@@ -1,6 +1,7 @@
 package choriautil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime"
@@ -73,7 +74,7 @@ func New(mgr *agents.Manager) (*mcorpc.Agent, error) {
 	return agent, nil
 }
 
-func infoAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+func infoAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
 	c := agent.Config
 
 	domain, err := agent.Choria.FacterDomain()

--- a/agents/discovery/discovery.go
+++ b/agents/discovery/discovery.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -42,7 +43,7 @@ func (da *Agent) Metadata() *agents.Metadata {
 	return da.meta
 }
 
-func (da *Agent) HandleMessage(msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, result chan *agents.AgentReply) {
+func (da *Agent) HandleMessage(ctx context.Context, msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, result chan *agents.AgentReply) {
 	reply := &agents.AgentReply{
 		Message: msg,
 		Request: request,

--- a/agents/provision/provision.go
+++ b/agents/provision/provision.go
@@ -1,6 +1,7 @@
 package provision
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -64,7 +65,7 @@ func New(mgr *agents.Manager) (*mcorpc.Agent, error) {
 	return agent, nil
 }
 
-func reprovisionAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+func reprovisionAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -107,7 +108,7 @@ func reprovisionAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.A
 	reply.Data = Reply{fmt.Sprintf("Restarting after %ds", splay)}
 }
 
-func configureAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+func configureAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
 	mu.Lock()
 	defer mu.Unlock()
 
@@ -142,7 +143,7 @@ func configureAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Age
 	reply.Data = Reply{fmt.Sprintf("Wrote %d lines to %s", lines, agent.Config.ConfigFile)}
 }
 
-func restartAction(req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+func restartAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/mcorpc/agent.go
+++ b/mcorpc/agent.go
@@ -1,6 +1,7 @@
 package mcorpc
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -13,7 +14,7 @@ import (
 )
 
 // Action is a function that implements a RPC Action
-type Action func(*Request, *Reply, *Agent, choria.ConnectorInfo)
+type Action func(context.Context, *Request, *Reply, *Agent, choria.ConnectorInfo)
 
 // Agent is an instance of the MCollective compatible RPC agents
 type Agent struct {
@@ -51,7 +52,7 @@ func (a *Agent) RegisterAction(name string, f Action) error {
 
 // HandleMessage attempts to parse a choria.Message as a MCollective SimpleRPC request and calls
 // the agents and actions associated with it
-func (a *Agent) HandleMessage(msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, outbox chan *agents.AgentReply) {
+func (a *Agent) HandleMessage(ctx context.Context, msg *choria.Message, request protocol.Request, conn choria.ConnectorInfo, outbox chan *agents.AgentReply) {
 	var err error
 
 	reply := a.newReply()
@@ -81,7 +82,7 @@ func (a *Agent) HandleMessage(msg *choria.Message, request protocol.Request, con
 
 	a.Log.Infof("Handling message %s for %s#%s from %s", msg.RequestID, a.Name(), rpcrequest.Action, request.CallerID())
 
-	action(rpcrequest, reply, a, conn)
+	action(ctx, rpcrequest, reply, a, conn)
 }
 
 // Name retrieves the name of the agent

--- a/server/agents/agents.go
+++ b/server/agents/agents.go
@@ -15,7 +15,7 @@ import (
 type Agent interface {
 	Metadata() *Metadata
 	Name() string
-	HandleMessage(*choria.Message, protocol.Request, choria.ConnectorInfo, chan *AgentReply)
+	HandleMessage(context.Context, *choria.Message, protocol.Request, choria.ConnectorInfo, chan *AgentReply)
 }
 
 type AgentReply struct {
@@ -157,7 +157,7 @@ func (a *Manager) Dispatch(ctx context.Context, wg *sync.WaitGroup, replies chan
 	timeout, cancel := context.WithTimeout(context.Background(), td)
 	defer cancel()
 
-	go agent.HandleMessage(msg, request, a.conn, result)
+	go agent.HandleMessage(timeout, msg, request, a.conn, result)
 
 	select {
 	case reply := <-result:

--- a/server/agents/agents_test.go
+++ b/server/agents/agents_test.go
@@ -30,7 +30,7 @@ func (s *stubAgent) Name() string {
 	return "stub"
 }
 
-func (s *stubAgent) HandleMessage(msg *choria.Message, request protocol.Request, ci choria.ConnectorInfo, result chan *AgentReply) {
+func (s *stubAgent) HandleMessage(ctx context.Context, msg *choria.Message, request protocol.Request, ci choria.ConnectorInfo, result chan *AgentReply) {
 	if msg.Payload == "sleep" {
 		time.Sleep(10 * time.Second)
 	}

--- a/server/connection.go
+++ b/server/connection.go
@@ -58,3 +58,20 @@ func (srv *Instance) brokerUrls() ([]choria.Server, error) {
 
 	return servers, err
 }
+
+func (srv *Instance) subscribeNode(ctx context.Context) error {
+	var err error
+
+	for _, collective := range srv.cfg.Collectives {
+		target := srv.connector.NodeDirectedTarget(collective, srv.cfg.Identity)
+
+		srv.log.Infof("Subscribing node %s to %s", srv.cfg.Identity, target)
+
+		err = srv.connector.QueueSubscribe(ctx, fmt.Sprintf("node.%s", collective), target, "", srv.requests)
+		if err != nil {
+			return fmt.Errorf("Could not subscribe to node directed targets: %s", err.Error())
+		}
+	}
+
+	return nil
+}

--- a/server/instance.go
+++ b/server/instance.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/choria-io/go-choria/choria"
@@ -97,21 +96,4 @@ func (srv *Instance) RegisterRegistrationProvider(ctx context.Context, wg *sync.
 // RegisterAgent adds a new agent to the running instance
 func (srv *Instance) RegisterAgent(ctx context.Context, name string, agent agents.Agent) error {
 	return srv.agents.RegisterAgent(ctx, name, agent, srv.connector)
-}
-
-func (srv *Instance) subscribeNode(ctx context.Context) error {
-	var err error
-
-	for _, collective := range srv.cfg.Collectives {
-		target := srv.connector.NodeDirectedTarget(collective, srv.cfg.Identity)
-
-		srv.log.Infof("Subscribing node %s to %s", srv.cfg.Identity, target)
-
-		err = srv.connector.QueueSubscribe(ctx, fmt.Sprintf("node.%s", collective), target, "", srv.requests)
-		if err != nil {
-			return fmt.Errorf("Could not subscribe to node directed targets: %s", err.Error())
-		}
-	}
-
-	return nil
 }


### PR DESCRIPTION
Before an action is invoked a timeout context was made that tells the
agent subsystem to give up waiting on an action but this was never
passed to the actual agents so they couldn't do sane things like
use exec.CommandContext()

This adjusts things so the timeout context is passed all over so
agents can time out appropriately