### PR TITLE
(#146, #148) Record server stats and check TTLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ping
 choria-*-*-*
 *.rpm
 *.tgz
+debug

--- a/server/agents/agents.go
+++ b/server/agents/agents.go
@@ -28,6 +28,16 @@ type ServerInfoSource interface {
 	Classes() []string
 	Facts() json.RawMessage
 	StartTime() time.Time
+	Stats() ServerStats
+}
+
+type ServerStats struct {
+	Valid      float64
+	Invalid    float64
+	Passed     float64
+	Filtered   float64
+	Replies    float64
+	TTLExpired float64
 }
 
 type AgentReply struct {

--- a/server/agents/agents_test.go
+++ b/server/agents/agents_test.go
@@ -80,6 +80,10 @@ func (si *stubsi) StartTime() time.Time {
 	return time.Now()
 }
 
+func (si *stubsi) Stats() ServerStats {
+	return ServerStats{}
+}
+
 func TestFileContent(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Server/Agents")

--- a/server/serverinfotest/stubsi.go
+++ b/server/serverinfotest/stubsi.go
@@ -40,3 +40,7 @@ func (si *InfoSource) Facts() json.RawMessage {
 func (si *InfoSource) StartTime() time.Time {
 	return time.Now()
 }
+
+func (si *InfoSource) Stats() agents.ServerStats {
+	return agents.ServerStats{}
+}

--- a/server/stats.go
+++ b/server/stats.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	validatedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_validated",
+		Help: "Number of messages that were received and validated succesfully",
+	}, []string{"identity"})
+
+	unvalidatedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_unvalidated",
+		Help: "Number of messages that were received but did not pass validation",
+	}, []string{"identity"})
+
+	passedCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_passed",
+		Help: "Number of messages where this instance matched the filter expression",
+	}, []string{"identity"})
+
+	filteredCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_filtered",
+		Help: "Number of messages where this instance did not match the filter expression",
+	}, []string{"identity"})
+
+	repliesCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_replies",
+		Help: "Number of reply messages that were produced",
+	}, []string{"identity"})
+
+	ttlExpiredCtr = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "choria_server_ttlexpired",
+		Help: "Number of messages received that were too old and dropped",
+	}, []string{"identity"})
+)
+
+func init() {
+	prometheus.MustRegister(validatedCtr)
+	prometheus.MustRegister(unvalidatedCtr)
+	prometheus.MustRegister(passedCtr)
+	prometheus.MustRegister(filteredCtr)
+	prometheus.MustRegister(repliesCtr)
+	prometheus.MustRegister(ttlExpiredCtr)
+}


### PR DESCRIPTION
Primarily this records a number of server stats in line with what
mcollective recorded so the rpcutil agent can be more compatible

In the process it was observed that TTLs are not checked, they are
now checked too