### PR TITLE
(#534) ensure status file is 644

### DIFF
--- a/server/infosource.go
+++ b/server/infosource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -152,8 +153,11 @@ func (srv *Instance) WriteServerStatus(ctx context.Context, wg *sync.WaitGroup) 
 		}
 
 		err = ioutil.WriteFile(target, j, 0644)
+		if err != nil {
+			return err
+		}
 
-		return err
+		return os.Chmod(target, 0644)
 	}
 
 	err := writer()


### PR DESCRIPTION
When an existing statusfile is found it would have been kept
on old permissions, we now set it after write ensuring existing
machines get the right permissions