### PR TITLE
(#377) include the RequestID in nats stream messages

### DIFF
--- a/broker/adapter/natsstream/adapter.go
+++ b/broker/adapter/natsstream/adapter.go
@@ -16,6 +16,7 @@ type adaptable interface {
 	Message() string
 	SenderID() string
 	Time() time.Time
+	RequestID() string
 }
 
 // NatStream is an adapter that connects a NATS topic with messages

--- a/broker/adapter/natsstream/output.go
+++ b/broker/adapter/natsstream/output.go
@@ -35,10 +35,11 @@ type stream struct {
 }
 
 type msg struct {
-	Protocol string    `json:"protocol"`
-	Data     string    `json:"data"`
-	Sender   string    `json:"sender"`
-	Time     time.Time `json:"time"`
+	Protocol  string    `json:"protocol"`
+	Data      string    `json:"data"`
+	Sender    string    `json:"sender"`
+	Time      time.Time `json:"time"`
+	RequestID string    `json:"requestid"`
 }
 
 func newStream(name string, work chan adaptable, logger *log.Entry) ([]*stream, error) {
@@ -196,10 +197,11 @@ func (sc *stream) publisher(ctx context.Context, wg *sync.WaitGroup) {
 		defer obs.ObserveDuration()
 
 		m := msg{
-			Protocol: "choria:adapters:natsstream:output:1",
-			Data:     r.Message(),
-			Sender:   r.SenderID(),
-			Time:     r.Time().UTC(),
+			Protocol:  "choria:adapters:natsstream:output:1",
+			Data:      r.Message(),
+			Sender:    r.SenderID(),
+			Time:      r.Time().UTC(),
+			RequestID: r.RequestID(),
 		}
 
 		j, err := json.Marshal(m)


### PR DESCRIPTION
It's typical to use custom reply to systems to build async requests
but without knowing which replies belong to which request its a bit
useless