### PR TITLE
(#1405) Expand 64-bit ARM buildspec list

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -25,16 +25,6 @@ jobs:
           packager_tag: el8-go1.17
           version: nightly
 
-  bullseye_aarch64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Build
-        uses: choria-io/actions/packager@main
-        with:
-          build_package: bullseye_aarch64
-          packager_tag: bullseye-go1.17
-          version: nightly
-
   linux_tarball:
     runs-on: ubuntu-latest
     steps:

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -194,10 +194,20 @@ foss:
       target_arch: x86_64-linux-gnu
       binary: 64bit_linux
 
+    bionic_aarch64:
+      template: debian/generic
+      target_arch: aarch64-linux-gnu
+      binary: aarch64_linux
+
     focal_64:
       template: debian/generic
       target_arch: x86_64-linux-gnu
       binary: 64bit_linux
+
+    focal_aarch64:
+      template: debian/generic
+      target_arch: aarch64-linux-gnu
+      binary: aarch64_linux
 
     buster_64:
       template: debian/generic
@@ -213,6 +223,11 @@ foss:
       template: debian/generic
       target_arch: arm-linux-gnueabihf
       binary: armv7_linux
+
+    buster_aarch64:
+      template: debian/generic
+      target_arch: aarch64-linux-gnu
+      binary: aarch64_linux
 
     bullseye_64:
       template: debian/generic


### PR DESCRIPTION
Now includes aarch64 for the non-EoL versions of Debian and Ubuntu
(Except for Debian Stretch, as its EoL date is in June this year)