### PR TITLE
(#1076) Remove trailing dot of SRV target

### DIFF
--- a/srvcache/cache.go
+++ b/srvcache/cache.go
@@ -2,6 +2,7 @@ package srvcache
 
 import (
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,7 +63,7 @@ func (c *Cache) LookupSrvServers(service string, proto string, name string, sche
 
 	servers := make([]Server, len(addrs))
 	for i, addr := range addrs {
-		servers[i] = &BasicServer{host: addr.Target, port: addr.Port, scheme: scheme}
+		servers[i] = &BasicServer{host: strings.TrimRight(addr.Target, "."), port: addr.Port, scheme: scheme}
 	}
 
 	return NewServers(servers...), nil


### PR DESCRIPTION
When using SRV records, the canonical hostname of the machine providing the service is expected to end with a dot.

But if this dot is kept, TLS connection will fail because the hostname does not match the Sever Name Indication (SNI):

```
org.eclipse.jetty.http.BadMessageException: 400: Host does not match SNI
```

Remove any trailing dot at the end of the target to fix this issue.
