### PR TITLE
(#1098) add discovery options support

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -146,7 +146,7 @@ The default discovery plugin to use. The default "mc" uses a network broadcast, 
 
  * **Type:** strings
 
-**This setting is deprecated or already unused**
+Default options to pass to the discovery plugin
 
 ## direct_addressing
 

--- a/client/choria_utilclient/action_info.go
+++ b/client/choria_utilclient/action_info.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.283539 +0100 CET m=+0.058945907"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.148642 +0100 CET m=+0.057338820"
 //
 // Client for Choria RPC Agent 'choria_util'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/choria_utilclient/action_machine_states.go
+++ b/client/choria_utilclient/action_machine_states.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.28841 +0100 CET m=+0.063817322"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.153977 +0100 CET m=+0.062673995"
 //
 // Client for Choria RPC Agent 'choria_util'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/choria_utilclient/action_machine_transition.go
+++ b/client/choria_utilclient/action_machine_transition.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.291688 +0100 CET m=+0.067094964"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.157179 +0100 CET m=+0.065876343"
 //
 // Client for Choria RPC Agent 'choria_util'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/choria_utilclient/doc.go
+++ b/client/choria_utilclient/doc.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.309574 +0100 CET m=+0.084981576"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.175273 +0100 CET m=+0.083970612"
 //
 // Client for Choria RPC Agent 'choria_util'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/discovery/external/external.go
+++ b/client/discovery/external/external.go
@@ -64,6 +64,7 @@ func (e *External) Discover(ctx context.Context, opts ...DiscoverOption) (n []st
 		collective: e.fw.Configuration().MainCollective,
 		timeout:    e.timeout,
 		command:    e.fw.Configuration().Choria.ExternalDiscoveryCommand,
+		do:         make(map[string]string),
 	}
 
 	for _, opt := range opts {
@@ -77,6 +78,11 @@ func (e *External) Discover(ctx context.Context, opts ...DiscoverOption) (n []st
 	if dopts.timeout < time.Second {
 		e.log.Warnf("Forcing discovery timeout to minimum 1 second")
 		dopts.timeout = time.Second
+	}
+
+	command, ok := dopts.do["command"]
+	if ok && command != "" {
+		dopts.command = command
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, dopts.timeout)

--- a/client/discovery/external/external_test.go
+++ b/client/discovery/external/external_test.go
@@ -61,5 +61,23 @@ var _ = Describe("Broadcast", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(nodes).To(Equal([]string{"one", "two"}))
 		})
+
+		It("Should support command overrides via options", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not tested on windows")
+			}
+
+			f := protocol.NewFilter()
+			f.AddAgentFilter("rpcutil")
+			f.AddFactFilter("country", "==", "mt")
+
+			wd, _ := os.Getwd()
+			fw.Config.Choria.ExternalDiscoveryCommand = filepath.Join(wd, "testdata/missing.rb")
+			cmd := filepath.Join(wd, "testdata/good.rb")
+			nodes, err := e.Discover(context.Background(), Filter(f), DiscoveryOptions(map[string]string{"command": cmd}))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nodes).To(Equal([]string{"one", "two"}))
+
+		})
 	})
 })

--- a/client/discovery/external/options.go
+++ b/client/discovery/external/options.go
@@ -11,6 +11,7 @@ type dOpts struct {
 	collective string
 	timeout    time.Duration
 	command    string
+	do         map[string]string
 }
 
 // DiscoverOption configures the broadcast discovery method
@@ -40,5 +41,16 @@ func Timeout(t time.Duration) DiscoverOption {
 func Command(c string) DiscoverOption {
 	return func(o *dOpts) {
 		o.command = c
+	}
+}
+
+// DiscoveryOptions sets the key value pairs that make user supplied discovery options.
+//
+// Supported options:
+//
+//   command - The command to execute instead of configured default
+func DiscoveryOptions(opt map[string]string) DiscoverOption {
+	return func(o *dOpts) {
+		o.do = opt
 	}
 }

--- a/client/discovery/flatfile/flatfile_test.go
+++ b/client/discovery/flatfile/flatfile_test.go
@@ -1,0 +1,96 @@
+package flatfile
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/choria-io/go-choria/protocol"
+)
+
+func TestFlatfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Client/Discovery/Flatfile")
+}
+
+var _ = Describe("Flatfile", func() {
+	It("Should expect a source", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background())
+		Expect(n).To(HaveLen(0))
+		Expect(err).To(MatchError("source file not specified"))
+	})
+
+	It("Should validate the filter", func() {
+		filter := protocol.NewFilter()
+		filter.AddAgentFilter("test")
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), Filter(filter), File("testdata/nodes.txt"))
+		Expect(n).To(HaveLen(0))
+		Expect(err).To(MatchError("only identity filters are supported"))
+	})
+
+	It("Should require a file format", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/nodes.txt"))
+		Expect(n).To(HaveLen(0))
+		Expect(err).To(MatchError("unknown file format"))
+	})
+
+	It("Should support flat files", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/nodes.txt"), Format(TextFormat))
+		Expect(n).To(Equal([]string{"one", "two", "three"}))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should support json files", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/nodes.json"), Format(JSONFormat))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal([]string{"one.json", "two.json", "three.json"}))
+	})
+
+	It("Should support yaml files", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/nodes.yaml"), Format(YAMLFormat))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal([]string{"one.yaml", "two.yaml", "three.yaml"}))
+	})
+
+	It("Should support choria response files", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/choria.json"), Format(ChoriaResponsesFormat))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal([]string{"n1.example.net", "n2.example.net", "n3.example.net"}))
+	})
+
+	It("Should support identity filters", func() {
+		filter := protocol.NewFilter()
+		filter.AddIdentityFilter("n1.example.net")
+		filter.AddIdentityFilter("/n2/")
+
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/choria.json"), Format(ChoriaResponsesFormat), Filter(filter))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal([]string{"n1.example.net", "n2.example.net"}))
+	})
+
+	It("Should validate node names", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/badnodes.txt"), Format(TextFormat))
+		Expect(err).To(MatchError(`invalid identity string "foo bar"`))
+		Expect(n).To(BeEmpty())
+	})
+
+	It("Should support gjson matches", func() {
+		ff := &FlatFile{}
+		n, err := ff.Discover(context.Background(), File("testdata/choria.json"), Format(JSONFormat), DiscoveryOptions(map[string]string{
+			"filter": "replies.#.sender",
+		}))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(n).To(Equal([]string{"n1.example.net", "n2.example.net", "n3.example.net"}))
+	})
+})

--- a/client/discovery/flatfile/options.go
+++ b/client/discovery/flatfile/options.go
@@ -2,6 +2,8 @@ package flatfile
 
 import (
 	"io"
+
+	"github.com/choria-io/go-choria/protocol"
 )
 
 type SourceFormat int
@@ -16,18 +18,27 @@ const (
 	// YAMLFormat parses a YAML file expecting an array of nodes
 	YAMLFormat
 
-	// ChoriaResponses uses Choria responses as produced by choria req -j as source
-	ChoriaResponses
+	// ChoriaResponsesFormat uses Choria responses as produced by choria req -j as source
+	ChoriaResponsesFormat
 )
 
 type dOpts struct {
 	source string
 	format SourceFormat
 	reader io.Reader
+	filter *protocol.Filter
+	do     map[string]string
 }
 
 // DiscoverOption configures the broadcast discovery method
 type DiscoverOption func(o *dOpts)
+
+// Filter sets the filter to use for the discovery, else a blank one is used
+func Filter(f *protocol.Filter) DiscoverOption {
+	return func(o *dOpts) {
+		o.filter = f
+	}
+}
 
 // Format specifies the file format
 func Format(f SourceFormat) DiscoverOption {
@@ -47,5 +58,16 @@ func File(f string) DiscoverOption {
 func Reader(r io.Reader) DiscoverOption {
 	return func(o *dOpts) {
 		o.reader = r
+	}
+}
+
+// DiscoveryOptions sets the key value pairs that make user supplied discovery options.
+//
+// Supported options:
+//
+//   filter - GJSON Path Syntax search over YAML or JSON data
+func DiscoveryOptions(opt map[string]string) DiscoverOption {
+	return func(o *dOpts) {
+		o.do = opt
 	}
 }

--- a/client/discovery/flatfile/testdata/badnodes.txt
+++ b/client/discovery/flatfile/testdata/badnodes.txt
@@ -1,0 +1,5 @@
+foo.node
+bar.node
+Bar.node
+foo bar
+

--- a/client/discovery/flatfile/testdata/choria.json
+++ b/client/discovery/flatfile/testdata/choria.json
@@ -1,0 +1,44 @@
+{
+  "agent": "rpcutil",
+  "action": "ping",
+  "replies": [
+    {
+      "sender": "n1.example.net",
+      "statuscode": 0,
+      "statusmsg": "OK",
+      "data": {
+        "pong": 1611245602
+      }
+    },
+    {
+      "sender": "n2.example.net",
+      "statuscode": 0,
+      "statusmsg": "OK",
+      "data": {
+        "pong": 1611245602
+      }
+    },
+    {
+      "sender": "n3.example.net",
+      "statuscode": 0,
+      "statusmsg": "OK",
+      "data": {
+        "pong": 1611245603
+      }
+    }
+  ],
+  "request_stats": {
+    "requestid": "64ad3de0bd284470824105b12ed64a81",
+    "no_responses": [],
+    "unexpected_responses": [],
+    "discovered": 3,
+    "failed": 0,
+    "ok": 3,
+    "responses": 3,
+    "publish_time": 256562143,
+    "request_time": 925439588,
+    "discover_time": 324561798,
+    "start_time_utc": "2021-01-21T16:13:22.167759243Z"
+  },
+  "summaries": {}
+}

--- a/client/discovery/flatfile/testdata/nodes.json
+++ b/client/discovery/flatfile/testdata/nodes.json
@@ -1,0 +1,1 @@
+["one.json","two.json","three.json"]

--- a/client/discovery/flatfile/testdata/nodes.txt
+++ b/client/discovery/flatfile/testdata/nodes.txt
@@ -1,0 +1,3 @@
+one
+two
+three

--- a/client/discovery/flatfile/testdata/nodes.yaml
+++ b/client/discovery/flatfile/testdata/nodes.yaml
@@ -1,0 +1,4 @@
+---
+- one.yaml
+- two.yaml
+- three.yaml

--- a/client/rpcutilclient/action_agent_inventory.go
+++ b/client/rpcutilclient/action_agent_inventory.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.235947 +0100 CET m=+0.011353806"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.101478 +0100 CET m=+0.010175021"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_collective_info.go
+++ b/client/rpcutilclient/action_collective_info.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.23929 +0100 CET m=+0.014696951"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.104518 +0100 CET m=+0.013215144"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_daemon_stats.go
+++ b/client/rpcutilclient/action_daemon_stats.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.242839 +0100 CET m=+0.018246227"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.107441 +0100 CET m=+0.016138392"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_get_config_item.go
+++ b/client/rpcutilclient/action_get_config_item.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.24761 +0100 CET m=+0.023017389"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.112381 +0100 CET m=+0.021077808"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_get_data.go
+++ b/client/rpcutilclient/action_get_data.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.250379 +0100 CET m=+0.025786248"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.1151 +0100 CET m=+0.023796828"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_get_fact.go
+++ b/client/rpcutilclient/action_get_fact.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.252806 +0100 CET m=+0.028212832"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.117671 +0100 CET m=+0.026367965"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_get_facts.go
+++ b/client/rpcutilclient/action_get_facts.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.255519 +0100 CET m=+0.030926313"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.12037 +0100 CET m=+0.029067544"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_inventory.go
+++ b/client/rpcutilclient/action_inventory.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.258594 +0100 CET m=+0.034000898"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.123463 +0100 CET m=+0.032160418"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/action_ping.go
+++ b/client/rpcutilclient/action_ping.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.265003 +0100 CET m=+0.040410206"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.127757 +0100 CET m=+0.036454760"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/rpcutilclient/doc.go
+++ b/client/rpcutilclient/doc.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.281017 +0100 CET m=+0.056424556"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.145408 +0100 CET m=+0.054105820"
 //
 // Client for Choria RPC Agent 'rpcutil'' Version 0.19.0 generated using Choria version 0.19.0
 

--- a/client/scoutclient/action_checks.go
+++ b/client/scoutclient/action_checks.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.31247 +0100 CET m=+0.087877207"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.179616 +0100 CET m=+0.088313884"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/client/scoutclient/action_goss_validate.go
+++ b/client/scoutclient/action_goss_validate.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.322808 +0100 CET m=+0.098215436"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.190222 +0100 CET m=+0.098919602"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/client/scoutclient/action_maintenance.go
+++ b/client/scoutclient/action_maintenance.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.318037 +0100 CET m=+0.093444174"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.186776 +0100 CET m=+0.095473229"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/client/scoutclient/action_resume.go
+++ b/client/scoutclient/action_resume.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.314992 +0100 CET m=+0.090399017"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.183353 +0100 CET m=+0.092050035"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/client/scoutclient/action_trigger.go
+++ b/client/scoutclient/action_trigger.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.326403 +0100 CET m=+0.101809964"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.195909 +0100 CET m=+0.104606533"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/client/scoutclient/doc.go
+++ b/client/scoutclient/doc.go
@@ -1,4 +1,4 @@
-// generated code; DO NOT EDIT; 2021-01-19 14:29:22.342089 +0100 CET m=+0.117496571"
+// generated code; DO NOT EDIT; 2021-01-21 18:37:17.218346 +0100 CET m=+0.127043166"
 //
 // Client for Choria RPC Agent 'scout'' Version 0.0.1 generated using Choria version 0.19.0
 

--- a/config/config.go
+++ b/config/config.go
@@ -103,19 +103,21 @@ type Config struct {
 	// Where to look for YAML or JSON based facts
 	FactSourceFile string `confkey:"plugin.yaml" default:"/etc/puppetlabs/mcollective/generated-facts.yaml" type:"path_string"`
 
+	// Default options to pass to the discovery plugin
+	DefaultDiscoveryOptions []string `confkey:"default_discovery_options"`
+
 	// Deprecated settings
 
-	ActivateAgents            bool     `confkey:"activate_agents" default:"true" deprecated:"1"`
-	Daemonize                 bool     `confkey:"daemonize" default:"false" deprecated:"1"`
-	DefaultDiscoveryOptions   []string `confkey:"default_discovery_options" deprecated:"1"`
-	DirectAddressingThreshold int      `confkey:"direct_addressing_threshold" default:"10" deprecated:"1"`
-	FactCacheTime             int      `confkey:"fact_cache_time" default:"300" deprecated:"1"`
-	FactSource                string   `confkey:"factsource" default:"yaml" deprecated:"1"`
-	KeepLogs                  int      `confkey:"keeplogs" default:"5" deprecated:"1"`
-	LogFacility               string   `confkey:"logfacility" default:"user" deprecated:"1"`
-	MaxLogSize                int      `confkey:"max_log_size" default:"2097152" deprecated:"1"`
-	SoftShutdown              bool     `confkey:"soft_shutdown" default:"true" deprecated:"1"`
-	SoftShutdownTimeout       int      `confkey:"soft_shutdown_timeout" default:"2" deprecated:"1"`
+	ActivateAgents            bool   `confkey:"activate_agents" default:"true" deprecated:"1"`
+	Daemonize                 bool   `confkey:"daemonize" default:"false" deprecated:"1"`
+	DirectAddressingThreshold int    `confkey:"direct_addressing_threshold" default:"10" deprecated:"1"`
+	FactCacheTime             int    `confkey:"fact_cache_time" default:"300" deprecated:"1"`
+	FactSource                string `confkey:"factsource" default:"yaml" deprecated:"1"`
+	KeepLogs                  int    `confkey:"keeplogs" default:"5" deprecated:"1"`
+	LogFacility               string `confkey:"logfacility" default:"user" deprecated:"1"`
+	MaxLogSize                int    `confkey:"max_log_size" default:"2097152" deprecated:"1"`
+	SoftShutdown              bool   `confkey:"soft_shutdown" default:"true" deprecated:"1"`
+	SoftShutdownTimeout       int    `confkey:"soft_shutdown_timeout" default:"2" deprecated:"1"`
 
 	ConfigFile string
 

--- a/config/docstrings.go
+++ b/config/docstrings.go
@@ -1,4 +1,4 @@
-// auto generated at 2021-01-19 14:29:18.390046 +0100 CET m=+0.001767946
+// auto generated at 2021-01-21 18:37:13.139441 +0100 CET m=+0.001505621
 
 package config
 
@@ -31,6 +31,7 @@ var docStrings = map[string]string{
 	"ttl":                             "How long published messages are allowed to linger on the network, lower numbers have a higher reliance on clocks being in sync",
 	"default_discovery_method":        "The default discovery plugin to use. The default \"mc\" uses a network broadcast, \"choria\" uses PuppetDB, external calls external commands",
 	"plugin.yaml":                     "Where to look for YAML or JSON based facts",
+	"default_discovery_options":       "Default options to pass to the discovery plugin",
 	"plugin.choria.puppetserver_host": "The hostname where your Puppet Server can be found",
 	"plugin.choria.puppetserver_port": "The port your Puppet Server listens on",
 	"plugin.choria.puppetca_host":     "The hostname where your Puppet Certificate Authority can be found",

--- a/filter/identity/identity.go
+++ b/filter/identity/identity.go
@@ -6,22 +6,37 @@ import (
 )
 
 // Match identities on a OR basis, since nodes have only 1 identity
-func Match(needles []string, certname string) bool {
-	for _, needle := range needles {
-		if strings.HasPrefix(needle, "/") && strings.HasSuffix(needle, "/") {
-			needle = strings.TrimPrefix(needle, "/")
-			needle = strings.TrimSuffix(needle, "/")
-			if matched, _ := regexp.MatchString(needle, certname); matched {
-				return true
-			}
-
-			continue
-		}
-
-		if needle == certname {
+func Match(filters []string, certname string) bool {
+	for _, filter := range filters {
+		if match(certname, filter) {
 			return true
 		}
 	}
 
 	return false
+}
+
+// FilterNodes return only nodes matching f
+func FilterNodes(nodes []string, f string) []string {
+	matched := []string{}
+
+	for _, n := range nodes {
+		if match(n, f) {
+			matched = append(matched, n)
+		}
+	}
+
+	return matched
+}
+
+func match(certname string, filter string) bool {
+	if strings.HasPrefix(filter, "/") && strings.HasSuffix(filter, "/") {
+		filter = strings.TrimPrefix(filter, "/")
+		filter = strings.TrimSuffix(filter, "/")
+		if matched, _ := regexp.MatchString(filter, certname); matched {
+			return true
+		}
+	}
+
+	return certname == filter
 }


### PR DESCRIPTION
This adds discovery options to the CLI and use that to pass
an optional filter to flatfile which can dig into json and
yaml files to find nodes

It also allows a custom command to be set in extenral
discovery plugins

Signed-off-by: R.I.Pienaar <rip@devco.net>