### PR TITLE
(#524) include the version when making lifecycle events

### DIFF
--- a/server/infosource.go
+++ b/server/infosource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/choria-io/go-lifecycle"
 
+	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/server/agents"
 	"github.com/choria-io/go-choria/server/discovery/classes"
 	"github.com/choria-io/go-choria/server/discovery/facts"
@@ -31,6 +32,7 @@ type InstanceStatus struct {
 func (srv *Instance) NewEvent(t lifecycle.Type, opts ...lifecycle.Option) error {
 	opts = append(opts, lifecycle.Component(srv.eventComponent()))
 	opts = append(opts, lifecycle.Identity(srv.cfg.Identity))
+	opts = append(opts, lifecycle.Version(build.Version))
 
 	e, err := lifecycle.New(t, opts...)
 	if err != nil {


### PR DESCRIPTION
This ensures that things like startup and alive can be made without
having to pass in extra functions