### PR TITLE
(#508) We are not all named `rip`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 task :default => [:test]
 
+ENV['MCOLLECTIVE_CERTNAME'] = 'rip.mcollective'
+
 desc "Run just tests no measurements"
 task :test do
   sh "ginkgo -r -skipMeasurements ."


### PR DESCRIPTION
Sets the default `MCOLLECTIVE_CERTNAME` in the Rakefile to make this
happier for other developers running tests outside the docker container
(ex, MacOS X)