### PR TITLE
(#426) default when in provisioning mode and the config does not exist

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/choria-io/go-choria/build"
+	"github.com/choria-io/go-choria/choria"
+	"github.com/choria-io/go-choria/config"
 	"github.com/choria-io/go-choria/server"
 	log "github.com/sirupsen/logrus"
 )
@@ -55,9 +57,24 @@ func (r *serverRunCommand) Setup() (err error) {
 }
 
 func (e *serverRunCommand) Configure() error {
-	err = commonConfigure()
-	if err != nil {
-		return err
+	if debug {
+		log.SetOutput(os.Stdout)
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Logging at debug level due to CLI override")
+	}
+
+	if choria.FileExist(configFile) {
+		cfg, err = config.NewConfig(configFile)
+		if err != nil {
+			return fmt.Errorf("could not parse configuration: %s", err)
+		}
+	} else if build.ProvisionBrokerURLs != "" {
+		cfg, err = config.NewDefaultConfig()
+		if err != nil {
+			return fmt.Errorf("could not create default configuration for provisioning: %s", err)
+		}
+	} else {
+		return fmt.Errorf("configuration file %s was not found", configFile)
 	}
 
 	cfg.DisableSecurityProviderVerify = true


### PR DESCRIPTION
For the server command it will:

 - use the given config file if it exist
 - if build.ProvisionBrokerURLs is not empty use defaults
 - fail

This should allow provisioning to recover from entire config file loss