### PR TITLE
(#444) Sets a default LimitNOFILE=51200 for Choria Broker.

### DIFF
--- a/packager/templates/debian/generic/broker.service
+++ b/packager/templates/debian/generic/broker.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 StandardOutput=syslog
 StandardError=syslog
+LimitNOFILE=51200
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf

--- a/packager/templates/el/el6/broker.init
+++ b/packager/templates/el/el6/broker.init
@@ -23,6 +23,9 @@ lockfile="/var/lock/subsys/${prog}"
 logfile="/var/log/${prog}"
 conffile="{{cpkg_etcdir}}/broker.conf"
 
+# set the open file limit to allow over 1024 connections
+ulimit -n 51200
+
 # pull in sysconfig settings
 [ -e /etc/sysconfig/${prog} ] && . /etc/sysconfig/${prog}
 

--- a/packager/templates/el/el7/broker.service
+++ b/packager/templates/el/el7/broker.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 StandardOutput=syslog
 StandardError=syslog
+LimitNOFILE=51200
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf


### PR DESCRIPTION
Since a default Choria deployment aims for (max.) 50.000 nodes, it is useful to set a matching value for the max. open files in the systemd unit-file. 

Tested on RHEL7 and Debian Jessie.

