### PR TITLE
(#350) allow the client name to be set

### DIFF
--- a/broker/federation/reply_transformer.go
+++ b/broker/federation/reply_transformer.go
@@ -42,7 +42,7 @@ func NewChoriaReplyTransformer(workers int, capacity int, broker *FederationBrok
 
 			cm.Message.SetUnfederated()
 
-			logger.Infof("Received a reply message '%s' via %s", cm.RequestID, cm.Message.SenderID())
+			logger.Debugf("Received a reply message '%s' via %s", cm.RequestID, cm.Message.SenderID())
 
 			self.out <- cm
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0835a1363e84f9937b53050f981d78ee34f5f12044ea3243c77bc8e7360c2fe8
-updated: 2018-06-29T08:28:10.28675+03:00
+hash: ad6924b15b4ec367f5624b6daa36551848a1a17c284917323c8c95cd43edbbed
+updated: 2018-07-02T17:51:22.406122+03:00
 imports:
 - name: github.com/alecthomas/template
   version: a0175ee3bccc567396460bf5acd36800cb10c49c
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - quantile
 - name: github.com/choria-io/go-client
-  version: 47772ba6aaf22133b163d3212936039f20f56dfc
+  version: 3abc5542c103b7a2c1990c099097dc756c0de4dc
   subpackages:
   - client
   - discovery/broadcast
@@ -142,7 +142,7 @@ imports:
 - name: github.com/sirupsen/logrus
   version: c155da19408a8799da419ed3eeb0cb5db0ad5dbc
 - name: github.com/tidwall/gjson
-  version: 01f00f129617a6fe98941fb920d6c760241b54d2
+  version: f123b340873a0084cb27267eddd8ff615115fbff
 - name: github.com/tidwall/match
   version: 1731857f09b1f38450e2c12409748407822dc6be
 - name: github.com/xeipuuv/gojsonpointer

--- a/glide.yaml
+++ b/glide.yaml
@@ -43,7 +43,7 @@ import:
 - package: github.com/choria-io/go-security
   version: 0.1.0
 - package: github.com/choria-io/go-client
-  version: ^0.1.1
+  version: ^0.2.0
   subpackages:
   - client
 - package: go.uber.org/atomic

--- a/mcorpc/client/client.go
+++ b/mcorpc/client/client.go
@@ -149,7 +149,9 @@ func (r *RPC) Discover(ctx context.Context, f *protocol.Filter) (n []string, err
 	r.opts.totalStats.StartDiscover()
 	defer r.opts.totalStats.EndDiscover()
 
-	n, err = b.Discover(ctx, broadcast.Filter(f), broadcast.Timeout(time.Duration(r.fw.Config.DiscoveryTimeout)*time.Second))
+	timeout := time.Duration(r.fw.Config.DiscoveryTimeout) * time.Second
+
+	n, err = b.Discover(ctx, broadcast.Filter(f), broadcast.Timeout(timeout), broadcast.Name(r.opts.ConnectionName))
 	if err != nil {
 		return n, err
 	}
@@ -229,6 +231,7 @@ func (r *RPC) unbatchedClient() (cl ChoriaClient, err error) {
 		cclient.Timeout(r.opts.Timeout),
 		cclient.OnPublishStart(r.opts.stats.StartPublish),
 		cclient.OnPublishFinish(r.opts.stats.EndPublish),
+		cclient.Name(r.opts.ConnectionName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not setup client: %s", err)
@@ -250,6 +253,7 @@ func (r *RPC) batchedClient(ctx context.Context, msgid string) (cl ChoriaClient,
 		cclient.OnPublishStart(r.opts.stats.StartPublish),
 		cclient.OnPublishFinish(r.opts.stats.EndPublish),
 		cclient.Connection(conn),
+		cclient.Name(r.opts.ConnectionName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not set up batched client: %s", err)

--- a/mcorpc/client/options.go
+++ b/mcorpc/client/options.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/choria-io/go-choria/choria"
@@ -25,6 +26,7 @@ type RequestOptions struct {
 	Timeout         time.Duration
 	Handler         Handler
 	RequestID       string
+	ConnectionName  string
 
 	totalStats *Stats
 
@@ -46,6 +48,7 @@ func NewRequestOptions(fw *choria.Framework, ddl *agent.DDL) *RequestOptions {
 		ProcessReplies:  true,
 		Progress:        false,
 		Workers:         3,
+		ConnectionName:  fmt.Sprintf("%s-mcorpc-%s", fw.Certname(), fw.NewRequestID()),
 		stats:           NewStats(),
 		totalStats:      NewStats(),
 		fw:              fw,
@@ -112,6 +115,17 @@ func (o *RequestOptions) ConfigureMessage(msg *choria.Message) error {
 // Stats retrieves the stats for the completed request
 func (o *RequestOptions) Stats() *Stats {
 	return o.totalStats
+}
+
+// ConnectionName sets the prefix used for various connection names
+//
+// Setting this when making many clients will minimise prometheus
+// metrics being created - 2 or 3 per client which with random generated
+// names will snowball over time
+func ConnectionName(n string) RequestOption {
+	return func(o *RequestOptions) {
+		o.ConnectionName = n
+	}
 }
 
 // WithProgress enable a progress writer

--- a/mcorpc/client/options_test.go
+++ b/mcorpc/client/options_test.go
@@ -181,4 +181,11 @@ var _ = Describe("McoRPC/Client/Options", func() {
 			Expect(seen).To(BeTrue())
 		})
 	})
+
+	Describe("ConnectionName", func() {
+		It("Should set the name", func() {
+			ConnectionName("ginkgo")(o)
+			Expect(o.ConnectionName).To(Equal("ginkgo"))
+		})
+	})
 })


### PR DESCRIPTION
This avoid prometheus metric leaks when many clients are being made
since each client would have a unique name and unique stats leading to a
huge buildup of metric labels