### PR TITLE
(#359) ensure subscription copiers exit correctly

### DIFF
--- a/mcorpc/client/client.go
+++ b/mcorpc/client/client.go
@@ -346,7 +346,7 @@ func (r *RPC) connectBatchedConnection(ctx context.Context, name string) (Connec
 	closer := func() {
 		select {
 		case <-ctx.Done():
-			r.log.Debug("Closing connection")
+			r.log.Debugf("Closing batched connection %s", name)
 			connector.Close()
 		}
 	}


### PR DESCRIPTION
The subscription copiers would not always exit correctly which as
they are being closed in the Close() call would lead to stale
NATS connections and a leak in go routines when using the client
in a long running program

This ensures that they will exit properly and stops the leaks