### PR TITLE
(#350) support fire and forget style requests

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4f2c9eb790e37bb9b19093d404de33f720e3af029316a436d1e6c6942104bbfb
-updated: 2018-06-26T09:30:27.690428+03:00
+hash: 6da59bb713c95ac6d820c13d035b630d7decc12231f7bf2a0ff4b070a6dea5ef
+updated: 2018-06-28T15:46:17.507429+03:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/choria-io/go-client
-  version: 9dacef621911a73228e4b77ba88b616d286d531b
+  version: bd8c6da1960aba740c875965c5d51b1cb4a5fe30
   subpackages:
   - client
   - discovery/broadcast
@@ -58,7 +58,7 @@ imports:
   - gomock
   - mockgen
 - name: github.com/golang/protobuf
-  version: df1d3ca07d2d07bba352d5b73c4313b4e2a6203e
+  version: 3a3da3a4e26776cc22a79ef46d5d58477532dede
   subpackages:
   - proto
 - name: github.com/matttproud/golang_protobuf_extensions
@@ -83,7 +83,7 @@ imports:
   subpackages:
   - pb
 - name: github.com/nats-io/nuid
-  version: 28b996b57a46dd0c2aa3a3dc7fa8780878331d00
+  version: 3e58d42c9cfe5cd9429f1a21ad8f35cd859ba829
 - name: github.com/onsi/ginkgo
   version: fa5fabab2a1bfbd924faf4c067d07ae414e2aedf
   subpackages:
@@ -124,25 +124,27 @@ imports:
   - prometheus
   - prometheus/promhttp
 - name: github.com/prometheus/client_model
-  version: 6f3806018612930941127f2a7c6c453ba2c527d2
+  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 61f87aac8082fa8c3c5655c7608d7478d46ac2ad
+  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: e645f4e5aaa8506fc71d6edbc5c4ff02c04c46f2
+  version: fe93d378a6b03758a2c1b65e86cf630bf78681c0
   subpackages:
+  - internal/util
+  - nfs
   - xfs
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: 01f00f129617a6fe98941fb920d6c760241b54d2
+  version: afaeb9562041a8018c74e006551143666aed08bf
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: github.com/xeipuuv/gojsonpointer
@@ -182,7 +184,7 @@ imports:
   version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 testImports:
 - name: golang.org/x/text
-  version: 5cec4b58c438bd98288aeb248bab2c1840713d21
+  version: 5c1cf69b5978e5a34c5f9ba09a83e56acc4b7877
   subpackages:
   - encoding
   - encoding/charmap

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,7 +43,7 @@ import:
 - package: github.com/choria-io/go-security
   version: 0.1.0
 - package: github.com/choria-io/go-client
-  version: 0.0.1
+  version: 0.1.0
   subpackages:
   - client
 - package: go.uber.org/atomic

--- a/mcorpc/client/client.go
+++ b/mcorpc/client/client.go
@@ -206,7 +206,7 @@ func (r *RPC) setupMessage(ctx context.Context, action string, payload interface
 	cl = r.cl
 
 	if r.cl == nil {
-		if r.opts.BatchSize == len(r.opts.Targets) {
+		if r.opts.BatchSize == len(r.opts.Targets) || r.opts.ProcessReplies == false {
 			cl, err = r.unbatchedClient()
 			if err != nil {
 				return nil, nil, err
@@ -280,6 +280,10 @@ func (r *RPC) request(ctx context.Context, msg *choria.Message, cl ChoriaClient)
 }
 
 func (r *RPC) handlerFactory(ctx context.Context, cancel func()) cclient.Handler {
+	if !r.opts.ProcessReplies {
+		return nil
+	}
+
 	handler := func(ctx context.Context, rawmsg *choria.ConnectorMessage) {
 		reply, err := r.fw.NewReplyFromTransportJSON(rawmsg.Data, false)
 		if err != nil {

--- a/mcorpc/client/options.go
+++ b/mcorpc/client/options.go
@@ -20,7 +20,6 @@ type RequestOptions struct {
 	Collective      string
 	ReplyTo         string
 	ProcessReplies  bool
-	ReceiveReplies  bool
 	Replies         chan *choria.ConnectorMessage
 	Progress        bool
 	Timeout         time.Duration
@@ -45,7 +44,6 @@ func NewRequestOptions(fw *choria.Framework, ddl *agent.DDL) *RequestOptions {
 		RequestType:     "direct_request",
 		Collective:      fw.Config.MainCollective,
 		ProcessReplies:  true,
-		ReceiveReplies:  true,
 		Progress:        false,
 		Workers:         3,
 		stats:           NewStats(),
@@ -95,7 +93,7 @@ func (o *RequestOptions) ConfigureMessage(msg *choria.Message) error {
 	// the reply target is such that we'd probably not receive replies
 	// so disable processing replies
 	if stdtarget != o.ReplyTo {
-		o.ReceiveReplies = false
+		o.ProcessReplies = false
 	}
 
 	err = msg.SetReplyTo(o.ReplyTo)
@@ -173,7 +171,7 @@ func Collective(c string) RequestOption {
 func ReplyTo(r string) RequestOption {
 	return func(o *RequestOptions) {
 		o.ReplyTo = r
-		o.ReceiveReplies = false
+		o.ProcessReplies = false
 	}
 }
 

--- a/mcorpc/client/options_test.go
+++ b/mcorpc/client/options_test.go
@@ -40,7 +40,7 @@ var _ = Describe("McoRPC/Client/Options", func() {
 			Expect(o.Targets).To(Equal([]string{"host1", "host2"}))
 			Expect(msg.Type()).To(Equal("request"))
 			Expect(o.ReplyTo).To(Equal(msg.ReplyTo()))
-			Expect(o.ReceiveReplies).To(BeTrue())
+			Expect(o.ProcessReplies).To(BeTrue())
 			Expect(o.totalStats.discoveredNodes).To(Equal([]string{"host1", "host2"}))
 			Expect(o.totalStats.RequestID).To(Equal(msg.RequestID))
 			Expect(o.RequestID).To(Equal(msg.RequestID))
@@ -69,7 +69,7 @@ var _ = Describe("McoRPC/Client/Options", func() {
 
 			Expect(msg.ReplyTo()).To(Equal("test.target"))
 			Expect(o.ReplyTo).To(Equal(msg.ReplyTo()))
-			Expect(o.ReceiveReplies).To(BeFalse())
+			Expect(o.ProcessReplies).To(BeFalse())
 		})
 	})
 
@@ -79,7 +79,6 @@ var _ = Describe("McoRPC/Client/Options", func() {
 			Expect(o.RequestType).To(Equal("direct_request"))
 			Expect(o.Collective).To(Equal("mcollective"))
 			Expect(o.ProcessReplies).To(BeTrue())
-			Expect(o.ReceiveReplies).To(BeTrue())
 			Expect(o.Progress).To(BeFalse())
 			Expect(o.Timeout).To(Equal(time.Duration(182) * time.Second))
 			Expect(o.stats).ToNot(BeNil())


### PR DESCRIPTION
This adds fire and forget requests to the mcorpc client and supports
this in batched mode too