### PR TITLE
(#58) Create a rpcutil agent

### DIFF
--- a/agents/choriautil/choriautil.go
+++ b/agents/choriautil/choriautil.go
@@ -66,10 +66,7 @@ func New(mgr *agents.Manager) (*mcorpc.Agent, error) {
 
 	agent := mcorpc.New("choria_util", metadata, mgr.Choria(), mgr.Logger())
 
-	err := agent.RegisterAction("info", infoAction)
-	if err != nil {
-		return nil, fmt.Errorf("could not register info action: %s", err.Error())
-	}
+	agent.MustRegisterAction("info", infoAction)
 
 	return agent, nil
 }

--- a/agents/discovery/discovery.go
+++ b/agents/discovery/discovery.go
@@ -35,6 +35,9 @@ func New(mgr *agents.Manager) (*Agent, error) {
 	return a, nil
 }
 
+func (da *Agent) SetServerInfo(agents.ServerInfoSource) {
+}
+
 func (da *Agent) Name() string {
 	return da.meta.Name
 }

--- a/agents/provision/provision.go
+++ b/agents/provision/provision.go
@@ -47,20 +47,9 @@ func New(mgr *agents.Manager) (*mcorpc.Agent, error) {
 
 	agent := mcorpc.New("choria_provision", metadata, mgr.Choria(), mgr.Logger())
 
-	err := agent.RegisterAction("configure", configureAction)
-	if err != nil {
-		return nil, fmt.Errorf("Could not register configure action: %s", err)
-	}
-
-	err = agent.RegisterAction("restart", restartAction)
-	if err != nil {
-		return nil, fmt.Errorf("Could not register restart action: %s", err)
-	}
-
-	err = agent.RegisterAction("reprovision", reprovisionAction)
-	if err != nil {
-		return nil, fmt.Errorf("Could not register reprovision action: %s", err)
-	}
+	agent.MustRegisterAction("configure", configureAction)
+	agent.MustRegisterAction("restart", restartAction)
+	agent.MustRegisterAction("reprovision", reprovisionAction)
 
 	return agent, nil
 }

--- a/agents/provision/provision_test.go
+++ b/agents/provision/provision_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/choria-io/go-choria/choria"
 	"github.com/choria-io/go-choria/mcorpc"
 	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/server/serverinfotest"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -44,7 +46,7 @@ var _ = Describe("Agent/Provision", func() {
 		fw, err = choria.NewWithConfig(cfg)
 		Expect(err).ToNot(HaveOccurred())
 
-		am = agents.New(requests, fw, nil, logrus.WithFields(logrus.Fields{"test": "1"}))
+		am = agents.New(requests, fw, nil, &serverinfotest.InfoSource{}, logrus.WithFields(logrus.Fields{"test": "1"}))
 		prov, err = New(am)
 		Expect(err).ToNot(HaveOccurred())
 		logrus.SetLevel(logrus.FatalLevel)

--- a/agents/rpcutil/rpcutil.go
+++ b/agents/rpcutil/rpcutil.go
@@ -1,0 +1,232 @@
+package rpcutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/mcorpc"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/server/discovery/facts"
+)
+
+type PingReply struct {
+	Pong int64 `json:"pong"`
+}
+
+type GetFactReply struct {
+	Fact  string      `json:"fact"`
+	Value interface{} `json:"value"`
+}
+
+type GetFactsReply struct {
+	Values map[string]interface{} `json:"values"`
+}
+
+type CollectiveInfoReply struct {
+	MainCollective string   `json:"main_collective"`
+	Collectives    []string `json:"collectives"`
+}
+
+type AgentInventoryInfoReply struct {
+	Agent string `json:"agent"`
+
+	agents.Metadata
+}
+
+type AgentInventoryReply struct {
+	Agents []AgentInventoryInfoReply `json:"agents"`
+}
+
+type GetConfigItemReply struct {
+	Item  string `json:"item"`
+	Value string `json:"value"`
+}
+
+type InventoryReply struct {
+	Agents         []string        `json:"agents"`
+	Facts          json.RawMessage `json:"facts"`
+	Classes        []string        `json:"classes"`
+	Version        string          `json:"version"`
+	DataPlugins    []string        `json:"data_plugins"`
+	MainCollective string          `json:"main_collective"`
+	Collectives    []string        `json:"collectives"`
+}
+
+type CPUTimes struct {
+	UserTime        int `json:"utime"`
+	SystemTime      int `json:"stime"`
+	ChildUserTime   int `json:"cutime"`
+	ChildSystemTime int `json:"cstime"`
+}
+
+type DaemonStatsReply struct {
+	Procs       []string `json:"threads"`
+	Agents      []string `json:"agents"`
+	PID         int      `json:"pid"`
+	Times       CPUTimes `json:"times"`
+	Validated   int      `json:"validated"`
+	Unvalidated int      `json:"unvalidated"`
+	Passed      int      `json:"passed"`
+	Filtered    int      `json:"filtered"`
+	StartTime   int64    `json:"starttime"`
+	Total       int      `json:"total"`
+	Replies     int      `json:"replies"`
+	ConfigFile  string   `json:"configfile"`
+	Version     string   `json:"version"`
+	TTLExpired  int      `json:"ttlexpired"`
+}
+
+// New creates a new rpcutil agent
+func New(mgr *agents.Manager) (*mcorpc.Agent, error) {
+	metadata := &agents.Metadata{
+		Name:        "rpcutil",
+		Description: "Choria MCollective RPC Compatability Utilities",
+		Author:      "R.I.Pienaar <rip@devco.net>",
+		Version:     build.Version,
+		License:     build.License,
+		Timeout:     2,
+		URL:         "http://choria.io",
+	}
+
+	agent := mcorpc.New("rpcutil", metadata, mgr.Choria(), mgr.Logger())
+
+	err := agent.RegisterAction("collective_info", collectiveInfoAction)
+	if err != nil {
+		return nil, fmt.Errorf("could not register collective_info action: %s", err)
+	}
+
+	agent.MustRegisterAction("ping", pingAction)
+	agent.MustRegisterAction("get_fact", getFactAction)
+	agent.MustRegisterAction("get_facts", getFactsAction)
+	agent.MustRegisterAction("agent_inventory", agentInventoryAction)
+	agent.MustRegisterAction("inventory", inventoryAction)
+	agent.MustRegisterAction("daemon_stats", daemonStatsAction)
+
+	for _, a := range []string{"get_config_item", "get_data"} {
+		agent.MustRegisterAction(a, incompatibleAction)
+	}
+
+	return agent, nil
+}
+
+func daemonStatsAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	output := &DaemonStatsReply{
+		Procs:      []string{fmt.Sprintf("Go %s with %d go procs on %d cores", runtime.Version(), runtime.NumGoroutine(), runtime.NumCPU())},
+		Agents:     agent.ServerInfoSource.KnownAgents(),
+		PID:        os.Getpid(),
+		Times:      CPUTimes{},
+		ConfigFile: agent.ServerInfoSource.ConfigFile(),
+		Version:    build.Version,
+		StartTime:  agent.ServerInfoSource.StartTime().Unix(),
+	}
+	reply.Data = output
+}
+
+func inventoryAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	output := &InventoryReply{
+		Agents:         agent.ServerInfoSource.KnownAgents(),
+		Classes:        agent.ServerInfoSource.Classes(),
+		Collectives:    agent.Config.Collectives,
+		DataPlugins:    []string{},
+		Facts:          agent.ServerInfoSource.Facts(),
+		MainCollective: agent.Config.MainCollective,
+		Version:        build.Version,
+	}
+
+	agent.Log.Infof("%#v", *output)
+
+	reply.Data = output
+}
+
+func agentInventoryAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	o := AgentInventoryReply{}
+	reply.Data = &o
+
+	for _, a := range agent.ServerInfoSource.KnownAgents() {
+		md, ok := agent.ServerInfoSource.AgentMetadata(a)
+
+		if ok {
+			o.Agents = append(o.Agents, AgentInventoryInfoReply{a, md})
+		}
+	}
+}
+
+func getFactsAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	type input struct {
+		Facts string `json:"facts"`
+	}
+
+	i := input{}
+	if !mcorpc.ParseRequestData(&i, req, reply) {
+		return
+	}
+
+	o := &GetFactsReply{
+		Values: make(map[string]interface{}),
+	}
+	reply.Data = o
+
+	for _, fact := range strings.Split(i.Facts, ",") {
+		fact = strings.TrimSpace(fact)
+		v, _ := getFactValue(fact, agent.Config)
+		o.Values[fact] = v
+	}
+}
+
+func getFactAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	type input struct {
+		Fact string `json:"fact"`
+	}
+
+	i := input{}
+	if !mcorpc.ParseRequestData(&i, req, reply) {
+		return
+	}
+
+	o := GetFactReply{i.Fact, nil}
+	reply.Data = &o
+
+	v, err := getFactValue(i.Fact, agent.Config)
+	if err != nil {
+		// I imagine you might want to error here, but old code just return nil
+		return
+	}
+
+	o.Value = v
+}
+
+func pingAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	reply.Data = PingReply{time.Now().Unix()}
+}
+
+func collectiveInfoAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	reply.Data = CollectiveInfoReply{
+		MainCollective: agent.Config.MainCollective,
+		Collectives:    agent.Config.Collectives,
+	}
+}
+
+func incompatibleAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn choria.ConnectorInfo) {
+	reply.Statuscode = mcorpc.Aborted
+	reply.Statusmsg = fmt.Sprintf("The %s action has not been implemented in the Go Choria server as it cannot be done in a compatible manner", req.Action)
+}
+
+func getFactValue(fact string, c *choria.Config) (interface{}, error) {
+	_, value, err := facts.GetFact(fact, c.FactSourceFile)
+	if err != nil {
+		return nil, err
+	}
+
+	if !value.Exists() {
+		return nil, nil
+	}
+
+	return value.Value(), nil
+}

--- a/agents/rpcutil/rpcutil_test.go
+++ b/agents/rpcutil/rpcutil_test.go
@@ -1,0 +1,150 @@
+package rpcutil
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/mcorpc"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/server/serverinfotest"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+
+	"testing"
+)
+
+func TestFileContent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Agent/RPCUtil")
+}
+
+var _ = Describe("Agent/RPCUtil", func() {
+	var (
+		requests chan *choria.ConnectorMessage
+		cfg      *choria.Config
+		fw       *choria.Framework
+		am       *agents.Manager
+		err      error
+		rpcutil  *mcorpc.Agent
+		reply    *mcorpc.Reply
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		requests = make(chan *choria.ConnectorMessage)
+		reply = &mcorpc.Reply{}
+
+		cfg, err = choria.NewConfig("testdata/test.cfg")
+		Expect(err).ToNot(HaveOccurred())
+		cfg.DisableTLS = true
+
+		fw, err = choria.NewWithConfig(cfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		am = agents.New(requests, fw, nil, &serverinfotest.InfoSource{}, logrus.WithFields(logrus.Fields{"test": "1"}))
+		rpcutil, err = New(am)
+		Expect(err).ToNot(HaveOccurred())
+		logrus.SetLevel(logrus.FatalLevel)
+
+		ctx = context.Background()
+		cfg.FactSourceFile = "testdata/facts.yaml"
+	})
+
+	var _ = Describe("New", func() {
+		It("Should create all actions we support", func() {
+			Expect(rpcutil.ActionNames()).To(Equal([]string{"agent_inventory", "collective_info", "daemon_stats", "get_config_item", "get_data", "get_fact", "get_facts", "inventory", "ping"}))
+		})
+	})
+
+	var _ = Describe("inventoryAction", func() {
+		It("Should retrieve the correct info", func() {
+			build.Version = "1.0.0"
+			cfg.Collectives = []string{"mcollective", "other"}
+
+			rpcutil.SetServerInfo(&serverinfotest.InfoSource{})
+
+			inventoryAction(ctx, &mcorpc.Request{}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+
+			r := reply.Data.(*InventoryReply)
+			Expect(r.Agents).To(Equal([]string{"stub_agent"}))
+			Expect(r.Classes).To(Equal([]string{"one", "two"}))
+			Expect(r.Collectives).To(Equal([]string{"mcollective", "other"}))
+			Expect(r.MainCollective).To(Equal("mcollective"))
+			Expect(r.DataPlugins).To(Equal([]string{}))
+			Expect(r.Facts).To(Equal(json.RawMessage(`{"stub":true}`)))
+			Expect(r.Version).To(Equal("1.0.0"))
+		})
+	})
+
+	var _ = Describe("agentInventoryAction", func() {
+		It("Should get the right inventory", func() {
+			rpcutil.SetServerInfo(&serverinfotest.InfoSource{})
+
+			agentInventoryAction(ctx, &mcorpc.Request{}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+
+			r := reply.Data.(*AgentInventoryReply).Agents[0]
+			Expect(r.Agent).To(Equal("stub_agent"))
+			Expect(r.Name).To(Equal("stub_agent"))
+			Expect(r.Timeout).To(Equal(10))
+		})
+	})
+
+	var _ = Describe("collectiveInfoAction", func() {
+		It("Should get the right collective info", func() {
+			cfg.MainCollective = "test_collective"
+			cfg.Collectives = []string{"test_collective", "other_collective"}
+
+			collectiveInfoAction(ctx, &mcorpc.Request{}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(CollectiveInfoReply).Collectives).To(Equal(cfg.Collectives))
+			Expect(reply.Data.(CollectiveInfoReply).MainCollective).To(Equal(cfg.MainCollective))
+		})
+	})
+
+	var _ = Describe("getFactsAction", func() {
+		It("Should get the right facts", func() {
+			getFactsAction(ctx, &mcorpc.Request{Data: json.RawMessage(`{"facts":"string, int, doesnt_exist"}`)}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(*GetFactsReply).Values["string"]).To(Equal("hello world"))
+			Expect(reply.Data.(*GetFactsReply).Values["int"]).To(Equal(float64(1)))
+			Expect(reply.Data.(*GetFactsReply).Values["doesnt_exist"]).To(BeNil())
+		})
+	})
+
+	var _ = Describe("getFactAction", func() {
+		It("Should get the right fact", func() {
+			getFactAction(ctx, &mcorpc.Request{Data: json.RawMessage(`{"fact":"string"}`)}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(*GetFactReply).Fact).To(Equal("string"))
+			Expect(reply.Data.(*GetFactReply).Value).To(Equal("hello world"))
+
+			getFactAction(ctx, &mcorpc.Request{Data: json.RawMessage(`{"fact":"struct"}`)}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(*GetFactReply).Fact).To(Equal("struct"))
+			expected := make(map[string]interface{})
+			expected["foo"] = "bar"
+			Expect(reply.Data.(*GetFactReply).Value).To(Equal(expected))
+		})
+
+		It("Should handle missing values", func() {
+			getFactAction(ctx, &mcorpc.Request{Data: json.RawMessage(`{"fact":"missing"}`)}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(*GetFactReply).Fact).To(Equal("missing"))
+			Expect(reply.Data.(*GetFactReply).Value).To(BeNil())
+		})
+	})
+
+	var _ = Describe("pingAction", func() {
+		It("Should pong correctly", func() {
+			pingAction(ctx, &mcorpc.Request{}, reply, rpcutil, nil)
+			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(reply.Data.(PingReply).Pong).To(BeNumerically("==", time.Now().Unix(), 1))
+		})
+	})
+})

--- a/agents/rpcutil/testdata/facts.yaml
+++ b/agents/rpcutil/testdata/facts.yaml
@@ -1,0 +1,7 @@
+---
+int: 1
+float: 1.1
+string: hello world
+bool: false
+struct:
+  foo: bar

--- a/agents/rpcutil/testdata/test.cfg
+++ b/agents/rpcutil/testdata/test.cfg
@@ -1,0 +1,1 @@
+classesfile = /foo/bar

--- a/server/agents.go
+++ b/server/agents.go
@@ -7,28 +7,37 @@ import (
 	"github.com/choria-io/go-choria/agents/choriautil"
 	"github.com/choria-io/go-choria/agents/discovery"
 	"github.com/choria-io/go-choria/agents/provision"
+	"github.com/choria-io/go-choria/agents/rpcutil"
+
 	"github.com/choria-io/go-choria/build"
 )
 
 func (srv *Instance) setupCoreAgents(ctx context.Context) error {
 	da, err := discovery.New(srv.agents)
 	if err != nil {
-		return fmt.Errorf("Could not setup initial agents: %s", err.Error())
+		return fmt.Errorf("Could not setup initial agents: %s", err)
 	}
 
 	srv.agents.RegisterAgent(ctx, "discovery", da, srv.connector)
 
 	cu, err := choriautil.New(srv.agents)
 	if err != nil {
-		return fmt.Errorf("Could not setup choria_util agent: %s", err.Error())
+		return fmt.Errorf("Could not setup choria_util agent: %s", err)
 	}
 
 	srv.agents.RegisterAgent(ctx, "choria_util", cu, srv.connector)
 
+	rpcu, err := rpcutil.New(srv.agents)
+	if err != nil {
+		return fmt.Errorf("Could not setup rpcutil agent: %s", err)
+	}
+
+	srv.agents.RegisterAgent(ctx, "rpcutil", rpcu, srv.connector)
+
 	if build.ProvisionBrokerURLs != "" && build.ProvisionAgent == "true" {
 		pa, err := provision.New(srv.agents)
 		if err != nil {
-			return fmt.Errorf("Could not setup choria_provision agent: %s", err.Error())
+			return fmt.Errorf("Could not setup choria_provision agent: %s", err)
 		}
 
 		srv.agents.RegisterAgent(ctx, "choria_provision", pa, srv.connector)

--- a/server/discovery/classes/classes.go
+++ b/server/discovery/classes/classes.go
@@ -11,7 +11,7 @@ import (
 
 // Match classes on a AND basis
 func Match(needles []string, source string, log *logrus.Entry) bool {
-	classes, err := readClasses(source)
+	classes, err := ReadClasses(source)
 	if err != nil {
 		log.Warnf("Could not parse classes file %s: %s", source, err.Error())
 		return false
@@ -64,7 +64,8 @@ func hasClass(needle string, stack []string) bool {
 	return false
 }
 
-func readClasses(file string) ([]string, error) {
+// ReadClasses reads a given file and attempts to parse it as a typical classes file
+func ReadClasses(file string) ([]string, error) {
 	classes := []string{}
 
 	fh, err := os.Open(file)

--- a/server/discovery/facts/facts.go
+++ b/server/discovery/facts/facts.go
@@ -1,6 +1,7 @@
 package facts
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -35,29 +36,55 @@ func Match(filters [][3]string, fw *choria.Framework, log *logrus.Entry) bool {
 	return matched
 }
 
-// HasFact evaluates the expression against facts in the file
-func HasFact(fact string, operator string, value string, file string) (bool, error) {
+// JSON parses the data, including doing any conversions needed, and returns JSON text
+func JSON(file string) (json.RawMessage, error) {
 	if file == "" {
-		return false, fmt.Errorf("Cannot do fact discovery there is no file configured")
+		return json.RawMessage("{}"), fmt.Errorf("Cannot do fact discovery there is no file configured")
 	}
 
 	if _, err := os.Stat(file); os.IsNotExist(err) {
-		return false, fmt.Errorf("Cannot do fact discovery the file '%s' does not exist", file)
+		return json.RawMessage("{}"), fmt.Errorf("Cannot do fact discovery the file '%s' does not exist", file)
 	}
 
 	j, err := ioutil.ReadFile(file)
 	if err != nil {
-		return false, fmt.Errorf("Could not read facts file %s: %s", file, err.Error())
+		return json.RawMessage("{}"), fmt.Errorf("Could not read facts file %s: %s", file, err.Error())
 	}
 
 	if strings.HasSuffix(file, "yaml") {
 		j, err = yaml.YAMLToJSON(j)
 		if err != nil {
-			return false, fmt.Errorf("Could not parse facts file %s as YAML: %s", file, err.Error())
+			return json.RawMessage("{}"), fmt.Errorf("Could not parse facts file %s as YAML: %s", file, err.Error())
 		}
 	}
 
+	return json.RawMessage(j), nil
+}
+
+// GetFact looks up a single fact from the facts file, errors reading
+// the file is reported but an absent fact is handled as empty result
+// and no error
+func GetFact(fact string, file string) ([]byte, gjson.Result, error) {
+	j, err := JSON(file)
+	if err != nil {
+		return nil, gjson.Result{}, err
+	}
+
 	found := gjson.GetBytes(j, fact)
+	if !found.Exists() {
+		return nil, gjson.Result{}, nil
+	}
+
+	return j, found, nil
+}
+
+// HasFact evaluates the expression against facts in the file
+func HasFact(fact string, operator string, value string, file string) (bool, error) {
+	j, found, err := GetFact(fact, file)
+	if err != nil {
+		return false, err
+	}
+
 	if !found.Exists() {
 		return false, nil
 	}

--- a/server/infosource.go
+++ b/server/infosource.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/server/discovery/classes"
+	"github.com/choria-io/go-choria/server/discovery/facts"
+)
+
+// KnownAgents is a list of agents loaded into the server instance
+func (srv *Instance) KnownAgents() []string {
+	return srv.agents.KnownAgents()
+}
+
+// AgentMetadata looks up the metadata for a specific agent
+func (srv *Instance) AgentMetadata(agent string) (agents.Metadata, bool) {
+	a, found := srv.agents.Get(agent)
+	if !found {
+		return agents.Metadata{}, false
+	}
+
+	return *a.Metadata(), true
+}
+
+// ConfigFile determines the config file used to start the instance
+func (srv *Instance) ConfigFile() string {
+	return srv.cfg.ConfigFile
+}
+
+// Classes is a list of classification classes this node matches
+func (srv *Instance) Classes() []string {
+	classes, err := classes.ReadClasses(srv.cfg.ClassesFile)
+	if err != nil {
+		return []string{}
+	}
+
+	return classes
+}
+
+// Facts are all the known facts to this instance
+func (srv *Instance) Facts() json.RawMessage {
+	j, _ := facts.JSON(srv.cfg.FactSourceFile)
+
+	return j
+}
+
+// StartTime is the time this instance were created
+func (srv *Instance) StartTime() time.Time {
+	return srv.startTime
+}

--- a/server/serverinfotest/stubsi.go
+++ b/server/serverinfotest/stubsi.go
@@ -1,0 +1,42 @@
+package serverinfotest
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/choria-io/go-choria/server/agents"
+)
+
+type InfoSource struct{}
+
+func (si *InfoSource) KnownAgents() []string {
+	return []string{"stub_agent"}
+}
+
+func (si *InfoSource) AgentMetadata(a string) (agents.Metadata, bool) {
+	return agents.Metadata{
+		Author:      "stub@example.net",
+		Description: "Stub Agent",
+		License:     "Apache-2.0",
+		Name:        "stub_agent",
+		Timeout:     10,
+		URL:         "https://choria.io/",
+		Version:     "1.0.0",
+	}, true
+}
+
+func (si *InfoSource) ConfigFile() string {
+	return "/stub/config.cfg"
+}
+
+func (si *InfoSource) Classes() []string {
+	return []string{"one", "two"}
+}
+
+func (si *InfoSource) Facts() json.RawMessage {
+	return json.RawMessage(`{"stub":true}`)
+}
+
+func (si *InfoSource) StartTime() time.Time {
+	return time.Now()
+}

--- a/statistics/stats.go
+++ b/statistics/stats.go
@@ -49,7 +49,6 @@ func Start(config *choria.Config, handler http.Handler) {
 	defer mu.Unlock()
 
 	cfg = config
-
 	port := config.Choria.StatsPort
 
 	if port == 0 {


### PR DESCRIPTION
This creates an rpcutil agent, to a large extend its 1:1 compatible but
there are inevitable differences:

  * get_config_item makes no sense unless I create a huge case statement/map thing
  * get_data - we have no data yet

Other differences:

  * daemon_stats have inevitable differences as its Go and not ruby
    and we do not yet keep certain stats for the server
  * get facts might have slightly different behaviour than in ruby
    since go isnt dynamic and wont just make any old shit from a yaml
    file

In general though I think these differences are fine and some might get
resolved in time