### PR TITLE
(#476) Add configuration flag to always overwrite the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Generally each provider will have it's own settings, there are a few system wide
 |Setting|Default|Description|
 |-------|-------|-----------|
 |`plugin.security.provider`|`puppet`|The security provider to use, can be `puppet` or `file`|
+|`plugin.security.always_overwrite_cache`|`false`|Tell the security provider to always overwrite the certificate cache, can be `true`, or `false`|
 |`plugin.choria.security.privileged_users`|`\\.privileged.mcollective$`|Comma sep list of valid certificates for privileged client users.|
 |`plugin.choria.security.certname_whitelist`|`\\.mcollective$`|Comma sep list of valid certificates for normal client users.|
 

--- a/config/config.go
+++ b/config/config.go
@@ -77,10 +77,11 @@ type ChoriaPluginConfig struct {
 	RubyLibdir      []string `confkey:"plugin.choria.agent_provider.mcorpc.libdir" type:"path_split"`
 
 	// security plugin
-	PrivilegedUsers   []string `confkey:"plugin.choria.security.privileged_users" type:"comma_split" default:"\\.privileged.mcollective$"`
-	CertnameWhitelist []string `confkey:"plugin.choria.security.certname_whitelist" type:"comma_split" default:"\\.mcollective$"`
-	Serializer        string   `confkey:"plugin.choria.security.serializer" validate:"enum=json,yaml"`
-	SecurityProvider  string   `confkey:"plugin.security.provider" default:"puppet" validate:"enum=puppet,file"`
+	PrivilegedUsers              []string `confkey:"plugin.choria.security.privileged_users" type:"comma_split" default:"\\.privileged.mcollective$"`
+	CertnameWhitelist            []string `confkey:"plugin.choria.security.certname_whitelist" type:"comma_split" default:"\\.mcollective$"`
+	Serializer                   string   `confkey:"plugin.choria.security.serializer" validate:"enum=json,yaml"`
+	SecurityProvider             string   `confkey:"plugin.security.provider" default:"puppet" validate:"enum=puppet,file"`
+	SecurityAlwaysOverwriteCache bool     `confkey:"plugin.security.always_overwrite_cache" default:"false"`
 
 	// file security
 	FileSecurityCertificate string `confkey:"plugin.security.file.certificate"`

--- a/server/discovery/facts/facts.go
+++ b/server/discovery/facts/facts.go
@@ -28,7 +28,7 @@ func Match(filters [][3]string, fw *choria.Framework, log *logrus.Entry) bool {
 		}
 
 		if matched == false {
-			log.Debug("Failed to match fact filter '%#v'", filter)
+			log.Debugf("Failed to match fact filter '%#v'", filter)
 			break
 		}
 	}


### PR DESCRIPTION
Support configuration where local file cache of certificates is always
overwritten

Fix fact discovery so that ginkgo works locally