### PR TITLE
(#1152) improve ping response calculations

### DIFF
--- a/choria/connection.go
+++ b/choria/connection.go
@@ -407,6 +407,8 @@ func (conn *Connection) publishFederatedBroadcast(msg *Message, transport protoc
 
 		log.Debugf("Sending a federated broadcast message to NATS target '%s' for message %s with type %s", target, msg.RequestID, msg.Type())
 
+		msg.NotifyPublish()
+
 		err = conn.PublishRaw(target, []byte(j))
 		if err != nil {
 			return err
@@ -440,7 +442,6 @@ func (conn *Connection) publishConnectedBroadcast(msg *Message, transport protoc
 	msg.NotifyPublish()
 
 	return conn.PublishRaw(target, []byte(j))
-
 }
 
 func (conn *Connection) publishConnectedDirect(msg *Message, transport protocol.TransportMessage) error {
@@ -458,6 +459,8 @@ func (conn *Connection) publishConnectedDirect(msg *Message, transport protocol.
 		}
 
 		log.Debugf("Sending a direct message to %s via NATS target '%s' for message %s type %s", host, target, msg.RequestID, msg.Type())
+
+		msg.NotifyPublish()
 
 		err = conn.PublishRaw(target, rawmsg)
 		if err != nil {

--- a/choria/message.go
+++ b/choria/message.go
@@ -131,7 +131,7 @@ func (m *Message) OnPublish(f func()) {
 	m.onPublish = f
 }
 
-// NotifyPublish triggers the callback set using OnPublish() in a blocking fasion
+// NotifyPublish triggers the callback set using OnPublish() in a blocking fashion
 func (m *Message) NotifyPublish() {
 	m.Lock()
 	defer m.Unlock()

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -80,7 +80,11 @@ func (p *pingCommand) Run(wg *sync.WaitGroup) (err error) {
 		return fmt.Errorf("could not create message: %s", err)
 	}
 	msg.Filter = filter
-	msg.OnPublish(func() { p.published = time.Now() })
+	msg.OnPublish(func() {
+		if p.published.IsZero() {
+			p.published = time.Now()
+		}
+	})
 
 	cl, err := client.New(c, client.Receivers(p.workers), client.Timeout(time.Duration(p.timeout)*time.Second))
 	if err != nil {


### PR DESCRIPTION
Ensures that the OnPublish() callbacks are called for all
kinds of message.

Handle multiple invocations correctly in the ping command

Signed-off-by: R.I.Pienaar <rip@devco.net>