### PR TITLE
(#281) Setup Identity when running as a client only

### DIFF
--- a/providers/security/puppetsec/option.go
+++ b/providers/security/puppetsec/option.go
@@ -48,12 +48,14 @@ func WithChoriaConfig(c *config.Config) Option {
 
 		if c.OverrideCertname != "" {
 			cfg.Identity = c.OverrideCertname
-		} else if runtime.GOOS == "windows" {
-			if u, ok := os.LookupEnv("USERNAME"); ok {
-				cfg.Identity = fmt.Sprintf("%s.mcollective", u)
+		} else if !c.InitiatedByServer {
+			var user_variable_name = "USER"
+
+			if runtime.GOOS == "windows" {
+				user_variable_name = "USERNAME"
 			}
-		} else if os.Getuid() != 0 {
-			if u, ok := os.LookupEnv("USER"); ok {
+
+			if u, ok := os.LookupEnv(user_variable_name); ok {
 				cfg.Identity = fmt.Sprintf("%s.mcollective", u)
 			}
 		}


### PR DESCRIPTION
Choria used to check if the user UID was different from 0 and in this
case was setting-up the Identity based on the user environment.  In
5b77ff95c7a990c6845008fac4272615d67fe6c1, we added support for windows
which does not provide such uid mecanism, and Identity was always set
according to the running user's environment.

This however cause trouble when running the Choria as a choria-server
service: by configuring Identity, the server does not use the expected
certificates.

Rework the way Identity is set to fix this issue: rely on
InitiatedByServer to determine if Choria is running as a server or not,
and only in this case setup Identity.