### PR TITLE
(#198) Reuse the varz get transport

### DIFF
--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -17,10 +17,11 @@ import (
 
 // Server represents the Choria network broker server
 type Server struct {
-	gnatsd *gnatsd.Server
-	opts   *gnatsd.Options
-	choria *choria.Framework
-	config *choria.Config
+	gnatsd      *gnatsd.Server
+	opts        *gnatsd.Options
+	choria      *choria.Framework
+	config      *choria.Config
+	vzTransport *http.Transport
 
 	started bool
 
@@ -35,6 +36,10 @@ func NewServer(c *choria.Framework, debug bool) (s *Server, err error) {
 		opts:    &gnatsd.Options{},
 		started: false,
 		mu:      &sync.Mutex{},
+		vzTransport: &http.Transport{
+			MaxIdleConns:    1,
+			IdleConnTimeout: 5 * time.Second,
+		},
 	}
 
 	s.opts.Host = c.Config.Choria.NetworkListenAddress

--- a/broker/network/stats.go
+++ b/broker/network/stats.go
@@ -79,27 +79,29 @@ func init() {
 }
 
 func (s *Server) getVarz() (*server.Varz, error) {
-	transport := &http.Transport{}
-	client := &http.Client{Transport: transport}
+	client := &http.Client{
+		Transport: s.vzTransport,
+		Timeout:   time.Second * 1,
+	}
 
 	url := fmt.Sprintf("http://localhost:%d/varz", s.opts.HTTPPort)
 
 	resp, err := client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get /varz stats: %s", err)
+		return nil, fmt.Errorf("could not get /varz stats: %s", err)
 	}
 
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get /varz stats: %s", err)
+		return nil, fmt.Errorf("could not get /varz stats: %s", err)
 	}
 
 	response := &server.Varz{}
 	err = json.Unmarshal(body, response)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get /varz stats: %s", err)
+		return nil, fmt.Errorf("could not get /varz stats: %s", err)
 	}
 
 	return response, nil

--- a/glide.lock
+++ b/glide.lock
@@ -48,7 +48,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/nats-io/gnatsd
-  version: 12a5ced612f30aa511906c0de12a124233752f70
+  version: 02dd205a481e8f9957f15ec2667e8b80bafecc14
   subpackages:
   - conf
   - logger


### PR DESCRIPTION
http.Transports should be reused by multiple connections and not
recreated, they manage keep alives and all sorts of things.

We were creating new ones which in time will leak network connection
like crazy.  This only started biting with a combo of go 1.10 and
gnatsd 1.0.6