### PR TITLE
(#778) force architecture in wixl command

### DIFF
--- a/packager/templates/windows/global/build.sh
+++ b/packager/templates/windows/global/build.sh
@@ -5,5 +5,5 @@ set -x
 apt-get install wixl
 find .
 cd {{cpkg_name}}-{{cpkg_version}}
-wixl -o {{cpkg_name}}-{{cpkg_version}}.msi dist/choria.wxs
+wixl -o {{cpkg_name}}-{{cpkg_version}}.msi -a x64 dist/choria.wxs
 mv {{cpkg_name}}-{{cpkg_version}}.msi ..


### PR DESCRIPTION
Overlooked that we had been forcing the architecture to the `wixl` command via `-a x64` in our testing.  This updates #778, and has been tested to generate a functional MSI using the build process.