### PR TITLE
(#353) handle STAN connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ I imagine a number of other scenarios:
 
 Here we configure the NATS Streaming Adapter.  It listens for `request` messages from the old school MCollective Registration system and republish those messages into NATS Streaming where you can process them at a more leisurely pace and configure retention to your own needs.
 
+Reliable connection handling requires at least NATS Streaming Server 0.10.0
+
 ```ini
 # sets up a named adapter, you can run many of the same type
 plugin.choria.adapters = discovery

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: dc9b03ea8f0db885eb1f1e98bd7564d025a3c53af712b54f9b5d86cb3fdd4c17
-updated: 2018-06-19T18:31:47.157736+02:00
+hash: 4f2c9eb790e37bb9b19093d404de33f720e3af029316a436d1e6c6942104bbfb
+updated: 2018-06-26T09:30:27.690428+03:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -47,7 +47,7 @@ imports:
   - encoders/builtin
   - util
 - name: github.com/gogo/protobuf
-  version: 30cf7ac33676b5786e78c746683f0d4cd64fa75b
+  version: 99cb9b23110011cc45571c901ecae6f6f5e65cd3
   subpackages:
   - gogoproto
   - proto
@@ -58,7 +58,7 @@ imports:
   - gomock
   - mockgen
 - name: github.com/golang/protobuf
-  version: 3a3da3a4e26776cc22a79ef46d5d58477532dede
+  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -79,11 +79,11 @@ imports:
   - encoders/builtin
   - util
 - name: github.com/nats-io/go-nats-streaming
-  version: 6e620057a207bd61e992c1c5b6a2de7b6a4cb010
+  version: e15a53f85e4932540600a16b56f6c4f65f58176f
   subpackages:
   - pb
 - name: github.com/nats-io/nuid
-  version: 3e58d42c9cfe5cd9429f1a21ad8f35cd859ba829
+  version: 28b996b57a46dd0c2aa3a3dc7fa8780878331d00
 - name: github.com/onsi/ginkgo
   version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
   subpackages:
@@ -124,27 +124,25 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: fe93d378a6b03758a2c1b65e86cf630bf78681c0
+  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
   subpackages:
-  - internal/util
-  - nfs
   - xfs
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: afaeb9562041a8018c74e006551143666aed08bf
+  version: 01f00f129617a6fe98941fb920d6c760241b54d2
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: github.com/xeipuuv/gojsonpointer
@@ -184,7 +182,7 @@ imports:
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: golang.org/x/text
-  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
+  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
   subpackages:
   - encoding
   - encoding/charmap

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,7 +10,7 @@ import:
 - package: github.com/nats-io/go-nats
   version: ^1
 - package: github.com/nats-io/go-nats-streaming
-  version: 0.3.4
+  version: ^0.4.0
 - package: github.com/satori/go.uuid
   version: ^1.2.0
 - package: github.com/tidwall/gjson


### PR DESCRIPTION
This uses the NATS Streaming feature found in streaming server >= 0.10.0
to detect and handle stream ping timeouts