### PR TITLE
(#324) allow the package group to be set for custom builds

### DIFF
--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -36,6 +36,7 @@ foss:
       release: 1
       manage_conf: 1
       contact: R.I.Pienaar <rip@devco.net>
+      rpm_group: System Environment/Base
 
     el5_32:
       template: el/el6

--- a/packager/templates/el/el6/choria.spec
+++ b/packager/templates/el/el6/choria.spec
@@ -9,6 +9,7 @@
 %define binary {{cpkg_binary}}
 %define tarball {{cpkg_tarball}}
 %define contact {{cpkg_contact}}
+%define pkggroup {{cpkg_rpm_group}}
 
 Name: %{pkgname}
 Version: %{version}
@@ -16,13 +17,15 @@ Release: %{release}.%{dist}
 Summary: The Choria Orchestrator Server
 License: Apache-2.0
 URL: https://choria.io
-Group: System Tools
+Group: %{pkggroup}
 Source0: %{tarball}
 Packager: %{contact}
 BuildRoot: %{_tmppath}/%{pkgname}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
 The Choria Orchestrator Server and Broker
+
+Please visit https://choria.io for more information
 
 %prep
 %setup -q

--- a/packager/templates/el/el6/config.yaml
+++ b/packager/templates/el/el6/config.yaml
@@ -6,6 +6,7 @@ required_properties:
   - contact
   - dist
   - target_arch
+  - rpm_group
 
 artifacts:
  - /usr/src/redhat/**/*.rpm

--- a/packager/templates/el/el7/choria.spec
+++ b/packager/templates/el/el7/choria.spec
@@ -9,6 +9,7 @@
 %define binary {{cpkg_binary}}
 %define tarball {{cpkg_tarball}}
 %define contact {{cpkg_contact}}
+%define pkggroup {{cpkg_rpm_group}}
 
 Name: %{pkgname}
 Version: %{version}
@@ -16,13 +17,15 @@ Release: %{release}.%{dist}
 Summary: The Choria Orchestrator Server
 License: Apache-2.0
 URL: https://choria.io
-Group: System Tools
+Group: %{pkggroup}
 Packager: %{contact}
 Source0: %{tarball}
 BuildRoot: %{_tmppath}/%{pkgname}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description
 The Choria Orchestrator Server and Broker
+
+Please visit https://choria.io for more information
 
 %prep
 %setup -q

--- a/packager/templates/el/el7/config.yaml
+++ b/packager/templates/el/el7/config.yaml
@@ -6,6 +6,7 @@ required_properties:
   - contact
   - dist
   - target_arch
+  - rpm_group
 
 artifacts:
  - /usr/src/redhat/**/*.rpm


### PR DESCRIPTION
This causes the rpm group to be set to System Environment/Base
by default but with the ability for people who do custom builds
to override it