### PR TITLE
(#326) improve startup process

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,10 @@ Here we configure the NATS Streaming Adapter.  It listens for `request` messages
 ```ini
 # sets up a named adapter, you can run many of the same type
 plugin.choria.adapters = discovery
-plugin.choria.adapters.discovery.type = natsstream
 
 # configure this discovery adapter
+plugin.choria.adapter.discovery.type = nats_stream
+
 # in this case the adapter does NATS->NATS Streaming so you need to configure both sides
 # here is NATS Streaming
 plugin.choria.adapter.discovery.stream.servers = stan1:4222,stan2:4222

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ task :build do
   sha = `git rev-parse --short HEAD`.chomp
   build = ENV["BUILD"] || "foss"
   packages = (ENV["PACKAGES"] || "").split(",")
-  packages = ["el5_32", "el5_64", "el6_32", "el6_64", "el7_64", "xenial_64", "xenial_64", "xenial_32"] if packages.empty?
+  packages = ["el5_32", "el5_64", "el6_32", "el6_64", "el7_64", "xenial_64", "xenial_64"] if packages.empty?
   go_version = ENV["GOVERSION"] || "1.10"
 
   source = "/go/src/github.com/choria-io/go-choria"

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -78,7 +78,7 @@ func (fw *Framework) setupSecurity() error {
 	case "file":
 		fw.security, err = filesec.New(filesec.WithChoriaConfig(fw.Config), filesec.WithLog(fw.Logger("security")))
 	default:
-		err = fmt.Errorf("Unknown security provider %s", fw.Config.Choria.SecurityProvider)
+		err = fmt.Errorf("unknown security provider %s", fw.Config.Choria.SecurityProvider)
 	}
 
 	if err != nil {

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -62,7 +62,7 @@ func (r *brokerRunCommand) Setup() (err error) {
 }
 
 func (b *brokerRunCommand) Configure() error {
-	return nil
+	return commonConfigure()
 }
 
 func (r *brokerRunCommand) Run(wg *sync.WaitGroup) (err error) {

--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/config"
 	"github.com/choria-io/go-protocol/protocol"
 	gnatsd "github.com/nats-io/gnatsd/server"
 )
@@ -21,7 +22,15 @@ func (b *buildinfoCommand) Setup() (err error) {
 }
 
 func (b *buildinfoCommand) Configure() (err error) {
-	return nil
+	cfg, err = config.NewDefaultConfig()
+	if err != nil {
+		return fmt.Errorf("Could not create default configuration: %s", err)
+	}
+
+	cfg.DisableSecurityProviderVerify = true
+	cfg.Choria.SecurityProvider = "file"
+
+	return
 }
 
 func (b *buildinfoCommand) Run(wg *sync.WaitGroup) (err error) {

--- a/cmd/enroll.go
+++ b/cmd/enroll.go
@@ -22,6 +22,11 @@ func (e *enrollCommand) Setup() (err error) {
 }
 
 func (e *enrollCommand) Configure() error {
+	err = commonConfigure()
+	if err != nil {
+		return err
+	}
+
 	cfg.DisableSecurityProviderVerify = true
 
 	if e.cn != "" {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -55,6 +55,11 @@ func (r *serverRunCommand) Setup() (err error) {
 }
 
 func (e *serverRunCommand) Configure() error {
+	err = commonConfigure()
+	if err != nil {
+		return err
+	}
+
 	cfg.DisableSecurityProviderVerify = true
 
 	return nil

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,7 +12,7 @@ import:
 - package: github.com/nats-io/go-nats-streaming
   version: 0.3.4
 - package: github.com/satori/go.uuid
-  version: ^1.1.0
+  version: ^1.2.0
 - package: github.com/tidwall/gjson
 - package: github.com/tidwall/match
 - package: github.com/xeipuuv/gojsonschema
@@ -24,6 +24,7 @@ import:
 - package: github.com/onsi/gomega
   version: ^1
 - package: github.com/ghodss/yaml
+  version: ^1.0.0
   subpackages:
   - encoders/builtin
   - util


### PR DESCRIPTION
Primarily this ensures that the 'file' security provider is used
by buildinfo so that it can show its output even in cases where
puppet does not exist

This reworks the cmd startup a bit to make things overall a bit
better and allow individual sub commands to do their own thing
rather than the special case if statement that was in cmd.go