### PR TITLE
(#290) Add a file security provider

### DIFF
--- a/choria/config.go
+++ b/choria/config.go
@@ -79,6 +79,14 @@ type ChoriaPluginConfig struct {
 	RubyAgentConfig string   `confkey:"plugin.choria.agent_provider.mcorpc.config"`
 	RubyLibdir      []string `confkey:"plugin.choria.agent_provider.mcorpc.libdir" type:"path_split"`
 
+	SecurityProvider string `confkey:"plugin.security.provider" default:"puppet"`
+
+	// file security
+	FileSecurityCertificate string `confkey:"plugin.security.file.certificate"`
+	FileSecurityKey         string `confkey:"plugin.security.file.key"`
+	FileSecurityCA          string `confkey:"plugin.security.file.ca"`
+	FileSecurityCache       string `confkey:"plugin.security.file.cache"`
+
 	// adapters
 	Adapters []string `confkey:"plugin.choria.adapters" type:"comma_split"`
 }

--- a/choria/file_security.go
+++ b/choria/file_security.go
@@ -1,0 +1,530 @@
+package choria
+
+import (
+	context "context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// FileSecurity impliments SecurityProvider using files on disk
+type FileSecurity struct {
+	fw   settingsProvider
+	conf *Config
+	log  *logrus.Entry
+}
+
+// NewFileSecurity creates a new instance of the Puppet Security provider
+func NewFileSecurity(fw settingsProvider, conf *Config, log *logrus.Entry) (*FileSecurity, error) {
+	p := &FileSecurity{
+		fw:   fw,
+		conf: conf,
+		log:  log.WithFields(logrus.Fields{"ssl": "file"}),
+	}
+
+	return p, nil
+}
+
+// Validate determines if the node represents a valid SSL configuration
+func (s *FileSecurity) Validate() ([]string, bool) {
+	errors := []string{}
+
+	if s.publicCertPath() != "" {
+		if !s.publicCertExists() {
+			errors = append(errors, fmt.Sprintf("public certificate %s does not exist", s.publicCertPath()))
+		}
+	} else {
+		errors = append(errors, "the public certificate path is not configured")
+	}
+
+	if s.privateKeyPath() != "" {
+		if !s.privateKeyExists() {
+			errors = append(errors, fmt.Sprintf("private key %s does not exist", s.privateKeyPath()))
+		}
+	} else {
+		errors = append(errors, "the private key path is not configured")
+	}
+
+	if s.caPath() != "" {
+		if !s.caExists() {
+			errors = append(errors, fmt.Sprintf("CA %s does not exist", s.caPath()))
+		}
+	} else {
+		errors = append(errors, "the CA path is not configured")
+	}
+
+	return errors, len(errors) == 0
+}
+
+// ChecksumBytes calculates a sha256 checksum for data
+func (s *FileSecurity) ChecksumBytes(data []byte) []byte {
+	sum := sha256.Sum256(data)
+
+	return sum[:]
+}
+
+// ChecksumString calculates a sha256 checksum for data
+func (s *FileSecurity) ChecksumString(data string) []byte {
+	return s.ChecksumBytes([]byte(data))
+}
+
+// SignBytes signs a message using a SHA256 PKCS1v15 protocol
+func (s *FileSecurity) SignBytes(str []byte) ([]byte, error) {
+	sig := []byte{}
+
+	pkpem, err := s.privateKeyPEM()
+	if err != nil {
+		return sig, err
+	}
+
+	pk, err := x509.ParsePKCS1PrivateKey(pkpem.Bytes)
+	if err != nil {
+		err = fmt.Errorf("could not parse private key PEM data: %s", err)
+		return sig, err
+	}
+
+	rng := rand.Reader
+	hashed := s.ChecksumBytes(str)
+	sig, err = rsa.SignPKCS1v15(rng, pk, crypto.SHA256, hashed[:])
+	if err != nil {
+		err = fmt.Errorf("could not sign message: %s", err)
+	}
+
+	return sig, err
+}
+
+// VerifyByteSignature verify that dat matches signature sig made by the key of identity
+// if identity is "" the active public key will be used
+func (s *FileSecurity) VerifyByteSignature(dat []byte, sig []byte, identity string) bool {
+	pubkeyPath := ""
+	var err error
+
+	pubkeyPath = s.publicCertPath()
+
+	if identity != "" {
+		pubkeyPath, err = s.cachePath(identity)
+	}
+
+	if err != nil {
+		s.log.Errorf("Could not verify signature: %s", err)
+		return false
+	}
+
+	pkpem, err := s.decodePEM(pubkeyPath)
+	if err != nil {
+		s.log.Errorf("Could not decode PEM data in public key %s: %s", pubkeyPath, err)
+		return false
+	}
+
+	cert, err := x509.ParseCertificate(pkpem.Bytes)
+	if err != nil {
+		s.log.Errorf("Could not parse decoded PEM data for public key %s: %s", pubkeyPath, err)
+		return false
+	}
+
+	rsaPublicKey := cert.PublicKey.(*rsa.PublicKey)
+	hashed := s.ChecksumBytes(dat)
+
+	err = rsa.VerifyPKCS1v15(rsaPublicKey, crypto.SHA256, hashed[:], sig)
+	if err != nil {
+		s.log.Errorf("Signature verification using %s failed: %s", pubkeyPath, err)
+		return false
+	}
+
+	return true
+}
+
+// VerifyStringSignature verify that str matches signature sig made by the key of identity
+func (s *FileSecurity) VerifyStringSignature(str string, sig []byte, identity string) bool {
+	return s.VerifyByteSignature([]byte(str), sig, identity)
+}
+
+// PrivilegedVerifyByteSignature verifies if the signature received is from any of the privileged certs or the given identity
+func (s *FileSecurity) PrivilegedVerifyByteSignature(dat []byte, sig []byte, identity string) bool {
+	var candidates []string
+
+	if identity != "" {
+		candidates = append(candidates, identity)
+	}
+
+	for _, candidate := range s.privilegedCerts() {
+		candidates = append(candidates, candidate)
+	}
+
+	for _, candidate := range candidates {
+		if s.VerifyByteSignature(dat, sig, candidate) {
+			s.log.Debugf("Allowing certificate %s to act as %s", candidate, identity)
+			return true
+		}
+	}
+
+	return false
+}
+
+// PrivilegedVerifyStringSignature verifies if the signature received is from any of the privilged certs or the given identity
+func (s *FileSecurity) PrivilegedVerifyStringSignature(dat string, sig []byte, identity string) bool {
+	return s.PrivilegedVerifyByteSignature([]byte(dat), sig, identity)
+}
+
+// SignString signs a message using a SHA256 PKCS1v15 protocol
+func (s *FileSecurity) SignString(str string) ([]byte, error) {
+	return s.SignBytes([]byte(str))
+}
+
+// CallerName creates a choria like caller name in the form of choria=identity
+func (s *FileSecurity) CallerName() string {
+	return fmt.Sprintf("choria=%s", s.Identity())
+}
+
+// CallerIdentity extracts the identity from a choria like caller name in the form of choria=identity
+func (s *FileSecurity) CallerIdentity(caller string) (string, error) {
+	re := regexp.MustCompile("^choria=([\\w\\.\\-]+)")
+	match := re.FindStringSubmatch(caller)
+
+	if match == nil {
+		return "", fmt.Errorf("could not find a valid caller identity name in %s", caller)
+	}
+
+	return match[1], nil
+}
+
+// CachePublicData caches the public key for a identity
+func (s *FileSecurity) CachePublicData(data []byte, identity string) error {
+	err := os.MkdirAll(s.certCacheDir(), os.FileMode(int(0755)))
+	if err != nil {
+		return fmt.Errorf("could not create Client Certificate Cache Directory: %s", err)
+	}
+
+	certfile, err := s.cachePath(identity)
+	if err != nil {
+		return err
+	}
+
+	if !s.shouldCacheClientCert(data, identity) {
+		return fmt.Errorf("certificate '%s' did not pass validation", identity)
+	}
+
+	err = ioutil.WriteFile(certfile, []byte(data), os.FileMode(int(0644)))
+	if err != nil {
+		return fmt.Errorf("could not cache client public certificate: %s", err.Error())
+	}
+
+	return nil
+}
+
+// CachedPublicData retrieves the previously cached public data for a given identity
+func (s *FileSecurity) CachedPublicData(identity string) ([]byte, error) {
+	certfile, err := s.cachePath(identity)
+	if err != nil {
+		return []byte{}, fmt.Errorf("could not cache public data: %s", err)
+	}
+
+	if _, err := os.Stat(certfile); os.IsNotExist(err) {
+		return []byte{}, fmt.Errorf("unknown public data: %s", identity)
+	}
+
+	return ioutil.ReadFile(certfile)
+}
+
+// Identity determines the choria certname
+func (s *FileSecurity) Identity() string {
+	if s.conf.OverrideCertname != "" {
+		return s.conf.OverrideCertname
+	}
+
+	if certname, ok := os.LookupEnv("MCOLLECTIVE_CERTNAME"); ok {
+		return certname
+	}
+
+	certname := s.conf.Identity
+
+	if s.fw.Getuid() != 0 {
+		if u, ok := os.LookupEnv("USER"); ok {
+			certname = fmt.Sprintf("%s.mcollective", u)
+		}
+	}
+
+	return certname
+}
+
+func (s *FileSecurity) privilegedCerts() []string {
+	certs := []string{}
+
+	filepath.Walk(s.certCacheDir(), func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			cert := []byte(strings.TrimSuffix(filepath.Base(path), ".pem"))
+
+			if MatchAnyRegex(cert, s.conf.Choria.PrivilegedUsers) {
+				certs = append(certs, string(cert))
+			}
+		}
+
+		return nil
+	})
+
+	sort.Strings(certs)
+
+	return certs
+}
+
+// VerifyCertificate verifies a certificate is signed with the configured CA and if
+// name is not "" that it matches the name given
+func (s *FileSecurity) VerifyCertificate(certpem []byte, name string) (error, bool) {
+	ca := s.caPath()
+	capem, err := ioutil.ReadFile(ca)
+	if err != nil {
+		s.log.Errorf("Could not read CA '%s': %s", s.caPath, err)
+		return errors.New(err.Error()), false
+	}
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(capem) {
+		s.log.Warnf("Could not use CA '%s' as PEM data: %s", ca, err)
+		return errors.New(err.Error()), false
+	}
+
+	block, _ := pem.Decode(certpem)
+	if block == nil {
+		s.log.Warnf("Could not decode certificate '%s' PEM data: %s", name, err)
+		return errors.New(err.Error()), false
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		s.log.Warnf("Could not parse certificate '%s': %s", name, err)
+		return errors.New(err.Error()), false
+	}
+
+	opts := x509.VerifyOptions{
+		Roots: roots,
+	}
+
+	if name != "" {
+		opts.DNSName = name
+	}
+
+	_, err = cert.Verify(opts)
+	if err != nil {
+		s.log.Warnf("Certificate does not pass verification as '%s': %s", name, err)
+		return errors.New(err.Error()), false
+	}
+
+	return nil, true
+}
+
+// HTTPClient creates a standard HTTP client with optional security, it will
+// be set to use the CA and client certs for auth. servername should match the
+// remote hosts name for SNI
+func (s *FileSecurity) HTTPClient(secure bool) (*http.Client, error) {
+	client := &http.Client{}
+
+	if secure {
+		tlsc, err := s.TLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("could not set up HTTP connection: %s", err)
+		}
+
+		client.Transport = &http.Transport{TLSClientConfig: tlsc}
+	}
+
+	return client, nil
+}
+
+// TLSConfig creates a TLS configuration for use by NATS, HTTPS etc
+func (s *FileSecurity) TLSConfig() (*tls.Config, error) {
+	pub := s.publicCertPath()
+	pri := s.privateKeyPath()
+	ca := s.caPath()
+
+	tlsc := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if s.privateKeyExists() && s.publicCertExists() {
+		cert, err := tls.LoadX509KeyPair(pub, pri)
+		if err != nil {
+			err = fmt.Errorf("could not load certificate %s and key %s: %s", pub, pri, err)
+			return nil, err
+		}
+
+		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			err = fmt.Errorf("error parsing certificate: %v", err)
+			return nil, err
+		}
+
+		tlsc.Certificates = []tls.Certificate{cert}
+	}
+
+	if s.caExists() {
+		caCert, err := ioutil.ReadFile(ca)
+		if err != nil {
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		tlsc.ClientCAs = caCertPool
+		tlsc.RootCAs = caCertPool
+	}
+
+	if s.conf.DisableTLSVerify {
+		tlsc.InsecureSkipVerify = true
+	}
+
+	tlsc.BuildNameToCertificate()
+
+	return tlsc, nil
+}
+
+// PublicCertPem retrieves the public certificate for this instance
+func (s *FileSecurity) PublicCertPem() (*pem.Block, error) {
+	path := s.publicCertPath()
+
+	return s.decodePEM(path)
+}
+
+// PublicCertTXT retrieves pem data in textual form for the public certificate of the current identity
+func (s *FileSecurity) PublicCertTXT() ([]byte, error) {
+	path := s.publicCertPath()
+
+	return ioutil.ReadFile(path)
+}
+
+// SSLContext creates a SSL context loaded with our certs and ca
+func (s *FileSecurity) SSLContext() (*http.Transport, error) {
+	tlsConfig, err := s.TLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+
+	return transport, nil
+}
+
+// Enroll is not supported
+func (s *FileSecurity) Enroll(ctx context.Context, wait time.Duration, cb func(int)) error {
+	return errors.New("The file security provider does not support enrollement")
+}
+
+func (s *FileSecurity) cachePath(identity string) (string, error) {
+	certfile := filepath.Join(s.certCacheDir(), fmt.Sprintf("%s.pem", identity))
+
+	return certfile, nil
+}
+
+func (s *FileSecurity) decodePEM(certpath string) (*pem.Block, error) {
+	var err error
+
+	if certpath == "" {
+		return nil, errors.New("invalid certpath '' provided")
+	}
+
+	keydat, err := ioutil.ReadFile(certpath)
+	if err != nil {
+		return nil, fmt.Errorf("could not read PEM data from %s: %s", certpath, err)
+	}
+
+	pb, _ := pem.Decode(keydat)
+	if pb == nil {
+		return nil, fmt.Errorf("failed to parse PEM data from key %s", certpath)
+	}
+
+	return pb, nil
+}
+
+func (s *FileSecurity) privateKeyPath() string {
+	return filepath.FromSlash(s.conf.Choria.FileSecurityKey)
+}
+
+func (s *FileSecurity) publicCertPath() string {
+	return filepath.FromSlash(s.conf.Choria.FileSecurityCertificate)
+}
+
+func (s *FileSecurity) caPath() string {
+	return filepath.FromSlash(s.conf.Choria.FileSecurityCA)
+}
+
+func (s *FileSecurity) privateKeyExists() bool {
+	_, err := os.Stat(s.privateKeyPath())
+
+	return err == nil
+}
+
+func (s *FileSecurity) publicCertExists() bool {
+	_, err := os.Stat(s.publicCertPath())
+
+	return err == nil
+}
+
+func (s *FileSecurity) caExists() bool {
+	_, err := os.Stat(s.caPath())
+
+	return err == nil
+}
+
+func (s *FileSecurity) privateKeyPEM() (pb *pem.Block, err error) {
+	key := s.privateKeyPath()
+
+	keydat, err := ioutil.ReadFile(key)
+	if err != nil {
+		return pb, fmt.Errorf("Could not read Private Key %s: %s", key, err)
+	}
+
+	pb, _ = pem.Decode(keydat)
+	if pb == nil {
+		return pb, fmt.Errorf("Failed to parse PEM data from key %s", key)
+	}
+
+	return
+}
+
+func (s *FileSecurity) certCacheDir() string {
+	return filepath.FromSlash(s.conf.Choria.FileSecurityCache)
+}
+
+func (s *FileSecurity) shouldCacheClientCert(data []byte, name string) bool {
+	if err, ok := s.VerifyCertificate(data, ""); !ok {
+		s.log.Warnf("Received certificate '%s' certiicate did not pass verification: %s", name, err)
+		return false
+	}
+
+	if MatchAnyRegex([]byte(name), s.conf.Choria.PrivilegedUsers) {
+		s.log.Warnf("Caching privileged certificate %s", name)
+		return true
+	}
+
+	if err, ok := s.VerifyCertificate(data, name); !ok {
+		s.log.Warnf("Received certificate '%s' did not pass verification: %s", name, err)
+		return false
+	}
+
+	if !MatchAnyRegex([]byte(name), s.conf.Choria.CertnameWhitelist) {
+		s.log.Warnf("Received certificate '%s' does not match the allowed list '%s'", name, s.conf.Choria.CertnameWhitelist)
+		return false
+	}
+
+	return true
+}

--- a/choria/file_security_test.go
+++ b/choria/file_security_test.go
@@ -1,0 +1,445 @@
+package choria
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	gomock "github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func setSSL(c *Config, parent string, id string) {
+	c.Choria.FileSecurityCertificate = filepath.Join(parent, "certs", fmt.Sprintf("%s.pem", id))
+	c.Choria.FileSecurityCA = filepath.Join(parent, "certs", "ca.pem")
+	c.Choria.FileSecurityCache = filepath.Join(parent, "choria_security", "public_certs")
+	c.Choria.FileSecurityKey = filepath.Join(parent, "private_keys", fmt.Sprintf("%s.pem", id))
+}
+
+var _ = Describe("FileSSL", func() {
+	var mockctl *gomock.Controller
+	var settings *MocksettingsProvider
+	var cfg *Config
+	var err error
+	var prov *FileSecurity
+	var l *logrus.Logger
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		settings = NewMocksettingsProvider(mockctl)
+
+		cfg, err = NewDefaultConfig()
+		Expect(err).ToNot(HaveOccurred())
+		cfg.OverrideCertname = "rip.mcollective"
+		setSSL(cfg, filepath.Join("testdata", "good"), "rip.mcollective")
+
+		l = logrus.New()
+		l.Out = ioutil.Discard
+
+		prov, err = NewFileSecurity(settings, cfg, l.WithFields(logrus.Fields{}))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		mockctl.Finish()
+		os.Setenv("MCOLLECTIVE_CERTNAME", "rip.mcollective")
+	})
+
+	It("Should impliment the provider interface", func() {
+		f := func(p SecurityProvider) {}
+		f(prov)
+	})
+
+	Describe("Validate", func() {
+		It("Should handle missing files", func() {
+			setSSL(cfg, filepath.Join("testdata", "nonexisting"), "test.mcollective")
+
+			cfg.OverrideCertname = "test.mcollective"
+			prov, err = NewFileSecurity(settings, cfg, l.WithFields(logrus.Fields{}))
+
+			Expect(err).ToNot(HaveOccurred())
+
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+			errs, ok := prov.Validate()
+
+			Expect(ok).To(BeFalse())
+			Expect(errs).To(HaveLen(3))
+			Expect(errs[0]).To(Equal(fmt.Sprintf("public certificate %s does not exist", cfg.Choria.FileSecurityCertificate)))
+			Expect(errs[1]).To(Equal(fmt.Sprintf("private key %s does not exist", cfg.Choria.FileSecurityKey)))
+			Expect(errs[2]).To(Equal(fmt.Sprintf("CA %s does not exist", cfg.Choria.FileSecurityCA)))
+		})
+
+		It("Should accept valid directories", func() {
+			cfg.OverrideCertname = "rip.mcollective"
+			setSSL(cfg, filepath.Join("testdata", "good"), "rip.mcollective")
+
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+			errs, ok := prov.Validate()
+			Expect(errs).To(HaveLen(0))
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("Identity", func() {
+		It("Should support OverrideCertname", func() {
+			cfg.OverrideCertname = "bob.choria"
+
+			Expect(prov.Identity()).To(Equal("bob.choria"))
+		})
+
+		It("Should support MCOLLECTIVE_CERTNAME", func() {
+			cfg.OverrideCertname = ""
+			os.Setenv("MCOLLECTIVE_CERTNAME", "env.choria")
+			Expect(prov.Identity()).To(Equal("env.choria"))
+		})
+
+		It("Should support non root users", func() {
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+			cfg.OverrideCertname = ""
+			os.Setenv("USER", "bob")
+			os.Unsetenv("MCOLLECTIVE_CERTNAME")
+			Expect(prov.Identity()).To(Equal("bob.mcollective"))
+		})
+
+		It("Should support root users", func() {
+			settings.EXPECT().Getuid().Return(0).AnyTimes()
+			os.Unsetenv("MCOLLECTIVE_CERTNAME")
+			cfg.Identity = "node.example.net"
+			cfg.OverrideCertname = ""
+			Expect(prov.Identity()).To(Equal("node.example.net"))
+		})
+	})
+
+	Describe("CallerName", func() {
+		It("Should return the right caller name", func() {
+			cfg.OverrideCertname = "test.choria"
+			Expect(prov.CallerName()).To(Equal("choria=test.choria"))
+		})
+	})
+
+	Describe("CallerIdentity", func() {
+		It("Should return the right caller ident", func() {
+			Expect(prov.CallerIdentity("choria=test.choria")).To(Equal("test.choria"))
+		})
+
+		It("Should handle invalid caller ident", func() {
+			_, err := prov.CallerIdentity("test.choria")
+			Expect(err).To(MatchError("could not find a valid caller identity name in test.choria"))
+		})
+	})
+
+	Describe("SignBytes", func() {
+		It("Should produce the right signature", func() {
+			sig, err := prov.SignBytes([]byte("too many secrets"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
+		})
+	})
+
+	Describe("VerifyByteSignature", func() {
+		It("Should validate correctly", func() {
+			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "")
+			Expect(valid).To(BeTrue())
+		})
+
+		It("Should fail for invalid sigs", func() {
+			valid := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), "")
+			Expect(valid).To(BeFalse())
+		})
+
+		It("Should support cached certificates", func() {
+			cfg.OverrideCertname = "2.mcollective"
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+
+			sig, err := base64.StdEncoding.DecodeString("Zq1F2bdXOAvB5Ca+iYCZ/BLYz2ZzbQP/V8kwQY0E3cuDrBDArX7UhUnBakzN+Msr7UyF+EkYmzvIi4KHnFBrgi7otM8Q5YMh5IT+IPaoHj3Rj/jorqD4g8ltZINqCUBWDN4wvSG98SxLyawV69gAK4SnP+oy7SU7zxuQiPwIMJ7lVoiQ3t+tiQAHUxeykQPw7WElLb+wPTb1k4DM3yRkijA9OeUk+3SVyl2sTCu5h/Lg0lcI372bkLDESlnhnvw7yuLD2SSncrEQrBdv/N2yEpY2fx1UKGlTrn9GH4MGA1GuzE1F87RH9P8ieeul6vI13BkBAlMk5KaGlmWpgiGri5UjCHHXMxEnXfwUcKFE+E6yVg4SbrJknkuJzNJduypMIep7YOnPHVLNIBZLuOUdJrRgBQ+Yb9mxPnEQHhOHeN0XHUcseRJEISqPkagpNx1xhOb7g3hsNyEvqibT/DZsc/2hyU2I/wG9fl26CnN9c12r1zInyCQYsU/wuIvjDtRZvTpLGJSJdgjSmTPzGmA/fKpAfOWObdsoLeorjF/pNweuc0x0JZMsBrZauldLL53wnnvllsFEmIAxs+RusoJ2UfW7WugZ7lXGISHTef6IHjukHgDBSbeGawVCnAgPbPz1dy42x04koUW3Bmz89fJ4/j+e49ijz7z3W/IercNeke4=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
+			Expect(valid).To(BeTrue())
+		})
+	})
+
+	Describe("PrivilegedVerifyByteSignature", func() {
+		It("Should allow a privileged cert to act as someone else", func() {
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+
+			sig, err := base64.StdEncoding.DecodeString("4dSmCRsnZzJjqSLdXxCRufw+wh9BrbqMZfEkB9c0yLkqjuc6r2b3tl5bh28l2lm50nPcIKeMyVHh2pkhvVsnjTYVhEYGTBcJdhAf/4PQCCqllHfiD0i+EZNTC916P4C2TVFNw5kOx/qjz6KYBuBV0K0U5JG1L7rHmlSoJ1La9vs/x1RMLly91NYnPOtCpwSsAwRG6uGMnCQK/vGg+NiwIQpQrchCpVf6rrXSqqUrJzZc/SeNl42AA2EYbkq8ys79sye1w91BF07gX6n/gK/472tlTh9OK49GmLdi15oGiEOPbkCbPYm2hcWAJzdqGprCQAsYjuMfUByswxkthEw72Bp9tmSuc6P6QPLswkAeVi4NivQCm81CFEB0ZKl0WluJp5xEL9/mO9/Z/iUuvMRGQSbfIzi+8PVJeNIWsY8rzsDMdoIdwPD+vqVU7BhHxKXjAHq2nnhQCj35HuV2dN7n0MOy4A6H5kA4a8d5UVTBRMsFZ5s6Bo4/leFOlylgU2DIWq+DXdg05Zr98H9JulDM0epKEjLeowo5z5f2s7/eQymaSzdoW2zUhe9Hp0G0D8CkQUXm/RzjzLBTZ1fNQYIQGA9U6n+ApwBNHW9ClmlbbvcUb+Bw2rRHVgKM6+kUam+TLpLljuZkOY6wkk+h97aHYJyO7tOezyTuPPM5L3CDQ+M=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
+			Expect(valid).To(BeTrue())
+		})
+
+		It("Should allow a cert to act as itself", func() {
+			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
+			Expect(valid).To(BeTrue())
+		})
+
+		It("Should not allow a unmatched cert", func() {
+			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
+			Expect(valid).To(BeFalse())
+		})
+	})
+
+	Describe("SignString", func() {
+		It("Should produce the right signature", func() {
+			sig, err := prov.SignString("too many secrets")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
+
+		})
+	})
+
+	Describe("VerifyStringSignature", func() {
+		It("Should validate correctly", func() {
+			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid := prov.VerifyStringSignature("too many secrets", sig, "")
+			Expect(valid).To(BeTrue())
+		})
+
+		It("Should fail for invalid sigs", func() {
+			valid := prov.VerifyStringSignature("too many secrets", []byte("meh"), "")
+			Expect(valid).To(BeFalse())
+		})
+	})
+
+	Describe("ChecksumBytes", func() {
+		It("Should produce the right checksum", func() {
+			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(prov.ChecksumBytes([]byte("too many secrets"))).To(Equal(sum))
+		})
+	})
+
+	Describe("ChecksumString", func() {
+		It("Should produce the right checksum", func() {
+			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(prov.ChecksumString("too many secrets")).To(Equal(sum))
+		})
+	})
+
+	Describe("TLSConfig", func() {
+		It("Should produce a valid TLS Config", func() {
+			c, err := prov.TLSConfig()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(c.InsecureSkipVerify).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			pub := prov.publicCertPath()
+			pri := prov.privateKeyPath()
+
+			cert, err := tls.LoadX509KeyPair(pub, pri)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(c.Certificates).To(HaveLen(1))
+			Expect(c.Certificates[0].Certificate).To(Equal(cert.Certificate))
+		})
+
+		It("Should support disabling tls verify", func() {
+			cfg.DisableTLSVerify = true
+
+			c, err := prov.TLSConfig()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(c.InsecureSkipVerify).To(BeTrue())
+
+		})
+	})
+
+	Describe("VerifyCertificate", func() {
+		var pem []byte
+
+		BeforeEach(func() {
+			pub := prov.publicCertPath()
+			pem, err = ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should fail for foreign certs", func() {
+			pem, err = ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
+			Expect(err).ToNot(HaveOccurred())
+			err, verified := prov.VerifyCertificate(pem, "rip.mcollective")
+			Expect(verified).To(BeFalse())
+			Expect(err).To(MatchError("x509: certificate signed by unknown authority"))
+
+		})
+
+		It("Should fail for invalid names", func() {
+			err, verified := prov.VerifyCertificate(pem, "bob")
+			Expect(err).To(MatchError("x509: certificate is valid for rip.mcollective, not bob"))
+			Expect(verified).To(BeFalse())
+		})
+
+		It("Should accept valid certs", func() {
+			_, verified := prov.VerifyCertificate(pem, "rip.mcollective")
+			Expect(verified).To(BeTrue())
+		})
+	})
+
+	Describe("PublicCertPem", func() {
+		It("Should return the correct pem data", func() {
+			dat, err := ioutil.ReadFile(cfg.Choria.FileSecurityCertificate)
+			Expect(err).ToNot(HaveOccurred())
+			pb, _ := pem.Decode(dat)
+			Expect(err).ToNot(HaveOccurred())
+
+			block, err := prov.PublicCertPem()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(block.Bytes).To(Equal(pb.Bytes))
+		})
+	})
+
+	Describe("shouldCacheClientCert", func() {
+		It("Should only accept valid certs signed by our ca", func() {
+			pd, err := ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "foo")).To(BeFalse())
+
+			pub := prov.publicCertPath()
+			pd, err = ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
+		})
+
+		It("Should cache privileged certs", func() {
+			cfg.OverrideCertname = "1.privileged.mcollective"
+
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "1.privileged.mcollective")).To(BeTrue())
+		})
+
+		It("Should not cache certs with wrong names", func() {
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "bob")).To(BeFalse())
+		})
+
+		It("Should only cache certs thats on the allowed list", func() {
+			cfg.Choria.CertnameWhitelist = []string{"bob"}
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeFalse())
+		})
+
+		It("Should cache valid certs", func() {
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
+		})
+	})
+
+	Describe("CachePublicData", func() {
+		It("Should not write untrusted files to disk", func() {
+			cfg.Choria.FileSecurityCache = os.TempDir()
+			pd, err := ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
+			Expect(err).ToNot(HaveOccurred())
+			err = prov.CachePublicData(pd, "foreign")
+			Expect(err).To(MatchError("certificate 'foreign' did not pass validation"))
+
+			cpath, err := prov.cachePath("foreign")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = os.Stat(cpath)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should write trusted files to disk", func() {
+			cfg.Choria.FileSecurityCache = os.TempDir()
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = prov.CachePublicData(pd, "rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
+
+			cpath, err := prov.cachePath("rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = os.Stat(cpath)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("CachedPublicData", func() {
+		It("Should read the correct file", func() {
+			cfg.Choria.FileSecurityCache = os.TempDir()
+			settings.EXPECT().Getuid().Return(500).AnyTimes()
+
+			pub := prov.publicCertPath()
+
+			pd, err := ioutil.ReadFile(pub)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = prov.CachePublicData(pd, "rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
+
+			dat, err := prov.CachedPublicData("rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dat).To(Equal(pd))
+		})
+	})
+
+	Describe("privilegedCerts", func() {
+		It("Should find the right certs", func() {
+			cfg.Choria.PrivilegedUsers = []string{"\\.privileged.mcollective$", "\\.super.mcollective$"}
+			cfg.Choria.CertnameWhitelist = []string{"\\.mcollective$"}
+
+			expected := []string{
+				"1.privileged.mcollective",
+				"1.super.mcollective",
+				"2.privileged.mcollective",
+				"2.super.mcollective",
+			}
+
+			Expect(prov.privilegedCerts()).To(Equal(expected))
+		})
+	})
+
+	Describe("privateKeyExists", func() {
+		It("Should detect existing keys", func() {
+			prov.conf.OverrideCertname = "rip.mcollective"
+			setSSL(cfg, filepath.Join("testdata", "good"), "rip.mcollective")
+
+			Expect(prov.privateKeyExists()).To(BeTrue())
+		})
+
+		It("Should detect absent keys", func() {
+			prov.conf.OverrideCertname = "na.mcollective"
+			setSSL(cfg, filepath.Join("testdata", "good"), "na.mcollective")
+
+			Expect(prov.privateKeyExists()).To(BeFalse())
+		})
+	})
+
+})

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -54,7 +54,7 @@ func NewWithConfig(config *Config) (*Framework, error) {
 		return &c, fmt.Errorf("could not set up logging: %s", err)
 	}
 
-	c.security, err = NewSecurityProvider("puppet", &c, c.Logger("security"))
+	c.security, err = NewSecurityProvider(config.Choria.SecurityProvider, &c, c.Logger("security"))
 	if err != nil {
 		return &c, fmt.Errorf("could not set up security framework: %s", err)
 	}

--- a/choria/puppet_security_test.go
+++ b/choria/puppet_security_test.go
@@ -1,16 +1,13 @@
 package choria
 
 import (
-	"crypto/tls"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/sirupsen/logrus"
 
@@ -25,6 +22,7 @@ var _ = Describe("PuppetSSL", func() {
 	var cfg *Config
 	var err error
 	var prov *PuppetSecurity
+	var l *logrus.Logger
 
 	BeforeEach(func() {
 		mockctl = gomock.NewController(GinkgoT())
@@ -33,8 +31,9 @@ var _ = Describe("PuppetSSL", func() {
 		cfg, err = NewDefaultConfig()
 		Expect(err).ToNot(HaveOccurred())
 		cfg.Choria.SSLDir = filepath.Join("testdata", "good")
+		cfg.OverrideCertname = "rip.mcollective"
 
-		l := logrus.New()
+		l = logrus.New()
 		l.Out = ioutil.Discard
 
 		prov, err = NewPuppetSecurity(settings, cfg, l.WithFields(logrus.Fields{}))
@@ -52,22 +51,16 @@ var _ = Describe("PuppetSSL", func() {
 	})
 
 	Describe("Validate", func() {
-		It("Should handle missing ssl dirs", func() {
-			cfg.Choria.SSLDir = ""
-			settings.EXPECT().Getuid().Return(0).Times(1)
-			settings.EXPECT().PuppetSetting("ssldir").Return(filepath.Join("testdata", "allmissing"), fmt.Errorf("error invoking puppet")).Times(1)
-
-			errs, ok := prov.Validate()
-			Expect(errs[0]).To(Equal("SSL Directory does not exist: error invoking puppet"))
-			Expect(ok).To(BeFalse())
-		})
-
 		It("Should handle missing files", func() {
 			cfg.Choria.SSLDir = filepath.Join("testdata", "allmissing")
 			cfg.OverrideCertname = "test.mcollective"
+			prov, err = NewPuppetSecurity(settings, cfg, l.WithFields(logrus.Fields{}))
+
+			Expect(err).ToNot(HaveOccurred())
 
 			settings.EXPECT().Getuid().Return(500).AnyTimes()
 			errs, ok := prov.Validate()
+
 			Expect(ok).To(BeFalse())
 			Expect(errs).To(HaveLen(3))
 			Expect(errs[0]).To(Equal(fmt.Sprintf("public certificate %s does not exist", filepath.Join(cfg.Choria.SSLDir, "certs", "test.mcollective.pem"))))
@@ -88,6 +81,8 @@ var _ = Describe("PuppetSSL", func() {
 	Describe("Identity", func() {
 		It("Should support OverrideCertname", func() {
 			cfg.OverrideCertname = "bob.choria"
+			prov.reinit()
+
 			Expect(prov.Identity()).To(Equal("bob.choria"))
 		})
 
@@ -99,6 +94,7 @@ var _ = Describe("PuppetSSL", func() {
 
 		It("Should support non root users", func() {
 			settings.EXPECT().Getuid().Return(500).AnyTimes()
+			cfg.OverrideCertname = ""
 			os.Setenv("USER", "bob")
 			os.Unsetenv("MCOLLECTIVE_CERTNAME")
 			Expect(prov.Identity()).To(Equal("bob.mcollective"))
@@ -108,258 +104,8 @@ var _ = Describe("PuppetSSL", func() {
 			settings.EXPECT().Getuid().Return(0).AnyTimes()
 			os.Unsetenv("MCOLLECTIVE_CERTNAME")
 			cfg.Identity = "node.example.net"
+			cfg.OverrideCertname = ""
 			Expect(prov.Identity()).To(Equal("node.example.net"))
-		})
-	})
-
-	Describe("CallerName", func() {
-		It("Should return the right caller name", func() {
-			cfg.OverrideCertname = "test.choria"
-			Expect(prov.CallerName()).To(Equal("choria=test.choria"))
-		})
-	})
-
-	Describe("CallerIdentity", func() {
-		It("Should return the right caller ident", func() {
-			Expect(prov.CallerIdentity("choria=test.choria")).To(Equal("test.choria"))
-		})
-
-		It("Should handle invalid caller ident", func() {
-			_, err := prov.CallerIdentity("test.choria")
-			Expect(err).To(MatchError("could not find a valid caller identity name in test.choria"))
-		})
-	})
-
-	Describe("SignBytes", func() {
-		It("Should produce the right signature", func() {
-			sig, err := prov.SignBytes([]byte("too many secrets"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
-		})
-	})
-
-	Describe("VerifyByteSignature", func() {
-		It("Should validate correctly", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), "")
-			Expect(valid).To(BeFalse())
-		})
-
-		It("Should support cached certificates", func() {
-			cfg.OverrideCertname = "2.mcollective"
-			settings.EXPECT().Getuid().Return(500).AnyTimes()
-
-			sig, err := base64.StdEncoding.DecodeString("Zq1F2bdXOAvB5Ca+iYCZ/BLYz2ZzbQP/V8kwQY0E3cuDrBDArX7UhUnBakzN+Msr7UyF+EkYmzvIi4KHnFBrgi7otM8Q5YMh5IT+IPaoHj3Rj/jorqD4g8ltZINqCUBWDN4wvSG98SxLyawV69gAK4SnP+oy7SU7zxuQiPwIMJ7lVoiQ3t+tiQAHUxeykQPw7WElLb+wPTb1k4DM3yRkijA9OeUk+3SVyl2sTCu5h/Lg0lcI372bkLDESlnhnvw7yuLD2SSncrEQrBdv/N2yEpY2fx1UKGlTrn9GH4MGA1GuzE1F87RH9P8ieeul6vI13BkBAlMk5KaGlmWpgiGri5UjCHHXMxEnXfwUcKFE+E6yVg4SbrJknkuJzNJduypMIep7YOnPHVLNIBZLuOUdJrRgBQ+Yb9mxPnEQHhOHeN0XHUcseRJEISqPkagpNx1xhOb7g3hsNyEvqibT/DZsc/2hyU2I/wG9fl26CnN9c12r1zInyCQYsU/wuIvjDtRZvTpLGJSJdgjSmTPzGmA/fKpAfOWObdsoLeorjF/pNweuc0x0JZMsBrZauldLL53wnnvllsFEmIAxs+RusoJ2UfW7WugZ7lXGISHTef6IHjukHgDBSbeGawVCnAgPbPz1dy42x04koUW3Bmz89fJ4/j+e49ijz7z3W/IercNeke4=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-	})
-
-	Describe("PrivilegedVerifyByteSignature", func() {
-		It("Should allow a privileged cert to act as someone else", func() {
-			settings.EXPECT().Getuid().Return(500).AnyTimes()
-
-			sig, err := base64.StdEncoding.DecodeString("4dSmCRsnZzJjqSLdXxCRufw+wh9BrbqMZfEkB9c0yLkqjuc6r2b3tl5bh28l2lm50nPcIKeMyVHh2pkhvVsnjTYVhEYGTBcJdhAf/4PQCCqllHfiD0i+EZNTC916P4C2TVFNw5kOx/qjz6KYBuBV0K0U5JG1L7rHmlSoJ1La9vs/x1RMLly91NYnPOtCpwSsAwRG6uGMnCQK/vGg+NiwIQpQrchCpVf6rrXSqqUrJzZc/SeNl42AA2EYbkq8ys79sye1w91BF07gX6n/gK/472tlTh9OK49GmLdi15oGiEOPbkCbPYm2hcWAJzdqGprCQAsYjuMfUByswxkthEw72Bp9tmSuc6P6QPLswkAeVi4NivQCm81CFEB0ZKl0WluJp5xEL9/mO9/Z/iUuvMRGQSbfIzi+8PVJeNIWsY8rzsDMdoIdwPD+vqVU7BhHxKXjAHq2nnhQCj35HuV2dN7n0MOy4A6H5kA4a8d5UVTBRMsFZ5s6Bo4/leFOlylgU2DIWq+DXdg05Zr98H9JulDM0epKEjLeowo5z5f2s7/eQymaSzdoW2zUhe9Hp0G0D8CkQUXm/RzjzLBTZ1fNQYIQGA9U6n+ApwBNHW9ClmlbbvcUb+Bw2rRHVgKM6+kUam+TLpLljuZkOY6wkk+h97aHYJyO7tOezyTuPPM5L3CDQ+M=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should allow a cert to act as itself", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should not allow a unmatched cert", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
-			Expect(valid).To(BeFalse())
-		})
-	})
-
-	Describe("SignString", func() {
-		It("Should produce the right signature", func() {
-			sig, err := prov.SignString("too many secrets")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
-
-		})
-	})
-
-	Describe("VerifyStringSignature", func() {
-		It("Should validate correctly", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.VerifyStringSignature("too many secrets", sig, "")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyStringSignature("too many secrets", []byte("meh"), "")
-			Expect(valid).To(BeFalse())
-		})
-	})
-
-	Describe("ChecksumBytes", func() {
-		It("Should produce the right checksum", func() {
-			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(prov.ChecksumBytes([]byte("too many secrets"))).To(Equal(sum))
-		})
-	})
-
-	Describe("ChecksumString", func() {
-		It("Should produce the right checksum", func() {
-			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(prov.ChecksumString("too many secrets")).To(Equal(sum))
-		})
-	})
-
-	Describe("TLSConfig", func() {
-		It("Should produce a valid TLS Config", func() {
-			c, err := prov.TLSConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(c.InsecureSkipVerify).To(BeFalse())
-			Expect(err).ToNot(HaveOccurred())
-
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pri, err := prov.privateKeyPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			cert, err := tls.LoadX509KeyPair(pub, pri)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(c.Certificates).To(HaveLen(1))
-			Expect(c.Certificates[0].Certificate).To(Equal(cert.Certificate))
-		})
-
-		It("Should support disabling tls verify", func() {
-			cfg.DisableTLSVerify = true
-
-			c, err := prov.TLSConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(c.InsecureSkipVerify).To(BeTrue())
-
-		})
-	})
-
-	Describe("VerifyCertificate", func() {
-		var pem []byte
-
-		BeforeEach(func() {
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-			pem, err = ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("Should fail for foreign certs", func() {
-			pem, err = ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			err, verified := prov.VerifyCertificate(pem, "rip.mcollective")
-			Expect(verified).To(BeFalse())
-			Expect(err).To(MatchError("x509: certificate signed by unknown authority"))
-
-		})
-
-		It("Should fail for invalid names", func() {
-			err, verified := prov.VerifyCertificate(pem, "bob")
-			Expect(err).To(MatchError("x509: certificate is valid for rip.mcollective, not bob"))
-			Expect(verified).To(BeFalse())
-		})
-
-		It("Should accept valid certs", func() {
-			_, verified := prov.VerifyCertificate(pem, "rip.mcollective")
-			Expect(verified).To(BeTrue())
-		})
-	})
-
-	Describe("PublicCertPem", func() {
-		It("Should return the correct pem data", func() {
-			dat, err := ioutil.ReadFile(filepath.Join(cfg.Choria.SSLDir, "certs", "rip.mcollective.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			pb, _ := pem.Decode(dat)
-			Expect(err).ToNot(HaveOccurred())
-
-			block, err := prov.PublicCertPem()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(block.Bytes).To(Equal(pb.Bytes))
-		})
-	})
-
-	Describe("shouldCacheClientCert", func() {
-		It("Should only accept valid certs signed by our ca", func() {
-			pd, err := ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "foo")).To(BeFalse())
-
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-			pd, err = ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
-		})
-
-		It("Should cache privileged certs", func() {
-			cfg.OverrideCertname = "1.privileged.mcollective"
-
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "1.privileged.mcollective")).To(BeTrue())
-		})
-
-		It("Should not cache certs with wrong names", func() {
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "bob")).To(BeFalse())
-		})
-
-		It("Should only cache certs thats on the allowed list", func() {
-			cfg.Choria.CertnameWhitelist = []string{"bob"}
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeFalse())
-		})
-
-		It("Should cache valid certs", func() {
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(prov.shouldCacheClientCert(pd, "rip.mcollective")).To(BeTrue())
 		})
 	})
 
@@ -380,97 +126,10 @@ var _ = Describe("PuppetSSL", func() {
 		})
 	})
 
-	Describe("CachePublicData", func() {
-		It("Should not write untrusted files to disk", func() {
-			prov.cache = os.TempDir()
-			pd, err := ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			err = prov.CachePublicData(pd, "foreign")
-			Expect(err).To(MatchError("certificate 'foreign' did not pass validation"))
-
-			cpath, err := prov.cachePath("foreign")
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = os.Stat(cpath)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("Should handle missing directories", func() {
-			prov.cache = filepath.Join("testdata", "nonexisting")
-
-			path, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(path)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-
-			if runtime.GOOS == "windows" {
-				Expect(err).To(MatchError(fmt.Sprintf("could not cache client public certificate: open %s: The system cannot find the path specified.", filepath.Join("testdata", "nonexisting", "rip.mcollective.pem"))))
-			} else {
-				Expect(err).To(MatchError(fmt.Sprintf("could not cache client public certificate: open %s: no such file or directory", filepath.Join("testdata", "nonexisting", "rip.mcollective.pem"))))
-			}
-		})
-
-		It("Should write trusted files to disk", func() {
-			prov.cache = os.TempDir()
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			cpath, err := prov.cachePath("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = os.Stat(cpath)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("CachedPublicData", func() {
-		It("Should read the correct file", func() {
-			prov.cache = os.TempDir()
-			settings.EXPECT().Getuid().Return(500).AnyTimes()
-
-			pub, err := prov.publicCertPath()
-			Expect(err).ToNot(HaveOccurred())
-
-			pd, err := ioutil.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			dat, err := prov.CachedPublicData("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(dat).To(Equal(pd))
-		})
-	})
-
-	Describe("privilegedCerts", func() {
-		It("Should find the right certs", func() {
-			cfg.Choria.PrivilegedUsers = []string{"\\.privileged.mcollective$", "\\.super.mcollective$"}
-			cfg.Choria.CertnameWhitelist = []string{"\\.mcollective$"}
-
-			expected := []string{
-				"1.privileged.mcollective",
-				"1.super.mcollective",
-				"2.privileged.mcollective",
-				"2.super.mcollective",
-			}
-
-			Expect(prov.privilegedCerts()).To(Equal(expected))
-		})
-	})
-
 	Describe("writeCSR", func() {
 		It("should not write over existing CSRs", func() {
 			prov.conf.OverrideCertname = "na.mcollective"
+			prov.reinit()
 
 			kpath, err := prov.privateKeyPath()
 			Expect(err).ToNot(HaveOccurred())
@@ -484,6 +143,7 @@ var _ = Describe("PuppetSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			prov.conf.OverrideCertname = "rip.mcollective"
+			prov.reinit()
 			err = prov.writeCSR(key, "rip.mcollective", "choria.io")
 
 			Expect(err).To(MatchError("a certificate request already exist for rip.mcollective"))
@@ -491,6 +151,7 @@ var _ = Describe("PuppetSSL", func() {
 
 		It("Should create a valid CSR", func() {
 			prov.conf.OverrideCertname = "na.mcollective"
+			prov.reinit()
 
 			kpath, err := prov.privateKeyPath()
 			Expect(err).ToNot(HaveOccurred())
@@ -528,6 +189,7 @@ var _ = Describe("PuppetSSL", func() {
 
 		It("Should create new keys", func() {
 			prov.conf.OverrideCertname = "na.mcollective"
+			prov.reinit()
 
 			path, err := prov.privateKeyPath()
 			defer os.Remove(path)
@@ -542,24 +204,16 @@ var _ = Describe("PuppetSSL", func() {
 	Describe("csrExists", func() {
 		It("Should detect existing keys", func() {
 			prov.conf.OverrideCertname = "rip.mcollective"
+			prov.reinit()
+
 			Expect(prov.csrExists()).To(BeTrue())
 		})
 
 		It("Should detect absent keys", func() {
 			prov.conf.OverrideCertname = "na.mcollective"
+			prov.reinit()
+
 			Expect(prov.csrExists()).To(BeFalse())
-		})
-	})
-
-	Describe("privateKeyExists", func() {
-		It("Should detect existing keys", func() {
-			prov.conf.OverrideCertname = "rip.mcollective"
-			Expect(prov.privateKeyExists()).To(BeTrue())
-		})
-
-		It("Should detect absent keys", func() {
-			prov.conf.OverrideCertname = "na.mcollective"
-			Expect(prov.privateKeyExists()).To(BeFalse())
 		})
 	})
 

--- a/choria/security.go
+++ b/choria/security.go
@@ -92,6 +92,8 @@ func NewSecurityProvider(provider string, fw *Framework, log *logrus.Entry) (Sec
 	switch provider {
 	case "puppet":
 		return NewPuppetSecurity(fw, fw.Config, log)
+	case "file":
+		return NewFileSecurity(fw, fw.Config, log)
 	}
 
 	return nil, fmt.Errorf("unknown security provider: %s", provider)


### PR DESCRIPTION
This adds a security provider that handles simple on-disk files,
and can be configured for arbitrary paths to pub, pri, ca and
cache.

It does not support enrollment of course

The Puppet one was reworked to wrap the file one and augment it
with enrollment but basically it just configures the file one for
its functionality