### PR TITLE
(#1234) Service Agents only run mode

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -21,6 +21,7 @@ type serverCommand struct {
 type serverRunCommand struct {
 	command
 
+	serviceHost      bool
 	disableTLS       bool
 	disableTLSVerify bool
 	pidFile          string
@@ -52,6 +53,7 @@ func (r *serverRunCommand) Setup() (err error) {
 		r.cmd.Flag("disable-tls", "Disables TLS").Hidden().Default("false").BoolVar(&r.disableTLS)
 		r.cmd.Flag("disable-ssl-verification", "Disables SSL Verification").Hidden().Default("false").BoolVar(&r.disableTLSVerify)
 		r.cmd.Flag("pid", "Write running PID to a file").StringVar(&r.pidFile)
+		r.cmd.Flag("service-host", "Runs as a Service Agent host").BoolVar(&r.serviceHost)
 	}
 
 	return

--- a/cmd/server_run.go
+++ b/cmd/server_run.go
@@ -20,5 +20,9 @@ func (r *serverRunCommand) Run(wg *sync.WaitGroup) (err error) {
 	}
 
 	wg.Add(1)
-	return instance.Run(ctx, wg)
+	if r.serviceHost {
+		return instance.RunServiceHost(ctx, wg)
+	} else {
+		return instance.Run(ctx, wg)
+	}
 }


### PR DESCRIPTION
This adds a run mode to the server that runs a Service Agents
Only mode, all non service agents will be denied.

The server will publish lifecycle events as service_host

Signed-off-by: R.I.Pienaar <rip@devco.net>