### PR TITLE
(#343) do not confuse identity and certname

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -44,15 +44,5 @@ var _ = Describe("Choria/Config", func() {
 			Expect(c.Option("plugin.package.setting", "default")).To(Equal("1"))
 			Expect(c.Option("plugin.package.other_setting", "default")).To(Equal("default"))
 		})
-
-		It("Should support environment override", func() {
-			old := os.Getenv("MCOLLECTIVE_CERTNAME")
-			os.Setenv("MCOLLECTIVE_CERTNAME", "bob.choria")
-			defer os.Setenv("MCOLLECTIVE_CERTNAME", old)
-
-			c, err := NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(c.Identity).To(Equal("bob.choria"))
-		})
 	})
 })


### PR DESCRIPTION
certname = who is running choria
identity = where do they run it

As part of the security provider work and recent attempts to remedy
this these 2 concepts got merged and certname concept was lost

This restores part of the correct behaviour with a follup in the
security providers rounding out the fix