### PR TITLE
(#207) ensure filter is valid 

### DIFF
--- a/choria/message.go
+++ b/choria/message.go
@@ -111,163 +111,163 @@ func NewMessage(payload string, agent string, collective string, msgType string,
 //
 // For requests you need to set the protocol version using SetProtocolVersion()
 // before calling Transport
-func (self *Message) Transport() (protocol.TransportMessage, error) {
-	if self.msgType == "request" || self.msgType == "direct_request" {
-		return self.requestTransport()
-	} else if self.msgType == "reply" {
-		return self.replyTransport()
+func (msg *Message) Transport() (protocol.TransportMessage, error) {
+	if msg.msgType == "request" || msg.msgType == "direct_request" {
+		return msg.requestTransport()
+	} else if msg.msgType == "reply" {
+		return msg.replyTransport()
 	}
 
-	return nil, fmt.Errorf("Do not know how to make a Transport for a %s type Message", self.msgType)
+	return nil, fmt.Errorf("Do not know how to make a Transport for a %s type Message", msg.msgType)
 }
 
-func (self *Message) requestTransport() (protocol.TransportMessage, error) {
-	if self.protoVersion == "" {
+func (msg *Message) requestTransport() (protocol.TransportMessage, error) {
+	if msg.protoVersion == "" {
 		return nil, errors.New("Cannot create a Request Transport without a version, please set it using SetProtocolVersion()")
 	}
 
-	if self.replyTo == "" {
+	if msg.replyTo == "" {
 		return nil, errors.New("Cannot create a Transport, no reply-to was set, please use SetReplyTo()")
 	}
 
-	transport, err := self.choria.NewRequestTransportForMessage(self, self.protoVersion)
+	transport, err := msg.choria.NewRequestTransportForMessage(msg, msg.protoVersion)
 	if err != nil {
 		return nil, fmt.Errorf("Could not create a Transport: %s", err)
 	}
 
-	transport.SetReplyTo(self.ReplyTo())
+	transport.SetReplyTo(msg.ReplyTo())
 
 	return transport, nil
 }
 
-func (self *Message) replyTransport() (protocol.TransportMessage, error) {
-	if self.req == nil {
+func (msg *Message) replyTransport() (protocol.TransportMessage, error) {
+	if msg.req == nil {
 		return nil, fmt.Errorf("Cannot create a Transport, no request were stored in the message")
 	}
 
-	return self.choria.NewReplyTransportForMessage(self, self.req)
+	return msg.choria.NewReplyTransportForMessage(msg, msg.req)
 }
 
 // SetProtocolVersion sets the version of the protocol that will be used by Transport()
-func (self *Message) SetProtocolVersion(version string) {
-	self.protoVersion = version
+func (msg *Message) SetProtocolVersion(version string) {
+	msg.protoVersion = version
 }
 
 // Validate tests the Message and makes sure its settings are sane
-func (self *Message) Validate() (bool, error) {
-	if self.Agent == "" {
+func (msg *Message) Validate() (bool, error) {
+	if msg.Agent == "" {
 		return false, fmt.Errorf("Agent has not been set")
 	}
 
-	if self.collective == "" {
+	if msg.collective == "" {
 		return false, fmt.Errorf("Collective has not been set")
 	}
 
-	if !self.choria.HasCollective(self.collective) {
-		return false, fmt.Errorf("'%s' is not on the list of known collectives", self.collective)
+	if !msg.choria.HasCollective(msg.collective) {
+		return false, fmt.Errorf("'%s' is not on the list of known collectives", msg.collective)
 	}
 
 	return true, nil
 }
 
 // ValidateTTL validates the message age
-func (self *Message) ValidateTTL() bool {
-	earliest := time.Now().Add(-1 * time.Duration(self.TTL))
+func (msg *Message) ValidateTTL() bool {
+	earliest := time.Now().Add(-1 * time.Duration(msg.TTL))
 
-	return self.TimeStamp.Before(earliest)
+	return msg.TimeStamp.Before(earliest)
 }
 
 // SetBase64Payload sets the payload for the message, use it if the payload is Base64 encoded
-func (self *Message) SetBase64Payload(payload string) error {
+func (msg *Message) SetBase64Payload(payload string) error {
 	str, err := base64.StdEncoding.DecodeString(payload)
 	if err != nil {
 		return fmt.Errorf("Could not decode supplied payload using base64: %s", err)
 	}
 
-	self.Payload = string(str)
+	msg.Payload = string(str)
 
 	return nil
 }
 
 // Base64Payload retrieves the payload Base64 encoded
-func (self *Message) Base64Payload() string {
-	return base64.StdEncoding.EncodeToString([]byte(self.Payload))
+func (msg *Message) Base64Payload() string {
+	return base64.StdEncoding.EncodeToString([]byte(msg.Payload))
 }
 
 // SetExpectedMsgID sets the Request ID that is expected from the reply data
-func (self *Message) SetExpectedMsgID(id string) error {
-	if self.Type() != "reply" {
+func (msg *Message) SetExpectedMsgID(id string) error {
+	if msg.Type() != "reply" {
 		return fmt.Errorf("Can only store expected message ID for reply messages")
 	}
 
-	self.expectedMessageID = id
+	msg.expectedMessageID = id
 
 	return nil
 }
 
 // ExpectedMessageID retrieves the expected message ID
-func (self *Message) ExpectedMessageID() string {
-	return self.expectedMessageID
+func (msg *Message) ExpectedMessageID() string {
+	return msg.expectedMessageID
 }
 
 // SetReplyTo sets the NATS target where replies to this message should go
-func (self *Message) SetReplyTo(replyTo string) error {
-	if !(self.Type() == "request" || self.Type() == "direct_request") {
+func (msg *Message) SetReplyTo(replyTo string) error {
+	if !(msg.Type() == "request" || msg.Type() == "direct_request") {
 		return fmt.Errorf("Custom reply to targets can only be set for requests")
 	}
 
-	self.replyTo = replyTo
+	msg.replyTo = replyTo
 
 	return nil
 }
 
 // ReplyTo retrieve the NATS reply target
-func (self *Message) ReplyTo() string {
-	return self.replyTo
+func (msg *Message) ReplyTo() string {
+	return msg.replyTo
 }
 
 // SetCollective sets the sub collective this message is targeting
-func (self *Message) SetCollective(collective string) error {
-	if !self.choria.HasCollective(collective) {
-		return fmt.Errorf("Cannot set collective to '%s', it is not on the list of known collectives", self.collective)
+func (msg *Message) SetCollective(collective string) error {
+	if !msg.choria.HasCollective(collective) {
+		return fmt.Errorf("Cannot set collective to '%s', it is not on the list of known collectives", msg.collective)
 	}
 
-	self.collective = collective
+	msg.collective = collective
 
 	return nil
 }
 
 // Collective retrieves the sub collective this message is targeting
-func (self *Message) Collective() string {
-	return self.collective
+func (msg *Message) Collective() string {
+	return msg.collective
 }
 
 // SetType sets the mssage type. One message, request, direct_request or reply
-func (self *Message) SetType(msgType string) (err error) {
+func (msg *Message) SetType(msgType string) (err error) {
 	if !(msgType == "message" || msgType == "request" || msgType == "direct_request" || msgType == "reply") {
 		return fmt.Errorf("%s is not a valid message type", msgType)
 	}
 
 	if msgType == "direct_request" {
-		if len(self.DiscoveredHosts) == 0 {
+		if len(msg.DiscoveredHosts) == 0 {
 			return fmt.Errorf("direct_request message type can only be set if DiscoveredHosts have been set")
 		}
 
-		self.Filter = protocol.NewFilter()
-		self.Filter.AddAgentFilter(self.Agent)
+		msg.Filter = protocol.NewFilter()
+		msg.Filter.AddAgentFilter(msg.Agent)
 	}
 
-	self.msgType = msgType
+	msg.msgType = msgType
 
 	return
 }
 
 // Type retrieves the message type
-func (self *Message) Type() string {
-	return self.msgType
+func (msg *Message) Type() string {
+	return msg.msgType
 }
 
 // String creates a string representation of the message for logs etc
-func (self *Message) String() string {
-	return fmt.Sprintf("%s from %s@%s for agent %s", self.RequestID, self.CallerID, self.SenderID, self.Agent)
+func (msg *Message) String() string {
+	return fmt.Sprintf("%s from %s@%s for agent %s", msg.RequestID, msg.CallerID, msg.SenderID, msg.Agent)
 }

--- a/choria/message.go
+++ b/choria/message.go
@@ -253,7 +253,7 @@ func (self *Message) SetType(msgType string) (err error) {
 			return fmt.Errorf("direct_request message type can only be set if DiscoveredHosts have been set")
 		}
 
-		self.Filter = &protocol.Filter{}
+		self.Filter = protocol.NewFilter()
 		self.Filter.AddAgentFilter(self.Agent)
 	}
 


### PR DESCRIPTION
When setting the message type to direct_request the filter gets
zero'd and just an agent filter gets added since you're telling
it to talk to a host it will do its best to do so.

The problem is we set it to a empty filter full of nils instead of
an initialized one - this would cause the schema validation code to
fail the requests