### PR TITLE
Run broker/server as a user if specified on el6

### DIFF
--- a/packager/templates/el/el6/broker.init
+++ b/packager/templates/el/el6/broker.init
@@ -22,6 +22,9 @@ lockfile="/var/lock/subsys/${prog}"
 logfile="/var/log/${prog}"
 conffile="{{cpkg_etcdir}}/broker.conf"
 
+# If you're going to change the value of $user for non-root operations, make sure you change the value of
+# $pidfile and $logfile as well, otherwise you won't be able to start the daemon correctly.
+
 # set the open file limit to allow over 1024 connections
 ulimit -n 51200
 
@@ -37,11 +40,12 @@ start() {
 
     umask 077
 
-    touch $logfile $pidfile
+    runuser "${user}" touch $logfile $pidfile
 
     echo -n $"Starting ${prog}: "
 
     daemon \
+      --user=${user} \
       --pidfile=${pidfile} \
       " { nohup ${exec} ${args} > ${logfile} 2>&1 & }"
 

--- a/packager/templates/el/el6/server.init
+++ b/packager/templates/el/el6/server.init
@@ -40,11 +40,12 @@ start() {
 
     umask 077
 
-    touch $logfile $pidfile
+    runuser "${user}" touch $logfile $pidfile
 
     echo -n $"Starting ${prog}: "
 
     daemon \
+      --user=${user} \
       --pidfile=${pidfile} \
       " { nohup ${COMMAND_PREFIX} ${exec} ${args} > ${logfile} 2>&1 & } ; sleep 0.5 ; [ -f ${pidfile} ]"
 


### PR DESCRIPTION
This is more useful for the actual broker than the server, but will
honor specified user value from sysconfig override.

Note: Changing the value of the user without changing the value of the
pid file or logfile will probably result in a bad time.  There is also
no good way of changing these values unless the broker or server are
shut down first, since the init script depends on the pid file.