### PR TITLE
(#1154) Support building ppc64le for EL7 and EL8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,19 @@ jobs:
 
     steps: *std_build_steps
 
+  build_el7_ppc64le_rpms:
+    docker:
+      - image: circleci/golang:1.16
+
+    working_directory: /go/src/github.com/choria-io/go-choria
+
+    environment:
+      PACKAGE: el7_ppc64le
+      BUILD: foss
+      BUILDER: choria/packager:el7-go1.16
+
+    steps: *std_build_steps
+
   build_el8_64bit_rpms:
     docker:
       - image: circleci/golang:1.16
@@ -113,6 +126,19 @@ jobs:
 
     environment:
       PACKAGE: el8_64
+      BUILD: foss
+      BUILDER: choria/packager:el8-go1.16
+
+    steps: *std_build_steps
+
+  build_el8_ppc64le_rpms:
+    docker:
+      - image: circleci/golang:1.16
+
+    working_directory: /go/src/github.com/choria-io/go-choria
+
+    environment:
+      PACKAGE: el8_ppc64le
       BUILD: foss
       BUILDER: choria/packager:el8-go1.16
 
@@ -305,7 +331,17 @@ workflows:
           requires:
             - test
 
+      - build_el8_ppc64le_rpms:
+          context: org-global
+          requires:
+            - test
+
       - build_el7_64bit_rpms:
+          context: org-global
+          requires:
+            - test
+
+      - build_el7_ppc64le_rpms:
           context: org-global
           requires:
             - test
@@ -318,7 +354,9 @@ workflows:
       - gather_artifacts:
           requires:
             - build_el7_64bit_rpms
+            - build_el7_ppc64le_rpms
             - build_el8_64bit_rpms
+            - build_el8_ppc64le_rpms
             - build_windows_64bit_msi
 
       - nightly_packagecloud:
@@ -347,7 +385,17 @@ workflows:
           requires:
             - hold
 
+      - build_el7_ppc64le_rpms:
+          filters: *semver_only
+          requires:
+            - hold
+
       - build_el8_64bit_rpms:
+          filters: *semver_only
+          requires:
+            - hold
+
+      - build_el8_ppc64le_rpms:
           filters: *semver_only
           requires:
             - hold
@@ -385,7 +433,9 @@ workflows:
       - gather_artifacts:
           requires:
             - build_el7_64bit_rpms
+            - build_el7_ppc64le_rpms
             - build_el8_64bit_rpms
+            - build_el8_ppc64le_rpms
             - build_xenial_64bit_debs
             - build_stretch_64bit_debs
             - build_buster_armhf_debs

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -46,10 +46,23 @@ foss:
       os: linux
       arch: arm
       arm: 7
+      pre:
+        - rm plugin_*.go || true
+        - GOOS=linux GOARCH=amd64 go generate --run plugin
+
+    ppc64le_linux:
+      os: linux
+      arch: ppc64le
+      pre:
+        - rm plugin_*.go || true
+        - GOOS=linux GOARCH=amd64 go generate --run plugin
 
     darwin:
       os: darwin
       arch: amd64
+      pre:
+        - rm plugin_*.go || true
+        - GOOS=linux GOARCH=amd64 go generate --run plugin
 
     # can probably not be built on an actual windows machine
     64bit_windows:
@@ -113,11 +126,23 @@ foss:
       target_arch: x86_64
       binary: 64bit_linux
 
+    el7_ppc64le:
+      template: el/el7
+      dist: el7
+      target_arch: ppc64le
+      binary: ppc64le_linux
+
     el8_64:
       template: el/el8
       dist: el8
       target_arch: x86_64
       binary: 64bit_linux
+
+    el8_ppc64le:
+      template: el/el8
+      dist: el8
+      target_arch: ppc64le
+      binary: ppc64le_linux
 
     xenial_64:
       template: debian/generic


### PR DESCRIPTION
Solves #1154 

binaries and RPMs built and verified on my local IBM ppc64le hardware just that the binaries included in the RPM work on that architecture.