### PR TITLE
(#243) Create an agent provider framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ debug
 .DS_Store
 *.deb
 *.dsc
+additional_agent_provider_*.go

--- a/README.md
+++ b/README.md
@@ -188,3 +188,18 @@ agents:
 ```
 
 When you run `go generate` (done during the building phase for you) this will create the shim you need to compile your agent into the binary.
+
+### Compiling in custom agent providers
+Agent Providers allow entirely new ways of writing agents to be created.  An example is the one that runs old mcollective ruby agents
+within a choria instance.
+
+During your CI or whatever you have to `glide get` the repo with your agent so it's available during compile, then create a file `packager/agent_providers.yaml`:
+
+```yaml
+---
+providers:
+  - name: rubymco
+    repo: github.com/choria-io/go-choria/mcorpc/ruby
+```
+
+When you run `go generate` (done during the building phase for you) this will create the shim you need to compile your agent into the binary.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 //go:generate go run server/gen_additional_agents.go
+//go:generate go run server/gen_additional_agent_providers.go
 
 import (
 	"os"

--- a/packager/agent_providers.yaml
+++ b/packager/agent_providers.yaml
@@ -1,0 +1,4 @@
+---
+providers:
+  - name: rubymco
+    repo: github.com/choria-io/go-choria/mcorpc/ruby

--- a/server/additional_agents.go
+++ b/server/additional_agents.go
@@ -34,12 +34,10 @@ func (srv *Instance) setupAdditionalAgents(ctx context.Context) error {
 	aamu.Lock()
 	defer aamu.Unlock()
 
-	if len(additionalAgents) > 0 {
-		for _, initializer := range additionalAgents {
-			err := initializer(ctx, srv.agents, srv.connector, srv.log)
-			if err != nil {
-				return err
-			}
+	for _, initializer := range additionalAgents {
+		err := initializer(ctx, srv.agents, srv.connector, srv.log)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/server/agent_providers.go
+++ b/server/agent_providers.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"context"
+	"sync"
+
+	"github.com/choria-io/go-choria/choria"
+	"github.com/sirupsen/logrus"
+)
+
+// AgentProvider is capable of adding agents into a running instance
+type AgentProvider interface {
+	Initialize(fw *choria.Framework, log *logrus.Entry)
+	RegisterAgents(ctx context.Context, mgr AgentManager, connector choria.InstanceConnector, log *logrus.Entry) error
+}
+
+var additionalAgentProviders []AgentProvider
+var aapmu *sync.Mutex
+
+func init() {
+	additionalAgentProviders = []AgentProvider{}
+	aapmu = &sync.Mutex{}
+}
+
+// RegisterAdditionalAgentProvider registers an agent provider as a subsystem
+// capable of delivering new types of agent like the legacy mcollective ruby compatible
+// ones
+//
+// Custom builders can use this to extend choria with new agent capabilities
+func RegisterAdditionalAgentProvider(p AgentProvider) {
+	aapmu.Lock()
+	defer aapmu.Unlock()
+
+	additionalAgentProviders = append(additionalAgentProviders, p)
+}
+
+func (srv *Instance) setupAdditionalAgentProviders(ctx context.Context) error {
+	aapmu.Lock()
+	defer aapmu.Unlock()
+
+	for _, provider := range additionalAgentProviders {
+		provider.Initialize(srv.fw, srv.log)
+
+		err := provider.RegisterAgents(ctx, srv.agents, srv.connector, srv.log)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/server/agents.go
+++ b/server/agents.go
@@ -8,10 +8,18 @@ import (
 	"github.com/choria-io/go-choria/agents/discovery"
 	"github.com/choria-io/go-choria/agents/provision"
 	"github.com/choria-io/go-choria/agents/rpcutil"
-	"github.com/choria-io/go-choria/mcorpc/ruby"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/sirupsen/logrus"
 
 	"github.com/choria-io/go-choria/build"
 )
+
+type AgentManager interface {
+	RegisterAgent(ctx context.Context, name string, agent agents.Agent, conn choria.AgentConnector) error
+	Logger() *logrus.Entry
+	Choria() *choria.Framework
+}
 
 func (srv *Instance) setupCoreAgents(ctx context.Context) error {
 	da, err := discovery.New(srv.agents)
@@ -43,10 +51,6 @@ func (srv *Instance) setupCoreAgents(ctx context.Context) error {
 
 		srv.agents.RegisterAgent(ctx, "choria_provision", pa, srv.connector)
 	}
-
-	srv.log.Info("Registering agents from the Ruby provider")
-	provider := ruby.New(srv.fw)
-	provider.RegisterAgents(ctx, srv.agents, srv.connector, srv.log)
 
 	return nil
 }

--- a/server/gen_additional_agent_providers.go
+++ b/server/gen_additional_agent_providers.go
@@ -1,0 +1,87 @@
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"encoding/json"
+
+	"github.com/alecthomas/template"
+	"github.com/ghodss/yaml"
+)
+
+type provider struct {
+	Name string
+	Repo string
+}
+
+type providers struct {
+	Providers []provider
+}
+
+const ftempl = `// auto generated {{.Now}}
+package main
+
+import (
+	ap "{{.Repo}}"
+
+	"github.com/choria-io/go-choria/server"
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	log.Info("Registering additional agent provider {{.Name}} from {{.Repo}}")
+	server.RegisterAdditionalAgentProvider(&ap.Provider{})
+}
+`
+
+func (p provider) Now() string {
+	return fmt.Sprintf("%s", time.Now())
+}
+
+func main() {
+	if _, err := os.Stat("packager/agent_providers.yaml"); os.IsNotExist(err) {
+		os.Exit(0)
+	}
+
+	j, err := ioutil.ReadFile("packager/agent_providers.yaml")
+	if err != nil {
+		log.Fatalf("Could not read agents spec file packager/agent_providers.yaml: %s", err)
+	}
+
+	j, err = yaml.YAMLToJSON(j)
+	if err != nil {
+		log.Fatalf("Could not parse agents spec file packager/agent_providers.yaml as YAML: %s", err)
+	}
+
+	extra := providers{}
+	err = json.Unmarshal(j, &extra)
+	if err != nil {
+		log.Fatalf("Could not JSON parse converted YAML: %s", err)
+	}
+
+	templ := template.Must(template.New("provider").Parse(ftempl))
+
+	for _, provider := range extra.Providers {
+		fname := fmt.Sprintf("additional_agent_provider_%s.go", provider.Name)
+
+		log.Printf("Generating loading code for agent provider %s from %s into %s", provider.Name, provider.Repo, fname)
+
+		f, err := os.Create(fname)
+		if err != nil {
+			log.Fatalf("cannot create file %s: ", fname, err)
+			return
+		}
+		defer f.Close()
+
+		err = templ.Execute(f, provider)
+		if err != nil {
+			log.Println("executing template:", err)
+		}
+	}
+}

--- a/server/instance.go
+++ b/server/instance.go
@@ -80,6 +80,13 @@ func (srv *Instance) Run(ctx context.Context, wg *sync.WaitGroup) {
 		return
 	}
 
+	if err := srv.setupAdditionalAgentProviders(ctx); err != nil {
+		srv.log.Errorf("Could not initialize initial additional agent providers: %s", err)
+		srv.connector.Close()
+
+		return
+	}
+
 	if err := srv.subscribeNode(ctx); err != nil {
 		srv.log.Errorf("Could not initialize node: %s", err)
 		srv.connector.Close()


### PR DESCRIPTION
This allows new agent providers to be plugged into choria during
compile time.

An example agent provider is the one that wraps the oldm mcollective
ruby agents in a go shim so that they can be accessed via the existing
mcorpc system.

It adds build hooks and go generate hooks to include the ruby one
by default