### PR TITLE
(#176) intercept certain debug logs and elevate them

### DIFF
--- a/broker/network/logger.go
+++ b/broker/network/logger.go
@@ -26,6 +26,20 @@ func (l Logger) Errorf(format string, v ...interface{}) {
 
 // Debugf logs at debug level
 func (l Logger) Debugf(format string, v ...interface{}) {
+	// this intercepts a few gnatsd debug messages that sould be higher and dispatch them somewhere more
+	// appropriate rather than debug.  This should hopefully go away once nats-io/gnatsd#622 is fixed
+	// otoh logging in natsd is basically everything is debug and on a big site debug will just overwhelm
+	// machines, so I suspect this pattern might stay for a while as I find more logs :(
+	if format == "Registering remote route %q" || format == "Trying to connect to route on %s" {
+		l.Noticef(format, v)
+		return
+	}
+
+	if format == "Detected duplicate remote route %q" {
+		l.Errorf(format, v)
+		return
+	}
+
 	l.log.Debugf(format, v...)
 }
 

--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -64,7 +64,17 @@ func NewServer(c *choria.Framework, debug bool) (s *Server, err error) {
 	}
 
 	s.gnatsd = gnatsd.New(s.opts)
-	s.gnatsd.SetLogger(newLogger(), s.opts.Debug, false)
+
+	// We always supply true for debug here because in our logger
+	// we intercept a few debug logs that really should have been
+	// info or warning ones.  This will hopefully be able to go
+	// back to normal once nats-io/gnatsd#622 is fixed
+	//
+	// this does though disable a performance optimisation in the
+	// nats logging classes where they don't call debug at all when
+	// not needed but I imagine logrus does not have a huge bottleneck
+	// in that area so its probably safe
+	s.gnatsd.SetLogger(newLogger(), true, false)
 
 	return
 }


### PR DESCRIPTION
gnatsd logs mainly at debug irrespective of the usability of most
messages, this is a problem because I suspect I am seeing cases
where the single worker between brokers are being disconnected
as slow consumers.  The logs that would help identify that are
all debug and enabling debug on a large broker cluster is not possible

So this does a rather nasty intercept of those log messages and elevate
them to notice or error.