### PR TITLE
(#222) allow the network broker write deadline to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ plugin.choria.network.peers = nats://choria1:5222, nats://choria2:5222, nats://c
 plugin.choria.network.peer_user = choria_cluster
 plugin.choria.network.peer_password = s£cret
 
+# the NATS network write deadline time, generally this is best left untouched
+plugin.choria.network.write_deadline = 5s # default
+
 # enables the typical NATS stats/status port, default is set to 0 and so disabled
 plugin.choria.stats_port = 8222
 

--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -46,6 +46,7 @@ func NewServer(c *choria.Framework, debug bool) (s *Server, err error) {
 	s.opts.Port = c.Config.Choria.NetworkClientPort
 	s.opts.Logtime = false
 	s.opts.MaxConn = build.MaxBrokerClients()
+	s.opts.WriteDeadline = c.Config.Choria.NetworkWriteDeadline
 
 	if debug || c.Config.LogLevel == "debug" {
 		s.opts.Debug = true

--- a/choria/config.go
+++ b/choria/config.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/choria-io/go-confkey"
 
@@ -57,15 +58,16 @@ type ChoriaPluginConfig struct {
 	Serializer        string   `confkey:"plugin.choria.security.serializer" validate:"enum=json,yaml"`
 
 	// network broker
-	NetworkListenAddress string   `confkey:"plugin.choria.network.listen_address" default:"::"`
-	NetworkClientPort    int      `confkey:"plugin.choria.network.client_port" default:"4222"`
-	NetworkPeerPort      int      `confkey:"plugin.choria.network.peer_port" default:"5222"`
-	NetworkPeerUser      string   `confkey:"plugin.choria.network.peer_user"`
-	NetworkPeerPassword  string   `confkey:"plugin.choria.network.peer_password"`
-	NetworkPeers         []string `confkey:"plugin.choria.network.peers" type:"comma_split"`
-	BrokerNetwork        bool     `confkey:"plugin.choria.broker_network" default:"false"`
-	BrokerDiscovery      bool     `confkey:"plugin.choria.broker_discovery" default:"false"`
-	BrokerFederation     bool     `confkey:"plugin.choria.broker_federation" default:"false"`
+	NetworkListenAddress string        `confkey:"plugin.choria.network.listen_address" default:"::"`
+	NetworkClientPort    int           `confkey:"plugin.choria.network.client_port" default:"4222"`
+	NetworkPeerPort      int           `confkey:"plugin.choria.network.peer_port" default:"5222"`
+	NetworkPeerUser      string        `confkey:"plugin.choria.network.peer_user"`
+	NetworkPeerPassword  string        `confkey:"plugin.choria.network.peer_password"`
+	NetworkPeers         []string      `confkey:"plugin.choria.network.peers" type:"comma_split"`
+	NetworkWriteDeadline time.Duration `confkey:"plugin.choria.network.write_deadline" type:"duration" default:"5s"`
+	BrokerNetwork        bool          `confkey:"plugin.choria.broker_network" default:"false"`
+	BrokerDiscovery      bool          `confkey:"plugin.choria.broker_discovery" default:"false"`
+	BrokerFederation     bool          `confkey:"plugin.choria.broker_federation" default:"false"`
 
 	// registration
 	FileContentRegistrationData   string `confkey:"plugin.choria.registration.file_content.data" default:""`

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 6db7f44383b0461f87d24a3b51c31a9b9e973ad39d89ac3308d365da34219814
-updated: 2018-03-05T15:52:29.328155+01:00
+updated: 2018-03-26T15:00:49.579343+02:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -12,15 +12,16 @@ imports:
   subpackages:
   - quantile
 - name: github.com/choria-io/go-confkey
-  version: 3a0ddeafbca44f8cd05f594ec7a6788913f0c1dc
+  version: 1416c30a60054226a232e049eb5496d6d6afb5f2
 - name: github.com/choria-io/go-protocol
   version: 72bc3ca9593e692e55a3f5dda61194803f54d619
   subpackages:
   - protocol
   - protocol/v1
 - name: github.com/choria-io/go-validator
-  version: 99e0f793dd701e8cf45fd27624390ea43699e3b9
+  version: 4ce2ef25983faa873cc4bcea0f1ef2a4273d42cc
   subpackages:
+  - duration
   - enum
   - ipaddress
   - ipv4
@@ -122,9 +123,9 @@ imports:
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
+  version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: 87033efcaec6215741137e8ca61952c53ef2685d
+  version: 01f00f129617a6fe98941fb920d6c760241b54d2
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: github.com/xeipuuv/gojsonpointer


### PR DESCRIPTION
This adds plugin.choria.network.write_deadline that defaults to 5
seconds allowing people to configure the write deadlines if they must