### PR TITLE
(misc) Sort classes alphabeticaly in inventory

### DIFF
--- a/filter/classes/classes.go
+++ b/filter/classes/classes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -90,6 +91,8 @@ func ReadClasses(file string) ([]string, error) {
 	for scanner.Scan() {
 		classes = append(classes, scanner.Text())
 	}
+
+	sort.Strings(classes)
 
 	return classes, nil
 }


### PR DESCRIPTION
mco(1) used to do this sorting, and it makes the output more readable for humans, so sort the list of configuration management classes.

**Note:** The list of agents above the configuration management classes appears to be sorted but use a similar code.  maybe it's wise to sort it explicitly too?