### PR TITLE
(#1604) Fix startup on windows

### DIFF
--- a/cmd/server_run_windows.go
+++ b/cmd/server_run_windows.go
@@ -57,12 +57,12 @@ loop:
 }
 
 func (r *serverRunCommand) platformRun(wg *sync.WaitGroup) (err error) {
-	interactive, err := svc.IsWindowsService()
+	is_service, err := svc.IsWindowsService()
 	if err != nil {
 		return err
 	}
 
-	if interactive {
+	if !is_service {
 		instance, err := r.prepareInstance()
 		if err != nil {
 			return err


### PR DESCRIPTION
Some refactoring in e2a6908c6d0c204cf71f6ebe090d04998c7b6046 unintenitonaly replaced a call to `svc.IsAnInteractiveSession()` with `svc.IsWindowsService()` without changing the variable name nor the logic. As a result when choria is started as a service it acted as a regular command, failing to register to the windows service manager and telling it it started successfuly, and when started from the CLI it failed to start because it could not do such registration only accessible to services.

Rename the variable and fix the logic to unbreak windows.
