### PR TITLE
(#218) Add copytruncate and notifempty log options

### DIFF
--- a/packager/templates/debian/global/choria-logrotate
+++ b/packager/templates/debian/global/choria-logrotate
@@ -1,4 +1,6 @@
 /var/log/{{cpkg_name}}.log {
   daily
+  copytruncate
+  notifempty
   rotate 10
 }

--- a/packager/templates/el/global/choria-logrotate
+++ b/packager/templates/el/global/choria-logrotate
@@ -1,4 +1,6 @@
 /var/log/{{cpkg_name}}.log {
   daily
+  copytruncate
+  notifempty
   rotate 10
 }


### PR DESCRIPTION
This ensures that log rotation does not result in empty logs
and avoids rotating empty logs which will eventually just make
many 20 byte files and suck