### PR TITLE
(#163) limit the reconnect buffer space

### DIFF
--- a/choria/connection.go
+++ b/choria/connection.go
@@ -547,6 +547,16 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 			conn.logger.Errorf("NATS client on %s encountered an error: %s", nc.ConnectedUrl(), err)
 			connErrorCtr.WithLabelValues(conn.name).Inc()
 		}),
+
+		// This is specifically set quite small, just about enough to handle short
+		// reconnects rather than the 8MB long buffer that's default.  30 000 nodes
+		// each sending several MB after reconnect is not what anyone wants
+		//
+		// See also https://github.com/nats-io/go-nats/issues/339
+		func(o *nats.Options) error {
+			o.ReconnectBufSize = 10 * 1024
+			return nil
+		},
 	}
 
 	if !conn.choria.Config.DisableTLS {

--- a/server/registration/registration.go
+++ b/server/registration/registration.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"github.com/choria-io/go-choria/choria"
-	"github.com/choria-io/go-protocol/protocol"
 	"github.com/choria-io/go-choria/registration"
 	"github.com/choria-io/go-choria/server/data"
+	"github.com/choria-io/go-protocol/protocol"
 	"github.com/sirupsen/logrus"
 )
 
@@ -43,7 +43,7 @@ func New(c *choria.Framework, conn choria.PublishableConnector, logger *logrus.E
 		choria:    c,
 		cfg:       c.Config,
 		connector: conn,
-		datac:     make(chan *data.RegistrationItem, 5),
+		datac:     make(chan *data.RegistrationItem, 1),
 	}
 
 	return r


### PR DESCRIPTION
The go nats library has a buffer used to store published messages
while the server reconnects, on reconnect it sends the buffer.

Once the buffer is full messages are not added to it - ie. only the
oldest stuff is sent.

This is pretty much useless to us in every scenario, no-one cares
for ancient registration stuff and replies - unless perhaps in an
async setup - has little value after much time.

Additionally this buffer is 30MB by default, imagine 20k nodes each
publishing 30MB of ancient rubbish on reconnect, this is not sensible
for us

So this sets the buffer to 10KB instead