### PR TITLE
(#1495) allow succesful, but unchaning kv gets to transition

### DIFF
--- a/aagent/watchers/kvwatcher/kv.go
+++ b/aagent/watchers/kvwatcher/kv.go
@@ -43,11 +43,12 @@ var stateNames = map[State]string{
 }
 
 type properties struct {
-	Bucket            string
-	Key               string
-	Mode              string
-	TransitionOnMatch bool `mapstructure:"on_matching_update"`
-	BucketPrefix      bool `mapstructure:"bucket_prefix"`
+	Bucket                    string
+	Key                       string
+	Mode                      string
+	TransitionOnSuccessfulGet bool `mapstructure:"on_successful_get"`
+	TransitionOnMatch         bool `mapstructure:"on_matching_update"`
+	BucketPrefix              bool `mapstructure:"bucket_prefix"`
 }
 
 type Watcher struct {
@@ -254,6 +255,10 @@ func (w *Watcher) poll() (State, error) {
 
 	default:
 		w.previousSeq = val.Sequence()
+		if w.properties.TransitionOnSuccessfulGet {
+			return Changed, nil
+		}
+
 		return Unchanged, nil
 	}
 }

--- a/aagent/watchers/machineswatcher/manager/machine.yaml
+++ b/aagent/watchers/machineswatcher/manager/machine.yaml
@@ -32,6 +32,7 @@ watchers:
       key: spec
       mode: poll
       bucket_prefix: false
+      on_successful_get: true
 
   - name: specification
     type: kv


### PR DESCRIPTION
Use this in the machines manager to transition initial
kv get on unchanged data

Signed-off-by: R.I.Pienaar <rip@devco.net>