### PR TITLE
(msic) Add path to FreeBSD clientconfiguration file

### DIFF
--- a/choria/util.go
+++ b/choria/util.go
@@ -45,6 +45,10 @@ func UserConfig() string {
 		return "/etc/choria/client.cfg"
 	}
 
+	if FileExist("/usr/local/etc/choria/client.conf") {
+		return "/usr/local/etc/choria/client.conf"
+	}
+
 	return "/etc/puppetlabs/mcollective/client.cfg"
 }
 


### PR DESCRIPTION
This file is already managed by the Puppet modules, but choria does not look for this path.  Add it to the list of checked configuration files.

I guess I will work on #751 next. It will be in the same area and is a must-have for my way of using mcollective/choria :wink: