### PR TITLE
(#1403) do not reset mtime on skipped checks

### DIFF
--- a/aagent/watchers/event/event.go
+++ b/aagent/watchers/event/event.go
@@ -58,3 +58,8 @@ func (e *Event) WatcherType() string {
 func (e *Event) SenderID() string {
 	return e.Identity
 }
+
+// MachineName is the name of the autonomous agent
+func (e *Event) MachineName() string {
+	return e.Machine
+}

--- a/aagent/watchers/filewatcher/file.go
+++ b/aagent/watchers/filewatcher/file.go
@@ -165,17 +165,14 @@ func (w *Watcher) handleCheck(s State, err error) error {
 		return w.SuccessTransition()
 
 	case Unchanged:
-		// not notifying, regular announces happen
+	// not notifying, regular announces happen
 
-	case Skipped, Unknown:
-		// clear the time so that next time after once being skipped or unknown
-		// it will treat the file as not seen before and detect changes, but if
-		// its set to do initial check it specifically will not do that because
-		// the behavior of the first run in that case would be to only wait for
-		// future changes, this retains that behavior on becoming valid again
-		if !w.properties.Initial {
-			w.mtime = time.Time{}
-		}
+	case Skipped:
+	// nothing really to do, we keep old mtime next time round
+	// we'll correctly notify of changes
+
+	case Unknown:
+		w.mtime = time.Time{}
 	}
 
 	return nil
@@ -189,7 +186,6 @@ func (w *Watcher) watch() (state State, err error) {
 	stat, err := os.Stat(w.properties.Path)
 	if err != nil {
 		w.mtime = time.Time{}
-
 		return Error, fmt.Errorf("does not exist")
 	}
 

--- a/aagent/watchers/watcher/watcher.go
+++ b/aagent/watchers/watcher/watcher.go
@@ -257,7 +257,7 @@ func (w *Watcher) FailureTransition() error {
 		return nil
 	}
 
-	w.Infof("fail transitioning using %s event", w.succEvent)
+	w.Infof("fail transitioning using %s event", w.failEvent)
 	return w.machine.Transition(w.failEvent)
 }
 

--- a/cmd/machine_watch.go
+++ b/cmd/machine_watch.go
@@ -20,6 +20,7 @@ type mWatchCommand struct {
 	onlyWatchers      bool
 	filterWatcherType []string
 	filterIdentity    string
+	filterMachine     string
 	log               *logrus.Entry
 
 	sync.Mutex
@@ -28,6 +29,7 @@ type mWatchCommand struct {
 type mWatchableState interface {
 	String() string
 	SenderID() string
+	MachineName() string
 }
 
 func (w *mWatchCommand) Setup() (err error) {
@@ -37,6 +39,7 @@ func (w *mWatchCommand) Setup() (err error) {
 		w.cmd.Flag("watchers", "View only watcher states").BoolVar(&w.onlyWatchers)
 		w.cmd.Flag("type", "Limit watcher events to certain types").StringsVar(&w.filterWatcherType)
 		w.cmd.Flag("identity", "Filters identity").StringVar(&w.filterIdentity)
+		w.cmd.Flag("machine", "Filters based on machine name").StringVar(&w.filterMachine)
 	}
 
 	return nil
@@ -132,6 +135,9 @@ func (w *mWatchCommand) showState(m inter.ConnectorMessage) {
 	if w.filterIdentity != "" && !strings.Contains(event.SenderID(), w.filterIdentity) {
 		return
 	}
+	if w.filterMachine != "" && !strings.Contains(event.MachineName(), w.filterMachine) {
+		return
+	}
 
 	w.Lock()
 	fmt.Println(event.String())
@@ -155,6 +161,9 @@ func (w *mWatchCommand) showTransition(m inter.ConnectorMessage) {
 	}
 
 	if w.filterIdentity != "" && !strings.Contains(transition.Identity, w.filterIdentity) {
+		return
+	}
+	if w.filterMachine != "" && !strings.Contains(transition.Machine, w.filterMachine) {
 		return
 	}
 


### PR DESCRIPTION
Also allow events to be filtered by machine name in
machine watch

Signed-off-by: R.I.Pienaar <rip@devco.net>