### PR TITLE
(#152) add a struct validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 |Date      |Issue |Description                                                                                              |
 |----------|------|---------------------------------------------------------------------------------------------------------|
+|2018/01/22|152   |Support automagic validation of structs received over the network, support shellsafe for now             |
 |2018/01/20|150   |Release 0.0.6                                                                                            |
 |2018/01/20|58    |A mostly compatible `rpcutil` agent was added                                                            |
 |2018/01/20|148   |The TTL of incoming request messages are checked                                                         |

--- a/mcorpc/validator/shellsafe.go
+++ b/mcorpc/validator/shellsafe.go
@@ -1,0 +1,32 @@
+package validator
+
+import (
+	"reflect"
+	"strings"
+)
+
+// ShellSafe checks if a string is safe to use in a shell without any escapes or redirects
+func ShellSafe(input string) bool {
+	badchars := []string{"`", "$", ";", "|", "&&", ">", "<"}
+
+	for _, c := range badchars {
+		if strings.Contains(input, c) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ShellSafeValue validates a reflect.Value is shellsafe
+func ShellSafeValue(input reflect.Value) bool {
+	if input.Kind() != reflect.String {
+		return false
+	}
+
+	if !ShellSafe(input.String()) {
+		return false
+	}
+
+	return true
+}

--- a/mcorpc/validator/shellsafe_test.go
+++ b/mcorpc/validator/shellsafe_test.go
@@ -1,0 +1,24 @@
+package validator
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ShellSafe", func() {
+	It("Should match bad strings", func() {
+		badchars := []string{"`", "$", ";", "|", "&&", ">", "<"}
+
+		for _, c := range badchars {
+			Expect(ShellSafe(fmt.Sprintf("thing%sthing", c))).To(BeFalse())
+		}
+	})
+
+	It("Should allow good things", func() {
+		Expect(ShellSafe("ok")).To(BeTrue())
+		Expect(ShellSafe("")).To(BeTrue())
+		Expect(ShellSafe("ok ok ok")).To(BeTrue())
+	})
+})

--- a/mcorpc/validator/validator.go
+++ b/mcorpc/validator/validator.go
@@ -1,0 +1,54 @@
+package validator
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ValidateStruct validates all keys in a struct using their validate tag
+func ValidateStruct(target interface{}) (bool, error) {
+	val := reflect.ValueOf(target)
+
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	return validateStructValue(val)
+}
+
+func validateStructValue(val reflect.Value) (bool, error) {
+	for i := 0; i < val.NumField(); i++ {
+		valueField := val.Field(i)
+		typeField := val.Type().Field(i)
+		validations := strings.Split(typeField.Tag.Get("validate"), ",")
+
+		if valueField.Kind() == reflect.Struct {
+			ok, err := validateStructValue(valueField)
+			if !ok {
+				return ok, err
+			}
+		}
+
+		for _, validation := range validations {
+			validation = strings.TrimSpace(validation)
+
+			if validation == "" {
+				continue
+			}
+
+			switch validation {
+			case "shellsafe":
+				if !ShellSafeValue(valueField) {
+					return false, fmt.Errorf("%s is not shellsafe", typeField.Name)
+				}
+
+			default:
+				return false, fmt.Errorf("unknown validator on %s: %s", typeField.Name, validation)
+			}
+		}
+	}
+
+	return true, nil
+
+}

--- a/mcorpc/validator/validator_test.go
+++ b/mcorpc/validator/validator_test.go
@@ -1,0 +1,51 @@
+package validator
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFileContent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "McoRPC/Validator")
+}
+
+var _ = Describe("ValidateStruct", func() {
+	type nest struct {
+		Nested string `validate:"shellsafe"`
+	}
+
+	type vdata struct {
+		SS string `validate:"shellsafe"`
+		nest
+	}
+
+	var (
+		s = vdata{}
+	)
+
+	It("Should support nested structs", func() {
+		s.SS = "safe"
+		s.Nested = "safe"
+
+		ok, err := ValidateStruct(s)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		s.SS = "safe"
+		s.Nested = "un > safe"
+
+		ok, err = ValidateStruct(s)
+		Expect(err).To(MatchError("Nested is not shellsafe"))
+		Expect(ok).To(BeFalse())
+
+		s.SS = "un > safe"
+		s.Nested = "safe"
+
+		ok, err = ValidateStruct(s)
+		Expect(err).To(MatchError("SS is not shellsafe"))
+		Expect(ok).To(BeFalse())
+	})
+})


### PR DESCRIPTION
Structures like:

    type Request struct {
       Command string `json:"command" validate:"shellsafe"`
    }

will automatically be validated in mcorpc.ParseRequestData and the
validator package can do this generically for anything, later it
will be extracted into its own utility