### PR TITLE
(misc) ensure gnatsd does not handle signals

### DIFF
--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -47,6 +47,7 @@ func NewServer(c *choria.Framework, debug bool) (s *Server, err error) {
 	s.opts.Logtime = false
 	s.opts.MaxConn = build.MaxBrokerClients()
 	s.opts.WriteDeadline = c.Config.Choria.NetworkWriteDeadline
+	s.opts.NoSigs = true
 
 	if debug || c.Config.LogLevel == "debug" {
 		s.opts.Debug = true


### PR DESCRIPTION
gnatsd recently got signal handling for live reloads etc, this is
undesirable when embedded and so we turn that off