### PR TITLE
(#297) fix enrollment on clean shells

### DIFF
--- a/choria/file_security_test.go
+++ b/choria/file_security_test.go
@@ -279,21 +279,19 @@ var _ = Describe("FileSSL", func() {
 		It("Should fail for foreign certs", func() {
 			pem, err = ioutil.ReadFile(filepath.Join("testdata", "foreign.pem"))
 			Expect(err).ToNot(HaveOccurred())
-			err, verified := prov.VerifyCertificate(pem, "rip.mcollective")
-			Expect(verified).To(BeFalse())
+			err := prov.VerifyCertificate(pem, "rip.mcollective")
 			Expect(err).To(MatchError("x509: certificate signed by unknown authority"))
 
 		})
 
 		It("Should fail for invalid names", func() {
-			err, verified := prov.VerifyCertificate(pem, "bob")
+			err := prov.VerifyCertificate(pem, "bob")
 			Expect(err).To(MatchError("x509: certificate is valid for rip.mcollective, not bob"))
-			Expect(verified).To(BeFalse())
 		})
 
 		It("Should accept valid certs", func() {
-			_, verified := prov.VerifyCertificate(pem, "rip.mcollective")
-			Expect(verified).To(BeTrue())
+			err := prov.VerifyCertificate(pem, "rip.mcollective")
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 

--- a/choria/security.go
+++ b/choria/security.go
@@ -64,7 +64,7 @@ type SecurityProvider interface {
 	HTTPClient(secure bool) (*http.Client, error)
 
 	// VerifyCertificate validates that a certificate is signed by a known CA
-	VerifyCertificate(certpem []byte, identity string) (error, bool)
+	VerifyCertificate(certpem []byte, identity string) error
 
 	// PublicCertPem retrieves pem data for the public certificate of the current identity
 	PublicCertPem() (*pem.Block, error)

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -45,6 +45,10 @@ func (b *brokerCommand) Run(wg *sync.WaitGroup) (err error) {
 	return
 }
 
+func (b *brokerCommand) Configure() error {
+	return nil
+}
+
 // broker run
 func (r *brokerRunCommand) Setup() (err error) {
 	if broker, ok := cmdWithFullCommand("broker"); ok {
@@ -55,6 +59,10 @@ func (r *brokerRunCommand) Setup() (err error) {
 	}
 
 	return
+}
+
+func (b *brokerRunCommand) Configure() error {
+	return nil
 }
 
 func (r *brokerRunCommand) Run(wg *sync.WaitGroup) (err error) {

--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -20,6 +20,10 @@ func (b *buildinfoCommand) Setup() (err error) {
 	return
 }
 
+func (b *buildinfoCommand) Configure() (err error) {
+	return nil
+}
+
 func (b *buildinfoCommand) Run(wg *sync.WaitGroup) (err error) {
 	defer wg.Done()
 

--- a/cmd/command.go
+++ b/cmd/command.go
@@ -18,6 +18,7 @@ type runableCmd interface {
 	Run(wg *sync.WaitGroup) error
 	FullCommand() string
 	Cmd() *kingpin.CmdClause
+	Configure() error
 }
 
 func (c *command) FullCommand() string {

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -21,14 +21,21 @@ func (e *enrollCommand) Setup() (err error) {
 	return
 }
 
+func (e *enrollCommand) Configure() error {
+	config.DisableSecurityProviderVerify = true
+
+	if e.cn != "" {
+		config.OverrideCertname = e.cn
+	}
+
+	return nil
+}
+
 func (e *enrollCommand) Run(wg *sync.WaitGroup) (err error) {
 	defer wg.Done()
 
-	if e.cn != "" {
-		c.Config.OverrideCertname = e.cn
-	}
+	fmt.Printf("Enrolling with the Security System using certname %s\n", c.Certname())
 
-	fmt.Println("Enrolling with the Security System")
 	err = c.Enroll(ctx, 250*time.Second, func(try int) { fmt.Printf("Attempting to download certificate for %s, try %d.\n", c.Certname(), try) })
 	if err != nil {
 		kingpin.Errorf("Could not enroll: %s", err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -36,6 +36,12 @@ func (b *serverCommand) Run(wg *sync.WaitGroup) (err error) {
 	return
 }
 
+func (e *serverCommand) Configure() error {
+	config.DisableSecurityProviderVerify = true
+
+	return nil
+}
+
 // server run
 func (r *serverRunCommand) Setup() (err error) {
 	if broker, ok := cmdWithFullCommand("server"); ok {
@@ -46,6 +52,12 @@ func (r *serverRunCommand) Setup() (err error) {
 	}
 
 	return
+}
+
+func (e *serverRunCommand) Configure() error {
+	config.DisableSecurityProviderVerify = true
+
+	return nil
 }
 
 func (r *serverRunCommand) Run(wg *sync.WaitGroup) (err error) {

--- a/glide.lock
+++ b/glide.lock
@@ -41,7 +41,7 @@ imports:
   - proto
   - protoc-gen-gogo/descriptor
 - name: github.com/golang/mock
-  version: 22bbf0ddf08105dfa364d0a2fa619dfa71014af5
+  version: 8b2eeeb0ca5f56c78bec5efde9c4a21d9201126c
   subpackages:
   - gomock
   - mockgen


### PR DESCRIPTION
This fixes enrollment on shells that's never been enrolled before
by reordering initialization in the command framework so individual
commands can modify the config before the framework is created

Also fixes other issues:

  * PEM encode private keys
  * Improve detection of files existing
  * Fails early when the shell already has security files
  * Cleans up a badly designed interface in certificate validation