### PR TITLE
(#1522) use "broker run" to run the broker

### DIFF
--- a/cmd/broker.go
+++ b/cmd/broker.go
@@ -52,7 +52,7 @@ func (b *brokerCommand) Setup() (err error) {
 
 	b.cmd.PreAction(func(pc *kingpin.ParseContext) error {
 		cmd := pc.String()
-		if cmd == "broker run" {
+		if cmd == "broker" || cmd == "broker run" {
 			return nil
 		}
 

--- a/packager/templates/debian/generic/broker.service
+++ b/packager/templates/debian/generic/broker.service
@@ -6,7 +6,7 @@ After=network.target
 LimitNOFILE=51200
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/debian/legacy/broker.service
+++ b/packager/templates/debian/legacy/broker.service
@@ -6,7 +6,7 @@ After=network.target
 LimitNOFILE=51200
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el6/broker.init
+++ b/packager/templates/el/el6/broker.init
@@ -28,7 +28,7 @@ ulimit -n 51200
 # pull in sysconfig settings
 [ -e /etc/sysconfig/${prog} ] && . /etc/sysconfig/${prog}
 
-args="broker --config=${conffile} --pid=${pidfile} ${EXTRA_OPTS}"
+args="broker run --config=${conffile} --pid=${pidfile} ${EXTRA_OPTS}"
 
 start() {
     [ -x $exec ] || exit 5

--- a/packager/templates/el/el7/broker.service
+++ b/packager/templates/el/el7/broker.service
@@ -6,7 +6,7 @@ After=network.target
 LimitNOFILE=51200
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el8/broker.service
+++ b/packager/templates/el/el8/broker.service
@@ -6,7 +6,7 @@ After=network.target
 LimitNOFILE=51200
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker --config={{cpkg_etcdir}}/broker.conf
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
In the past we had just broker run under broker and that was
set to default.  Now that we have the nats cli there we cannot
rely on this default anymore.

Inits needed to be updated to call broker run specifically

Signed-off-by: R.I.Pienaar <rip@devco.net>