### PR TITLE
(#428) add a tool to view provisioning targets

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -133,7 +133,6 @@ func Run() (err error) {
 	}
 
 	if err != nil {
-		log.Errorf("Shutting down due to: %s", err)
 		cancel()
 	}
 

--- a/cmd/tool_provisioner.go
+++ b/cmd/tool_provisioner.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/choria-io/go-choria/provtarget"
+)
+
+type provisionerCommand struct {
+	command
+}
+
+func (p *provisionerCommand) Setup() (err error) {
+	if tool, ok := cmdWithFullCommand("tool"); ok {
+		p.cmd = tool.Cmd().Command("provisioner", "View the provisioner targets based on related plugins")
+	}
+
+	return nil
+}
+
+func (p *provisionerCommand) Configure() error {
+	err := commonConfigure()
+	if err != nil {
+		return err
+	}
+
+	cfg.DisableSecurityProviderVerify = true
+
+	return nil
+}
+
+func (p *provisionerCommand) Run(wg *sync.WaitGroup) (err error) {
+	defer wg.Done()
+
+	if !c.ProvisionMode() {
+		return fmt.Errorf("not a server compiled for auto provisioning")
+	}
+
+	fmt.Printf("Attempting provisioner resolution using: %s\n", provtarget.Name())
+
+	targets, err := provtarget.Targets(c.Logger("provisioner"))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Provisioning using %d broker(s):\n\n", len(targets))
+
+	for _, t := range targets {
+		fmt.Printf("\t%s", t.String())
+	}
+
+	fmt.Println()
+
+	return nil
+}
+
+func init() {
+	cli.commands = append(cli.commands, &provisionerCommand{})
+}


### PR DESCRIPTION
This tool runs the provisioning target plugin and shows the result
with optional debug logging