### PR TITLE
(#1576) allow the server service to auto start on el7 and 8

### DIFF
--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -94,6 +94,7 @@ foss:
       etcdir: /etc/choria
       release: 1
       manage_conf: 1
+      manage_server_preset: 0
       contact: R.I.Pienaar <rip@devco.net>
       rpm_group: System Environment/Base
       server_start_runlevels: "-"

--- a/packager/templates/el/el7/broker.service
+++ b/packager/templates/el/el7/broker.service
@@ -7,6 +7,8 @@ LimitNOFILE=51200
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el7/choria.spec
+++ b/packager/templates/el/el7/choria.spec
@@ -6,6 +6,7 @@
 %define release {{cpkg_release}}
 %define dist {{cpkg_dist}}
 %define manage_conf {{cpkg_manage_conf}}
+%define manage_server_preset {{cpkg_manage_server_preset}}
 %define binary {{cpkg_binary}}
 %define tarball {{cpkg_tarball}}
 %define contact {{cpkg_contact}}
@@ -40,15 +41,19 @@ rm -rf %{buildroot}
 %{__install} -d -m0755  %{buildroot}%{bindir}
 %{__install} -d -m0755  %{buildroot}%{etcdir}
 %{__install} -d -m0755  %{buildroot}/var/log
+%{__install} -d -m0755  %{buildroot}/usr/lib/systemd/system-preset
 %{__install} -m0644 dist/server.sysconfig %{buildroot}/etc/sysconfig/%{pkgname}-server
 %{__install} -m0644 dist/server.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-server.service
 %{__install} -m0644 dist/broker.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-broker.service
 %{__install} -m0644 dist/choria-logrotate %{buildroot}/etc/logrotate.d/%{pkgname}
+%{__install} -m0755 %{binary} %{buildroot}%{bindir}/%{pkgname}
 %if 0%{?manage_conf} > 0
 %{__install} -m0640 dist/server.conf %{buildroot}%{etcdir}/server.conf
 %{__install} -m0640 dist/broker.conf %{buildroot}%{etcdir}/broker.conf
 %endif
-%{__install} -m0755 %{binary} %{buildroot}%{bindir}/%{pkgname}
+%if 0%{?manage_server_preset} > 0
+%{__install} -m0644 dist/server-enable.preset %{buildroot}/usr/lib/systemd/system-preset/60-%{pkgname}-server.preset
+%endif
 
 %clean
 rm -rf %{buildroot}
@@ -76,6 +81,9 @@ fi
 %if 0%{?manage_conf} > 0
 %config(noreplace)%{etcdir}/broker.conf
 %config(noreplace)%{etcdir}/server.conf
+%endif
+%if 0%{?manage_server_preset} > 0
+/usr/lib/systemd/system-preset/60-%{pkgname}-server.preset
 %endif
 %{bindir}/%{pkgname}
 /etc/logrotate.d/%{pkgname}

--- a/packager/templates/el/el7/config.yaml
+++ b/packager/templates/el/el7/config.yaml
@@ -3,6 +3,7 @@ required_properties:
   - bindir
   - etcdir
   - manage_conf
+  - manage_server_preset
   - contact
   - dist
   - target_arch

--- a/packager/templates/el/el7/server.service
+++ b/packager/templates/el/el7/server.service
@@ -8,6 +8,8 @@ User=root
 Group=root
 ExecStart=/bin/sh -c "${COMMAND_PREFIX} {{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf"
 KillMode=process
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el8/broker.service
+++ b/packager/templates/el/el8/broker.service
@@ -7,6 +7,8 @@ LimitNOFILE=51200
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} broker run --config={{cpkg_etcdir}}/broker.conf
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/el8/choria.spec
+++ b/packager/templates/el/el8/choria.spec
@@ -6,6 +6,7 @@
 %define release {{cpkg_release}}
 %define dist {{cpkg_dist}}
 %define manage_conf {{cpkg_manage_conf}}
+%define manage_server_preset {{cpkg_manage_server_preset}}
 %define binary {{cpkg_binary}}
 %define tarball {{cpkg_tarball}}
 %define contact {{cpkg_contact}}
@@ -40,15 +41,19 @@ rm -rf %{buildroot}
 %{__install} -d -m0755  %{buildroot}%{bindir}
 %{__install} -d -m0755  %{buildroot}%{etcdir}
 %{__install} -d -m0755  %{buildroot}/var/log
+%{__install} -d -m0755  %{buildroot}/usr/lib/systemd/system-preset
 %{__install} -m0644 dist/server.sysconfig %{buildroot}/etc/sysconfig/%{pkgname}-server
 %{__install} -m0644 dist/server.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-server.service
 %{__install} -m0644 dist/broker.service %{buildroot}/usr/lib/systemd/system/%{pkgname}-broker.service
 %{__install} -m0644 dist/choria-logrotate %{buildroot}/etc/logrotate.d/%{pkgname}
+%{__install} -m0755 %{binary} %{buildroot}%{bindir}/%{pkgname}
 %if 0%{?manage_conf} > 0
 %{__install} -m0640 dist/server.conf %{buildroot}%{etcdir}/server.conf
 %{__install} -m0640 dist/broker.conf %{buildroot}%{etcdir}/broker.conf
 %endif
-%{__install} -m0755 %{binary} %{buildroot}%{bindir}/%{pkgname}
+%if 0%{?manage_server_preset} > 0
+%{__install} -m0644 dist/server-enable.preset %{buildroot}/usr/lib/systemd/system-preset/60-%{pkgname}-server.preset
+%endif
 
 %clean
 rm -rf %{buildroot}
@@ -76,6 +81,9 @@ fi
 %if 0%{?manage_conf} > 0
 %config(noreplace)%{etcdir}/broker.conf
 %config(noreplace)%{etcdir}/server.conf
+%endif
+%if 0%{?manage_server_preset} > 0
+/usr/lib/systemd/system-preset/60-%{pkgname}-server.preset
 %endif
 %{bindir}/%{pkgname}
 /etc/logrotate.d/%{pkgname}

--- a/packager/templates/el/el8/config.yaml
+++ b/packager/templates/el/el8/config.yaml
@@ -3,6 +3,7 @@ required_properties:
   - bindir
   - etcdir
   - manage_conf
+  - manage_server_preset
   - contact
   - dist
   - target_arch

--- a/packager/templates/el/el8/server.service
+++ b/packager/templates/el/el8/server.service
@@ -8,6 +8,8 @@ User=root
 Group=root
 ExecStart=/bin/sh -c "${COMMAND_PREFIX} {{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf"
 KillMode=process
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/packager/templates/el/global/server-enable.preset
+++ b/packager/templates/el/global/server-enable.preset
@@ -1,0 +1,1 @@
+enable %{pkgname}-server.service


### PR DESCRIPTION
This adds a new build setting flag manage_server_preset for el machines that
when set to 1 will place a preset file to enable the service at boot time

It also sets the server and broker to auto restart with 5s grace

Signed-off-by: R.I.Pienaar <rip@devco.net>