### PR TITLE
(#291) configure global logger options

### DIFF
--- a/choria/framework.go
+++ b/choria/framework.go
@@ -266,6 +266,10 @@ func (self *Framework) SetupLogging(debug bool) (err error) {
 		self.log.SetLevel(log.DebugLevel)
 	}
 
+	log.SetFormatter(self.log.Formatter)
+	log.SetLevel(self.log.Level)
+	log.SetOutput(self.log.Out)
+
 	return
 }
 


### PR DESCRIPTION
We'd like to move to reusing a instance of the logger rather than
each caller using its own instance and the general chaos thats there
now, but while this is happening the old global level logger still
needs to be configured.

Previously we made the logger instance on the framework but did not
also configure the global logger thus all logging went to stdout
by default