### PR TITLE
Fake the use of DNS sans

### DIFF
--- a/config/choria.go
+++ b/config/choria.go
@@ -94,6 +94,7 @@ type ChoriaPluginConfig struct {
 	FileSecurityKey         string `confkey:"plugin.security.file.key" type:"path_string"`         // When using file security provider, the path to the private key
 	FileSecurityCA          string `confkey:"plugin.security.file.ca" type:"path_string"`          // When using file security provider, the path to the Certificate Authority public certificate
 	FileSecurityCache       string `confkey:"plugin.security.file.cache" type:"path_string"`       // When using file security provider, the path to the client cache
+	FileSecurityAppendSAN   bool   `confkey:"plugin.security.file.append_san" default:"true"`      // Assume we are using puppet based certificates, without a SAN, and append one
 
 	CertManagerSecurityNamespace  string   `confkey:"plugin.security.certmanager.namespace" default:"choria"`   // When using Cert Manager security provider, the namespace the issuer is in
 	CertManagerSecurityIssuer     string   `confkey:"plugin.security.certmanager.issuer"`                       // When using Cert Manager security provider, the name of the issuer

--- a/providers/security/filesec/file_security_test.go
+++ b/providers/security/filesec/file_security_test.go
@@ -6,11 +6,12 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"github.com/choria-io/go-choria/tlssetup"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/choria-io/go-choria/tlssetup"
 
 	"github.com/choria-io/go-choria/config"
 	"github.com/choria-io/go-choria/providers/security"
@@ -33,6 +34,7 @@ func setSSL(c *Config, parent string, id string) {
 	c.PrivilegedUsers = []string{"\\.privileged.mcollective$"}
 	c.DisableTLSVerify = false
 	c.Identity = id
+	c.AppendSAN = true
 
 	useFakeUID = true
 	fakeUID = 500

--- a/providers/security/filesec/option.go
+++ b/providers/security/filesec/option.go
@@ -2,8 +2,9 @@ package filesec
 
 import (
 	"fmt"
-	"github.com/choria-io/go-choria/tlssetup"
 	"os"
+
+	"github.com/choria-io/go-choria/tlssetup"
 
 	"github.com/choria-io/go-choria/config"
 	"github.com/sirupsen/logrus"
@@ -28,6 +29,7 @@ func WithChoriaConfig(c *config.Config) Option {
 		RemoteSignerTokenFile:        c.Choria.RemoteSignerTokenFile,
 		RemoteSignerTokenEnvironment: c.Choria.RemoteSignerTokenEnvironment,
 		TLSConfig:                    tlssetup.TLSConfig(c),
+		AppendSAN:                    c.Choria.FileSecurityAppendSAN,
 	}
 
 	if cn, ok := os.LookupEnv("MCOLLECTIVE_CERTNAME"); ok {


### PR DESCRIPTION
If a DNS san doesn't exist, add one which contains the common name.