### PR TITLE
(#271) Rotate choria-*.log

### DIFF
--- a/packager/templates/debian/global/choria-logrotate
+++ b/packager/templates/debian/global/choria-logrotate
@@ -1,4 +1,4 @@
-/var/log/{{cpkg_name}}-audit.log
+/var/log/{{cpkg_name}}-*.log
 /var/log/{{cpkg_name}}.log
 {
   daily

--- a/packager/templates/el/global/choria-logrotate
+++ b/packager/templates/el/global/choria-logrotate
@@ -1,4 +1,4 @@
-/var/log/{{cpkg_name}}-audit.log
+/var/log/{{cpkg_name}}-*.log
 /var/log/{{cpkg_name}}.log
 {
   daily


### PR DESCRIPTION
To allow things like the mcollective compat framework to log and
be rotated we create a pattern where they will all go