### PR TITLE
(#1405) Add 64-bit ARM package

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,6 +25,16 @@ jobs:
           packager_tag: el8-go1.17
           version: nightly
 
+  bullseye_aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: choria-io/actions/packager@main
+        with:
+          build_package: bullseye_aarch64
+          packager_tag: bullseye-go1.17
+          version: nightly
+
   linux_tarball:
     runs-on: ubuntu-latest
     steps:
@@ -69,6 +79,7 @@ jobs:
     needs:
       - el7_64
       - el8_64
+      - bullseye_aarch64
       - linux_tarball
       - windows_zip
       - darwin_amd64_tarball

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -54,6 +54,13 @@ foss:
         - rm plugin_*.go || true
         - GOOS=linux GOARCH=amd64 go generate --run plugin
 
+    aarch64_linux:
+      os: linux
+      arch: arm64
+      pre:
+        - rm plugin_*.go || true
+        - GOOS=linux GOARCH=amd64 go generate --run plugin
+
     ppc64le_linux:
       os: linux
       arch: ppc64le
@@ -211,6 +218,11 @@ foss:
       template: debian/generic
       target_arch: x86_64-linux-gnu
       binary: 64bit_linux
+
+    bullseye_aarch64:
+      template: debian/generic
+      target_arch: aarch64-linux-gnu
+      binary: aarch64_linux
 
     windows_64:
       name: Choria


### PR DESCRIPTION
As I only have access to bullseye systems for testing, I've only written up the buildspec for one of those.
The package builds, installs, and runs fine on my test system though. (a Raspberry Pi 4 Model B)