### PR TITLE
(#1039) improve last message handling

### DIFF
--- a/statistics/instance.go
+++ b/statistics/instance.go
@@ -64,6 +64,15 @@ func (i *InstanceStatus) CheckFileAge(maxAge time.Duration) error {
 
 func (i *InstanceStatus) CheckLastMessage(maxAge time.Duration) error {
 	previous := time.Unix(i.LastMessage, 0)
+
+	// we don't check the first maxAge if uptime is low and we never had any messages
+	// to avoid large sets of critical after restarts, upgrades etc
+	if i.LastMessage == 0 {
+		if float64(i.Uptime) < maxAge.Seconds() {
+			return nil
+		}
+	}
+
 	if previous.Before(time.Now().Add(-1 * maxAge)) {
 		return fmt.Errorf("last message at %v", previous.UTC())
 	}


### PR DESCRIPTION
Only checks the last message after maxAge passed to avoid
complaining directly after restarts or upgrades

Signed-off-by: R.I.Pienaar <rip@devco.net>