### PR TITLE
(misc) Fix display of discovered nodes count in reply footer

### DIFF
--- a/providers/agent/mcorpc/replyfmt/results.go
+++ b/providers/agent/mcorpc/replyfmt/results.go
@@ -93,8 +93,10 @@ func (r *RPCResults) RenderTXTFooter(w io.Writer, verbose bool) {
 
 		switch {
 		case stats.ResponseCount == 0:
+			dcnt = color.RedString(strconv.Itoa(stats.DiscoveredCount))
 			rcnt = color.RedString(strconv.Itoa(stats.ResponseCount))
 		case stats.ResponseCount != stats.DiscoveredCount:
+			dcnt = color.YellowString(strconv.Itoa(stats.DiscoveredCount))
 			rcnt = color.YellowString(strconv.Itoa(stats.ResponseCount))
 		default:
 			dcnt = color.GreenString(strconv.Itoa(stats.DiscoveredCount))


### PR DESCRIPTION
A regression was introduced in cebe2cd78c63f1260d5198945b9c2cc67626a691
where the number of discovered nodes is not displayed if this number is
0 or if the number of responses is different from the number of
discovered nodes.

Properly initialize the string representation of the number of
discovered nodes to fix this issue.