### PR TITLE
(#1250) Print inventory columns vertically

### DIFF
--- a/cmd/inventory.go
+++ b/cmd/inventory.go
@@ -117,14 +117,14 @@ func (i *inventoryCommand) inventoryAgent() error {
 	fmt.Printf("               Replies Sent: %d\n", stats.Replies)
 	fmt.Println()
 	fmt.Printf("  Agents:\n\n")
-	util.SliceGroups(inventory.Agents, 3, func(g []string) {
+	util.SliceVerticalGroups(inventory.Agents, 3, func(g []string) {
 		fmt.Printf("    %-15s %-15s %-15s\n", g[0], g[1], g[2])
 	})
 	fmt.Println()
 	fmt.Printf("  Tagged Classes:\n\n")
 	longest := util.LongestString(inventory.Classes, 40)
 	format := fmt.Sprintf("    %%-%ds %%-%ds\n", longest, longest)
-	util.SliceGroups(inventory.Classes, 2, func(g []string) {
+	util.SliceVerticalGroups(inventory.Classes, 2, func(g []string) {
 		fmt.Printf(format, g[0], g[1])
 	})
 	fmt.Println()

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -168,6 +168,36 @@ func SliceGroups(input []string, size int, fn func(group []string)) {
 	}
 }
 
+// SliceVerticalGroups takes a slice of words and make new chunks of given size
+// and call the function with the sub slice.  The results are ordered for
+// vertical alignment.  If there are not enough items in the input slice empty
+// strings will pad the last group
+func SliceVerticalGroups(input []string, size int, fn func(group []string)) {
+	// how many to add
+	padding := size - (len(input) % size)
+
+	if padding != size {
+		p := []string{}
+
+		for i := 0; i <= padding; i++ {
+			p = append(p, "")
+		}
+
+		input = append(input, p...)
+	}
+
+	// how many chunks we're making
+	count := len(input) / size
+
+	for i := 0; i < count; i++ {
+		chunk := []string{}
+		for s := 0; s < size; s++ {
+			chunk = append(chunk, input[i+s*count])
+		}
+		fn(chunk)
+	}
+}
+
 // StrToBool converts a typical mcollective boolianish string to bool
 func StrToBool(s string) (bool, error) {
 	clean := strings.TrimSpace(s)


### PR DESCRIPTION
Improve output of choria inventory by sorting items "vertically" in a
similar fashion to `ls(1)` or `column(1)`.

Fixes: #1250 