### PR TITLE
(#501) only mutate when creating framework instances

### DIFF
--- a/choria/framework.go
+++ b/choria/framework.go
@@ -47,9 +47,9 @@ func New(path string) (*Framework, error) {
 }
 
 // NewWithConfig creates a new instance of the framework with the supplied config instance
-func NewWithConfig(config *config.Config) (*Framework, error) {
+func NewWithConfig(cfg *config.Config) (*Framework, error) {
 	c := Framework{
-		Config: config,
+		Config: cfg,
 		mu:     &sync.Mutex{},
 	}
 
@@ -66,6 +66,8 @@ func NewWithConfig(config *config.Config) (*Framework, error) {
 	if err != nil {
 		return &c, fmt.Errorf("could not set up security framework: %s", err)
 	}
+
+	config.Mutate(cfg, c.Logger("config"))
 
 	return &c, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -251,8 +251,6 @@ func normalize(c *Config) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	mutate(c)
-
 	return nil
 }
 

--- a/config/mutator_mock_test.go
+++ b/config/mutator_mock_test.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	logrus "github.com/sirupsen/logrus"
 	reflect "reflect"
 )
 
@@ -32,11 +33,11 @@ func (m *MockMutator) EXPECT() *MockMutatorMockRecorder {
 }
 
 // Mutate mocks base method
-func (m *MockMutator) Mutate(arg0 *Config) {
-	m.ctrl.Call(m, "Mutate", arg0)
+func (m *MockMutator) Mutate(arg0 *Config, arg1 *logrus.Entry) {
+	m.ctrl.Call(m, "Mutate", arg0, arg1)
 }
 
 // Mutate indicates an expected call of Mutate
-func (mr *MockMutatorMockRecorder) Mutate(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), arg0)
+func (mr *MockMutatorMockRecorder) Mutate(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Mutate", reflect.TypeOf((*MockMutator)(nil).Mutate), arg0, arg1)
 }

--- a/config/mutators.go
+++ b/config/mutators.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"sync"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Mutator is a function that can mutate the configuration
 type Mutator interface {
-	Mutate(*Config)
+	Mutate(*Config, *logrus.Entry)
 }
 
 var mutators = []Mutator{}
@@ -27,11 +29,12 @@ func MutatorNames() []string {
 	return mutatorNames
 }
 
-func mutate(c *Config) {
+// Mutate calls all registered mutators on the given configuration
+func Mutate(c *Config, log *logrus.Entry) {
 	mu.Lock()
 	defer mu.Unlock()
 
 	for _, mutator := range mutators {
-		mutator.Mutate(c)
+		mutator.Mutate(c, log)
 	}
 }

--- a/config/mutators_test.go
+++ b/config/mutators_test.go
@@ -1,18 +1,25 @@
 package config
 
 import (
+	"io/ioutil"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Choria/Config/Mutator", func() {
 	var (
 		mockctl *gomock.Controller
+		log     *logrus.Entry
 	)
 
 	BeforeEach(func() {
 		mockctl = gomock.NewController(GinkgoT())
+		logger := logrus.New()
+		logger.SetOutput(ioutil.Discard)
+		log = logrus.NewEntry(logger)
 	})
 
 	AfterEach(func() {
@@ -26,8 +33,8 @@ var _ = Describe("Choria/Config/Mutator", func() {
 			m2 := NewMockMutator(mockctl)
 			c := &Config{}
 
-			m1.EXPECT().Mutate(gomock.Any()).Do(func(c *Config) { c.Identity = "set_by_1" }).Times(1)
-			m2.EXPECT().Mutate(gomock.Any()).Do(func(c *Config) { c.LogFile = "set_by_2" }).Times(1)
+			m1.EXPECT().Mutate(gomock.Any(), gomock.Any()).Do(func(c *Config, _ *logrus.Entry) { c.Identity = "set_by_1" }).Times(1)
+			m2.EXPECT().Mutate(gomock.Any(), gomock.Any()).Do(func(c *Config, _ *logrus.Entry) { c.LogFile = "set_by_2" }).Times(1)
 
 			Expect(mutators).To(HaveLen(0))
 			RegisterMutator("m1", m1)
@@ -35,7 +42,7 @@ var _ = Describe("Choria/Config/Mutator", func() {
 			Expect(mutators).To(HaveLen(2))
 			Expect(MutatorNames()).To(Equal([]string{"m1", "m2"}))
 
-			mutate(c)
+			Mutate(c, log)
 
 			Expect(c.Identity).To(Equal("set_by_1"))
 			Expect(c.LogFile).To(Equal("set_by_2"))


### PR DESCRIPTION
If we mutate unconditionally during config creation it gets a bit
meta in case people want to valid mutated configurations are valid
or in places where mutators change things like protocol.Security
since that would then immediately turn on security while someone
was just validating a config

Really long term this singleton protocol.Security must go away and
become a instance var somewhere so this class of pain goes away and
would also fix things like the backplane, for now this will get us
one step further though