### PR TITLE
(#687) support disabling requests without filters

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -52,24 +52,24 @@ A few special types are defined, the rest map to standard Go types
 |[plugin.choria.puppetserver_host](#pluginchoriapuppetserver_host)|[plugin.choria.puppetserver_port](#pluginchoriapuppetserver_port)|
 |[plugin.choria.randomize_middleware_hosts](#pluginchoriarandomize_middleware_hosts)|[plugin.choria.registration.file_content.compression](#pluginchoriaregistrationfile_contentcompression)|
 |[plugin.choria.registration.file_content.data](#pluginchoriaregistrationfile_contentdata)|[plugin.choria.registration.file_content.target](#pluginchoriaregistrationfile_contenttarget)|
-|[plugin.choria.security.certname_whitelist](#pluginchoriasecuritycertname_whitelist)|[plugin.choria.security.privileged_users](#pluginchoriasecurityprivileged_users)|
-|[plugin.choria.security.request_signer.token_environment](#pluginchoriasecurityrequest_signertoken_environment)|[plugin.choria.security.request_signer.token_file](#pluginchoriasecurityrequest_signertoken_file)|
-|[plugin.choria.security.request_signer.url](#pluginchoriasecurityrequest_signerurl)|[plugin.choria.security.serializer](#pluginchoriasecurityserializer)|
-|[plugin.choria.server.provision](#pluginchoriaserverprovision)|[plugin.choria.srv_domain](#pluginchoriasrv_domain)|
-|[plugin.choria.ssldir](#pluginchoriassldir)|[plugin.choria.stats_address](#pluginchoriastats_address)|
-|[plugin.choria.stats_port](#pluginchoriastats_port)|[plugin.choria.status_file_path](#pluginchoriastatus_file_path)|
-|[plugin.choria.status_update_interval](#pluginchoriastatus_update_interval)|[plugin.choria.use_srv](#pluginchoriause_srv)|
-|[plugin.nats.credentials](#pluginnatscredentials)|[plugin.nats.ngs](#pluginnatsngs)|
-|[plugin.nats.pass](#pluginnatspass)|[plugin.nats.user](#pluginnatsuser)|
-|[plugin.security.always_overwrite_cache](#pluginsecurityalways_overwrite_cache)|[plugin.security.cipher_suites](#pluginsecuritycipher_suites)|
-|[plugin.security.ecc_curves](#pluginsecurityecc_curves)|[plugin.security.file.ca](#pluginsecurityfileca)|
-|[plugin.security.file.cache](#pluginsecurityfilecache)|[plugin.security.file.certificate](#pluginsecurityfilecertificate)|
-|[plugin.security.file.key](#pluginsecurityfilekey)|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|
-|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|[plugin.security.provider](#pluginsecurityprovider)|
-|[plugin.yaml](#pluginyaml)|[publish_timeout](#publish_timeout)|
-|[registerinterval](#registerinterval)|[registration](#registration)|
-|[registration_collective](#registration_collective)|[registration_splay](#registration_splay)|
-|[require_client_filter](#require_client_filter)|[rpcaudit](#rpcaudit)|
+|[plugin.choria.require_client_filter](#pluginchoriarequire_client_filter)|[plugin.choria.security.certname_whitelist](#pluginchoriasecuritycertname_whitelist)|
+|[plugin.choria.security.privileged_users](#pluginchoriasecurityprivileged_users)|[plugin.choria.security.request_signer.token_environment](#pluginchoriasecurityrequest_signertoken_environment)|
+|[plugin.choria.security.request_signer.token_file](#pluginchoriasecurityrequest_signertoken_file)|[plugin.choria.security.request_signer.url](#pluginchoriasecurityrequest_signerurl)|
+|[plugin.choria.security.serializer](#pluginchoriasecurityserializer)|[plugin.choria.server.provision](#pluginchoriaserverprovision)|
+|[plugin.choria.srv_domain](#pluginchoriasrv_domain)|[plugin.choria.ssldir](#pluginchoriassldir)|
+|[plugin.choria.stats_address](#pluginchoriastats_address)|[plugin.choria.stats_port](#pluginchoriastats_port)|
+|[plugin.choria.status_file_path](#pluginchoriastatus_file_path)|[plugin.choria.status_update_interval](#pluginchoriastatus_update_interval)|
+|[plugin.choria.use_srv](#pluginchoriause_srv)|[plugin.nats.credentials](#pluginnatscredentials)|
+|[plugin.nats.ngs](#pluginnatsngs)|[plugin.nats.pass](#pluginnatspass)|
+|[plugin.nats.user](#pluginnatsuser)|[plugin.security.always_overwrite_cache](#pluginsecurityalways_overwrite_cache)|
+|[plugin.security.cipher_suites](#pluginsecuritycipher_suites)|[plugin.security.ecc_curves](#pluginsecurityecc_curves)|
+|[plugin.security.file.ca](#pluginsecurityfileca)|[plugin.security.file.cache](#pluginsecurityfilecache)|
+|[plugin.security.file.certificate](#pluginsecurityfilecertificate)|[plugin.security.file.key](#pluginsecurityfilekey)|
+|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|
+|[plugin.security.provider](#pluginsecurityprovider)|[plugin.yaml](#pluginyaml)|
+|[publish_timeout](#publish_timeout)|[registerinterval](#registerinterval)|
+|[registration](#registration)|[registration_collective](#registration_collective)|
+|[registration_splay](#registration_splay)|[rpcaudit](#rpcaudit)|
 |[rpcauditprovider](#rpcauditprovider)|[rpcauthorization](#rpcauthorization)|
 |[rpcauthprovider](#rpcauthprovider)|[rpclimitmethod](#rpclimitmethod)|
 |[securityprovider](#securityprovider)|[soft_shutdown](#soft_shutdown)|
@@ -530,6 +530,13 @@ YAML or JSON file to use as data source for registration
 
 NATS Subject to publish registration data to
 
+## plugin.choria.require_client_filter
+
+ * **Type:** boolean
+ * **Default Value:** false
+
+If a client filter should always be required, only used in Go clients
+
 ## plugin.choria.security.certname_whitelist
 
  * **Type:** comma_split
@@ -762,13 +769,6 @@ The Sub Collective to publish registration data to
  * **Default Value:** false
 
 When true delays initial registration publish by a random period up to registerinterval following registration publishes will be at registerinterval without further splay
-
-## require_client_filter
-
- * **Type:** boolean
- * **Default Value:** false
-
-If a client filter should always be required, appears unused at the moment
 
 ## rpcaudit
 

--- a/choria/message_test.go
+++ b/choria/message_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Choria/Message", func() {
 		})
 
 		It("Should prevent empty filters when configured to do so", func() {
-			fw.Config.RequireClientFilter = true
+			fw.Config.Choria.RequireClientFilter = true
 			m, err := NewMessage("hello world", "ginkgo", "test_collective", "request", nil, fw)
 			Expect(err).ToNot(HaveOccurred())
 			m.SetProtocolVersion(protocol.RequestV1)
@@ -243,14 +243,25 @@ var _ = Describe("Choria/Message", func() {
 			_, err = m.requestTransport()
 			Expect(err).To(MatchError("cannot create a Request Transport, requests without filters have been disabled"))
 
-			fw.Config.RequireClientFilter = false
+			fw.Config.Choria.RequireClientFilter = false
 			_, err = m.requestTransport()
 			Expect(err).ToNot(HaveOccurred())
 
-			fw.Config.RequireClientFilter = true
+			fw.Config.Choria.RequireClientFilter = true
 			m.Filter.AddClassFilter("foo")
 			_, err = m.requestTransport()
 			Expect(err).ToNot(HaveOccurred())
+
+			// discovery has m.Agent==discovery but the filter agent will be what the next request will target so special case tests
+			fw.Config.Choria.RequireClientFilter = true
+			m, err = NewMessage("hello world", "discovery", "test_collective", "request", nil, fw)
+			Expect(err).ToNot(HaveOccurred())
+			m.SetProtocolVersion(protocol.RequestV1)
+			m.SetReplyTo("reply.to")
+			m.Filter.AddAgentFilter("rpcutil")
+			_, err = m.requestTransport()
+			Expect(err).To(MatchError("cannot create a Request Transport, requests without filters have been disabled"))
+
 		})
 
 		It("Should set up the transport", func() {

--- a/cmd/req.go
+++ b/cmd/req.go
@@ -239,6 +239,7 @@ func (r *reqCommand) Run(wg *sync.WaitGroup) (err error) {
 	opts := []rpc.RequestOption{
 		rpc.Collective(r.collective),
 		rpc.Targets(nodes),
+		rpc.Filter(r.filter),
 		rpc.ReplyHandler(r.responseHandler(results)),
 		rpc.Workers(r.workers),
 		rpc.LimitMethod(cfg.RPCLimitMethod),

--- a/config/choria.go
+++ b/config/choria.go
@@ -98,6 +98,8 @@ type ChoriaPluginConfig struct {
 	StatusUpdateSeconds int    `confkey:"plugin.choria.status_update_interval" default:"30"` // How frequently to write to the status_file_path
 
 	MachineSourceDir string `confkey:"plugin.choria.machine.store" url:"https://choria.io/docs/autoagents/"` // Directory where Autonomous Agents are stored
+
+	RequireClientFilter bool `confkey:"plugin.choria.require_client_filter" default:"false"` // If a client filter should always be required, only used in Go clients
 }
 
 func newChoria() *ChoriaPluginConfig {

--- a/config/config.go
+++ b/config/config.go
@@ -104,9 +104,6 @@ type Config struct {
 	// Where to look for YAML or JSON based facts
 	FactSourceFile string `confkey:"plugin.yaml" default:"/etc/puppetlabs/mcollective/generated-facts.yaml" type:"path_string"`
 
-	// If a client filter should always be required, appears unused at the moment
-	RequireClientFilter bool `confkey:"require_client_filter" default:"false"`
-
 	// Deprecated settings
 
 	ActivateAgents            bool   `confkey:"activate_agents" default:"true" deprecated:"1"`

--- a/config/docstrings.go
+++ b/config/docstrings.go
@@ -1,4 +1,4 @@
-// auto generated at 2020-02-17 12:36:31.238477 +0100 CET m=+0.001821647
+// auto generated at 2020-03-13 12:47:26.089585 +0100 CET m=+0.000998862
 
 package config
 
@@ -32,7 +32,6 @@ var docStrings = map[string]string{
 	"default_discovery_options":                               "Configurable options to always pass to the discovery subsystem",
 	"default_discovery_method":                                "The default discovery plugin to use. The default \"mc\" uses a network broadcast and \"choria\" uses PuppetDB",
 	"plugin.yaml":                                             "Where to look for YAML or JSON based facts",
-	"require_client_filter":                                   "If a client filter should always be required, appears unused at the moment",
 	"plugin.choria.puppetserver_host":                         "The hostname where your Puppet Server can be found",
 	"plugin.choria.puppetserver_port":                         "The port your Puppet Server listens on",
 	"plugin.choria.puppetca_host":                             "The hostname where your Puppet Certificate Authority can be found",
@@ -100,4 +99,5 @@ var docStrings = map[string]string{
 	"plugin.choria.status_file_path":                          "Path to a JSON file to write server health information to regularly",
 	"plugin.choria.status_update_interval":                    "How frequently to write to the status_file_path",
 	"plugin.choria.machine.store":                             "Directory where Autonomous Agents are stored",
+	"plugin.choria.require_client_filter":                     "If a client filter should always be required, only used in Go clients",
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cloudevents/sdk-go v1.0.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.9.0
+	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/mock v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=


### PR DESCRIPTION
This moves the config item to plugin to avoid breaking the ruby
config parser that fails on unknown things

Additionally improves handling of discovery messages when detecting
if a message is unfiltered