### PR TITLE
(#384) require request options to always be given to rpc client

### DIFF
--- a/mcorpc/client/client.go
+++ b/mcorpc/client/client.go
@@ -108,12 +108,8 @@ func New(fw *choria.Framework, agent string, opts ...Option) (rpc *RPC, err erro
 	return rpc, nil
 }
 
-// SetOptions sets the options that apply to calls to Do and Discover on this client
-// where those do accept their own options they will get merged with these
-func (r *RPC) SetOptions(opts ...RequestOption) {
-	if r.opts == nil {
-		r.opts = NewRequestOptions(r.fw, r.ddl)
-	}
+func (r *RPC) setOptions(opts ...RequestOption) {
+	r.opts = NewRequestOptions(r.fw, r.ddl)
 
 	for _, opt := range opts {
 		opt(r.opts)
@@ -177,9 +173,7 @@ func (r *RPC) Do(ctx context.Context, action string, payload interface{}, opts .
 // Discover performs a broadcast discovery, using this method will update the client to
 // with these discovered nodes and update appropriate stats
 func (r *RPC) Discover(ctx context.Context, f *protocol.Filter, opts ...RequestOption) (n []string, err error) {
-	// its a common pattern to setup a client - like discovery data etc - and then reuse it for a few calls
-	// this ensures that this pattern is possible, Reset() will clear opts here and it'll effectively start fresh
-	r.SetOptions(opts...)
+	r.setOptions(opts...)
 
 	b := broadcast.New(r.fw)
 
@@ -207,9 +201,7 @@ func (r *RPC) DiscoveredNodes() []string {
 }
 
 func (r *RPC) setupMessage(ctx context.Context, action string, payload interface{}, opts ...RequestOption) (msg *choria.Message, cl ChoriaClient, err error) {
-	// its a common pattern to setup a client - like discovery data etc - and then reuse it for a few calls
-	// this ensures that this pattern is possible, Reset() will clear opts here and it'll effectively start fresh
-	r.SetOptions()
+	r.setOptions()
 
 	// regardless of above, we always need new stats
 	r.opts.totalStats = NewStats()

--- a/mcorpc/client/client_test.go
+++ b/mcorpc/client/client_test.go
@@ -70,9 +70,9 @@ var _ = Describe("McoRPC/Client", func() {
 
 	Describe("SetOptions", func() {
 		It("Should set the options", func() {
-			rpc.SetOptions()
+			rpc.setOptions()
 			Expect(rpc.opts.BatchSize).To(Equal(0))
-			rpc.SetOptions(InBatches(10, 1))
+			rpc.setOptions(InBatches(10, 1))
 			Expect(rpc.opts.BatchSize).To(Equal(10))
 		})
 	})
@@ -186,28 +186,6 @@ var _ = Describe("McoRPC/Client", func() {
 			d, err := stats.RequestDuration()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(d).ToNot(BeZero())
-		})
-
-		It("Should support reusing options", func() {
-			Expect(rpc.opts).To(BeNil())
-			cl.EXPECT().Request(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			res1, err := rpc.Do(
-				ctx,
-				"test_action",
-				request{Testing: true},
-				Targets(strings.Fields("test.sender.0 test.sender.1")),
-			)
-			Expect(err).ToNot(HaveOccurred())
-			o := rpc.opts
-
-			res2, err := rpc.Do(
-				ctx,
-				"test_action",
-				request{Testing: true},
-			)
-
-			Expect(o).To(Equal(rpc.opts))
-			Expect(res1.Stats()).ToNot(Equal(res2.Stats()))
 		})
 
 		It("Should support batched mode", func() {


### PR DESCRIPTION
The ruby like pattern where options are set and reused over and over,
while convenient, is prone to error and undefined behaviour, I thought
we'd keep that here but in practise that just didnt transpose well to
Go so lets insist its given always