### PR TITLE
(#751) Improve project parsing

### DIFF
--- a/choria/connection.go
+++ b/choria/connection.go
@@ -574,7 +574,7 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 
 		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
 			if err != nil {
-				conn.logger.Warnf("NATS client connection got disconnected: %s", nc.LastError())
+				conn.logger.Warnf("NATS client connection got disconnected: %v", nc.LastError())
 			}
 		}),
 
@@ -586,7 +586,7 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 		nats.ClosedHandler(func(nc *nats.Conn) {
 			err = nc.LastError()
 			if err != nil {
-				conn.logger.Warnf("NATS client connection closed: %s", nc.LastError())
+				conn.logger.Warnf("NATS client connection closed: %v", nc.LastError())
 			}
 			connClosedCtr.Inc()
 		}),

--- a/client/discovery/cli_helper.go
+++ b/client/discovery/cli_helper.go
@@ -185,21 +185,6 @@ func (o *StandardOptions) SetDefaultsFromConfig(cfg *config.Config) {
 	}
 }
 
-// SetDefaults sets default values for options, should be called before doing any discovery after flags are parsed
-func (o *StandardOptions) SetDefaults(collective string, dm string, dt int) {
-	if o.DiscoveryMethod == "" {
-		o.DiscoveryMethod = dm
-	}
-
-	if o.Collective == "" {
-		o.Collective = collective
-	}
-
-	if o.DiscoveryTimeout == 0 {
-		o.DiscoveryTimeout = dt
-	}
-}
-
 // NewFilter creates a new filter based on the options supplied, additionally agent will be added to the list
 func (o *StandardOptions) NewFilter(agent string) (*protocol.Filter, error) {
 	return filter.NewFilter(

--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/choria-io/go-choria/broker/adapter"
 	"github.com/choria-io/go-choria/broker/federation"
 	"github.com/choria-io/go-choria/broker/network"
+	"github.com/choria-io/go-choria/config"
 	"github.com/choria-io/go-choria/statistics"
 )
 
@@ -62,7 +63,18 @@ func (r *brokerRunCommand) Setup() (err error) {
 }
 
 func (r *brokerRunCommand) Configure() error {
-	return commonConfigure()
+	if configFile == "" {
+		return fmt.Errorf("configuration file required")
+	}
+
+	cfg, err = config.NewSystemConfig(configFile, false)
+	if err != nil {
+		return fmt.Errorf("could not parse configuration: %s", err)
+	}
+
+	cfg.ApplyBuildSettings(bi)
+
+	return nil
 }
 
 func (r *brokerRunCommand) Run(wg *sync.WaitGroup) (err error) {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -66,13 +66,13 @@ func (r *serverRunCommand) Configure() error {
 
 	switch {
 	case choria.FileExist(configFile):
-		cfg, err = config.NewConfig(configFile)
+		cfg, err = config.NewSystemConfig(configFile, true)
 		if err != nil {
 			return fmt.Errorf("could not parse configuration: %s", err)
 		}
 
 	case bi.ProvisionBrokerURLs() != "":
-		cfg, err = config.NewDefaultConfig()
+		cfg, err = config.NewDefaultSystemConfig(true)
 		if err != nil {
 			return fmt.Errorf("could not create default configuration for provisioning: %s", err)
 		}
@@ -84,7 +84,6 @@ func (r *serverRunCommand) Configure() error {
 	cfg.ApplyBuildSettings(bi)
 
 	cfg.DisableSecurityProviderVerify = true
-	cfg.InitiatedByServer = true
 
 	if os.Getenv("INSECURE_YES_REALLY") == "true" {
 		protocol.Secure = "false"

--- a/cmd/tool_provisioner.go
+++ b/cmd/tool_provisioner.go
@@ -37,6 +37,7 @@ func (p *tProvisionerCommand) Configure() error {
 
 	cfg.DisableSecurityProviderVerify = true
 	cfg.InitiatedByServer = true
+	cfg.InitiatedBySystem = true
 	cfg.Choria.Provision = true
 
 	return nil

--- a/config/testdata/choria.cfg
+++ b/config/testdata/choria.cfg
@@ -14,3 +14,5 @@ plugin.choria.ssl_dir = /nonexisting
 plugin.choria.use_srv = false
 
 plugin.choria.network.write_deadline = 10s
+
+plugin.project.test = 0

--- a/config/testdata/project/choria.conf
+++ b/config/testdata/project/choria.conf
@@ -1,0 +1,1 @@
+plugin.project.test=1

--- a/config/util.go
+++ b/config/util.go
@@ -16,25 +16,33 @@ import (
 )
 
 // ProjectConfigurationFiles returns any configuration file in the specified directory and their parents directories.
-func ProjectConfigurationFiles(path string, err error) []string {
-	var res []string
+func ProjectConfigurationFiles(path string) ([]string, error) {
+	var (
+		res []string
+		err error
+	)
 
 	if !filepath.IsAbs(path) {
 		path, err = filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var parent = filepath.Dir(path)
 	if parent != path {
-		res = ProjectConfigurationFiles(parent, err)
+		res, err = ProjectConfigurationFiles(parent)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	var config = filepath.Join(path, "choria.conf")
-
+	config := filepath.Join(path, "choria.conf")
 	if FileExist(config) {
 		res = append(res, config)
 	}
 
-	return res
+	return res, nil
 }
 
 // FileExist checks if a file exist on disk

--- a/providers/security/puppetsec/option.go
+++ b/providers/security/puppetsec/option.go
@@ -48,14 +48,15 @@ func WithChoriaConfig(c *config.Config) Option {
 
 		if c.OverrideCertname != "" {
 			cfg.Identity = c.OverrideCertname
-		} else if !c.InitiatedByServer {
-			var user_variable_name = "USER"
+		} else if !c.InitiatedByServer && !c.InitiatedBySystem {
+			userEnvVar := "USER"
 
 			if runtime.GOOS == "windows" {
-				user_variable_name = "USERNAME"
+				userEnvVar = "USERNAME"
 			}
 
-			if u, ok := os.LookupEnv(user_variable_name); ok {
+			u, ok := os.LookupEnv(userEnvVar)
+			if ok {
 				cfg.Identity = fmt.Sprintf("%s.mcollective", u)
 			}
 		}


### PR DESCRIPTION
Previously we had InitiatedByServer to indicate server
specific behaviours and we overloaded that to assume all
system components are servers.  This is not true for the
broker.

Now we have ways to create a system configuration with
InitiatedBySystem set, the projects parsing and puppet
security system uses that to do the right thing - avoid
loading projects and use the system TLS when not configured

Signed-off-by: R.I.Pienaar <rip@devco.net>