### PR TITLE
(#462) allow custom packagers to define their own start position

### DIFF
--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -43,6 +43,7 @@ foss:
       manage_conf: 1
       contact: R.I.Pienaar <rip@devco.net>
       rpm_group: System Environment/Base
+      server_start_level: 50
 
     el5_32:
       template: el/el6

--- a/packager/templates/el/el6/config.yaml
+++ b/packager/templates/el/el6/config.yaml
@@ -7,6 +7,7 @@ required_properties:
   - dist
   - target_arch
   - rpm_group
+  - server_start_level
 
 artifacts:
  - /usr/src/redhat/**/*.rpm

--- a/packager/templates/el/el6/server.init
+++ b/packager/templates/el/el6/server.init
@@ -10,6 +10,7 @@
 # Default-Stop:      0 1 6
 # Short-Description: Choria.IO Orchestration Server
 # Description:       Choria.IO Orchestration Server
+# chkconfig          2345 {{cpkg_server_start_level}} 05
 ### END INIT INFO
 
 # source function library


### PR DESCRIPTION
Custom packages for el6 can now define where in the run level they
start, 50 is the default chkconfig uses but some might want to start
it at 99 and they can now do so in their packages by setting
server_start_level to an appropraite level