### PR TITLE
(#1388) Restart choria-server on Debian on update

### DIFF
--- a/packager/templates/debian/generic/postinst
+++ b/packager/templates/debian/generic/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+action="$1"
+
+if [ "$action" = configure ]; then
+	old_version="$2"
+
+	if [ -z "$old_version" ]; then
+		systemctl enable choria-server.service
+	else
+		systemctl try-restart choria-broker.service choria-server.service
+	fi
+fi

--- a/packager/templates/debian/generic/postrm
+++ b/packager/templates/debian/generic/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl daemon-reload

--- a/packager/templates/debian/generic/prerm
+++ b/packager/templates/debian/generic/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+action="$1"
+
+if [ "$action" = remove ]; then
+	systemctl --no-reload disable choria-server.service choria-broker.service
+	systemctl stop choria-server.service choria-broker.service
+fi

--- a/packager/templates/debian/generic/rules
+++ b/packager/templates/debian/generic/rules
@@ -11,10 +11,6 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 
-override_dh_systemd_start:
-
-override_dh_systemd_enable:
-
 override_dh_auto_install:
 
 	install -Dm755 {{cpkg_binary}} debian/{{cpkg_name}}/usr/bin/{{cpkg_name}}

--- a/packager/templates/debian/generic/rules
+++ b/packager/templates/debian/generic/rules
@@ -27,4 +27,4 @@ endif
 	dh_systemd_enable -p{{cpkg_name}} --name={{cpkg_name}}-server
 
 	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-broker --no-start {{cpkg_name}}.{{cpkg_name}}-broker.service
-	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-server {{cpkg_name}}.{{cpkg_name}}-server.service
+	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-server --no-start {{cpkg_name}}.{{cpkg_name}}-server.service

--- a/packager/templates/debian/legacy/postinst
+++ b/packager/templates/debian/legacy/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+action="$1"
+
+if [ "$action" = configure ]; then
+	old_version="$2"
+
+	if [ -z "$old_version" ]; then
+		systemctl enable choria-server.service
+	else
+		systemctl try-restart choria-broker.service choria-server.service
+	fi
+fi

--- a/packager/templates/debian/legacy/postrm
+++ b/packager/templates/debian/legacy/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl daemon-reload

--- a/packager/templates/debian/legacy/prerm
+++ b/packager/templates/debian/legacy/prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+action="$1"
+
+if [ "$action" = remove ]; then
+	systemctl --no-reload disable choria-server.service choria-broker.service
+	systemctl stop choria-server.service choria-broker.service
+fi

--- a/packager/templates/debian/legacy/rules
+++ b/packager/templates/debian/legacy/rules
@@ -11,10 +11,6 @@ override_dh_auto_test:
 
 override_dh_auto_build:
 
-override_dh_systemd_start:
-
-override_dh_systemd_enable:
-
 override_dh_auto_install:
 
 	install -Dm755 {{cpkg_binary}} debian/{{cpkg_name}}/usr/bin/{{cpkg_name}}

--- a/packager/templates/debian/legacy/rules
+++ b/packager/templates/debian/legacy/rules
@@ -27,4 +27,4 @@ endif
 	dh_systemd_enable -p{{cpkg_name}} --name={{cpkg_name}}-server
 
 	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-broker --no-start {{cpkg_name}}.{{cpkg_name}}-broker.service
-	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-server {{cpkg_name}}.{{cpkg_name}}-server.service
+	dh_installinit -p{{cpkg_name}} --name={{cpkg_name}}-server --no-start {{cpkg_name}}.{{cpkg_name}}-server.service


### PR DESCRIPTION
So, it happen the logic that can "almost" manage the services as intended is already there:

https://github.com/choria-io/go-choria/blob/00825d7b9dec655577d8bca2f46f8c891417b78a/packager/templates/debian/generic/rules#L30-L34

…just "disabled" by some overrides a few lines above:

https://github.com/choria-io/go-choria/blob/00825d7b9dec655577d8bca2f46f8c891417b78a/packager/templates/debian/generic/rules#L14-L16

I write "almost" because when passing `--no-start` to `dh_installinit` like is done for the broker service, the service is not restarted on upgrade not stopped when the package is removed.

Puppet seems to be quite creative for handling the puppet service manually in their [postinst](https://github.com/puppetlabs/vanagon/blob/main/resources/deb/postinst.erb#L9), [prerm](https://github.com/puppetlabs/vanagon/blob/main/resources/deb/prerm.erb#L21) and [postrm](https://github.com/puppetlabs/vanagon/blob/main/resources/deb/postrm.erb#L19) scripts in order to not start the puppet agent when installing, but restart it when upgrading, stopping it when removing the package and so on.

~~I am not sure if it is wiser to replicate such a setup or just leave the broker service untouched on upgrades.~~  **EDIT** It's not at all what we spoke about in #1388 so I will definitively add this logic :stuck_out_tongue_closed_eyes:  **EDIT2** Done :ballot_box_with_check: 

Fixes #1388 