### PR TITLE
(#467) support writing server status regularly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Running `choria broker run --config /path/to/broker.cfg` will start the various 
 
 When enabled a vast cache of Prometheus compatible metrics are exposed under `/choria/prometheus`, use `plugin.choria.stats_port` and `plugin.choria.stats_address` to enable
 
+Additionally server status can be written regularly - 30 seconds interval by default:
+
+```yaml
+plugin.choria.status_file_path = /var/tmp/choria_status.json
+plugin.choria.status_update_interval = 30
+```
+
 ## Configurable Security Subsystems
 
 While the ruby Choria code only integrates with Puppet CA this daemon has multiple security systems and will in time not be tied to Puppet but will support SECP and FIPS compliance and more. The ruby code will gain parity in time.

--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,10 @@ type ChoriaPluginConfig struct {
 
 	// adapters
 	Adapters []string `confkey:"plugin.choria.adapters" type:"comma_split"`
+
+	// status file
+	StatusFilePath      string `confkey:"plugin.choria.status_file_path"`
+	StatusUpdateSeconds int    `confkey:"plugin.choria.status_update_interval" default:"30"`
 }
 
 // Config represents Choria configuration

--- a/server/agents/agents.go
+++ b/server/agents/agents.go
@@ -34,13 +34,13 @@ type ServerInfoSource interface {
 }
 
 type ServerStats struct {
-	Total      float64
-	Valid      float64
-	Invalid    float64
-	Passed     float64
-	Filtered   float64
-	Replies    float64
-	TTLExpired float64
+	Total      float64 `json:"total"`
+	Valid      float64 `json:"valid"`
+	Invalid    float64 `json:"invalid"`
+	Passed     float64 `json:"passed"`
+	Filtered   float64 `json:"filtered"`
+	Replies    float64 `json:"replies"`
+	TTLExpired float64 `json:"ttlexpired"`
 }
 
 type AgentReply struct {

--- a/server/processor.go
+++ b/server/processor.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/choria-io/go-protocol/protocol"
 
@@ -60,6 +61,8 @@ func (srv *Instance) handleRawMessage(ctx context.Context, wg *sync.WaitGroup, r
 	}
 
 	validatedCtr.WithLabelValues(srv.cfg.Identity).Inc()
+
+	srv.lastMsgProcessed = time.Now()
 
 	wg.Add(1)
 	go srv.agents.Dispatch(ctx, wg, replies, msg, req)


### PR DESCRIPTION
This supports writing a server status JSON file that helps monitors
to detect hanging, crashed etc server instances, it's of course
really hard to do this perfectly since no messages does not mean
down it might just be no one is using it.

So we will signal issues by exposing the last processed message time,
server uptime, connected server, is it in provisioning mode and some
basic internal stats