### PR TITLE
(#473) add a COMMAND_PREFIX for the el startup system

### DIFF
--- a/packager/templates/el/el6/server.init
+++ b/packager/templates/el/el6/server.init
@@ -22,6 +22,9 @@ lockfile="/var/lock/subsys/${prog}"
 logfile="/var/log/${prog}"
 conffile="{{cpkg_etcdir}}/server.conf"
 
+COMMAND_PREFIX=""
+EXTRA_OPTS=""
+
 # pull in sysconfig settings
 [ -e /etc/sysconfig/${prog} ] && . /etc/sysconfig/${prog}
 
@@ -43,7 +46,7 @@ start() {
 
     daemon \
       --pidfile=${pidfile} \
-      " { nohup ${exec} ${args} > ${logfile} 2>&1 & } ; sleep 0.5 ; [ -f ${pidfile} ]"
+      " { nohup ${COMMAND_PREFIX} ${exec} ${args} > ${logfile} 2>&1 & } ; sleep 0.5 ; [ -f ${pidfile} ]"
 
     RETVAL=$?
     echo

--- a/packager/templates/el/el6/server.sysconfig
+++ b/packager/templates/el/el6/server.sysconfig
@@ -1,1 +1,0 @@
-EXTRA_OPTS=""

--- a/packager/templates/el/el7/choria.spec
+++ b/packager/templates/el/el7/choria.spec
@@ -34,11 +34,13 @@ Please visit https://choria.io for more information
 
 %install
 rm -rf %{buildroot}
+%{__install} -d -m0755  %{buildroot}/etc/sysconfig
 %{__install} -d -m0755  %{buildroot}/usr/lib/systemd/system
 %{__install} -d -m0755  %{buildroot}/etc/logrotate.d
 %{__install} -d -m0755  %{buildroot}%{bindir}
 %{__install} -d -m0755  %{buildroot}%{etcdir}
 %{__install} -d -m0755  %{buildroot}/var/log
+%{__install} -m0644 dist/server.sysconfig %{buildroot}/etc/sysconfig/%{pkgname}-server
 %{__install} -m0644 dist/server.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-server.service
 %{__install} -m0644 dist/broker.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-broker.service
 %{__install} -m0644 dist/choria-logrotate %{buildroot}/etc/logrotate.d/%{pkgname}
@@ -79,7 +81,7 @@ fi
 /etc/logrotate.d/%{pkgname}
 /usr/lib/systemd/system/%{pkgname}-server.service
 /usr/lib/systemd/system/%{pkgname}-broker.service
-
+%config(noreplace)/etc/sysconfig/%{pkgname}-server
 
 %changelog
 * Tue Dec 05 2017 R.I.Pienaar <rip@devco.net>

--- a/packager/templates/el/el7/server.service
+++ b/packager/templates/el/el7/server.service
@@ -3,11 +3,12 @@ Description=The Choria Orchestrator Server
 After=network.target
 
 [Service]
+EnvironmentFile=/etc/sysconfig/{{cpkg_name}}-server
 StandardOutput=syslog
 StandardError=syslog
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf
+ExecStart=/bin/sh -c "${COMMAND_PREFIX} {{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf"
 KillMode=process
 
 [Install]

--- a/packager/templates/el/global/server.sysconfig
+++ b/packager/templates/el/global/server.sysconfig
@@ -1,0 +1,6 @@
+# These are additional flags to pass to the choria server invocation
+EXTRA_OPTS=""
+
+# This is a prefix command to invoke the server, use this is perhaps you want
+# to run choria in a namespace and wish to invoke nsenter or ip netns exec
+COMMAND_PREFIX=""


### PR DESCRIPTION
This allows someone set set COMMAND_PREFIX to something like:

  COMMAND_PREFIX="ip netns exec CHORIA"

which will then run the choria daemon in it's own namespace