### PR TITLE
(#852) Install choria binary in /usr/bin

### DIFF
--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -50,7 +50,7 @@ foss:
     defaults:
       name: choria
       display_name: Choria
-      bindir: /usr/sbin
+      bindir: /usr/bin
       etcdir: /etc/choria
       release: 1
       manage_conf: 1

--- a/packager/templates/debian/generic/rules
+++ b/packager/templates/debian/generic/rules
@@ -17,7 +17,7 @@ override_dh_systemd_enable:
 
 override_dh_auto_install:
 
-	install -Dm755 {{cpkg_binary}} debian/{{cpkg_name}}/usr/sbin/{{cpkg_name}}
+	install -Dm755 {{cpkg_binary}} debian/{{cpkg_name}}/usr/bin/{{cpkg_name}}
 
 ifeq ({{cpkg_manage_conf}},1)
 	install -Dm640 debian/broker.conf -t debian/{{cpkg_name}}/etc/{{cpkg_name}}


### PR DESCRIPTION
/usr/sbin was previously chosen because choria only provided services
components.  Now that choria also has client capabilities, install it to
/usr/bin which is in the $PATH of all users by default.

Fixes #852