### PR TITLE
(#284) Add KillMode=process to choria-server systemd unit files

### DIFF
--- a/packager/templates/debian/generic/server.service
+++ b/packager/templates/debian/generic/server.service
@@ -8,6 +8,7 @@ StandardError=syslog
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el7/server.service
+++ b/packager/templates/el/el7/server.service
@@ -8,6 +8,7 @@ StandardError=syslog
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Adding KillMode=process prevents situation where Puppet would get killed
by a restart of choria-server when puppet was run by choria-server and Puppet
restart choria-server.

Fixes #284 