### PR TITLE
(#1640) allow invalid security setup during provisioning

### DIFF
--- a/cmd/server_run.go
+++ b/cmd/server_run.go
@@ -124,11 +124,15 @@ func (r *serverRunCommand) provisionConfig(f string) (*config.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not create default configuration for provisioning: %s", err)
 	}
+
 	cfg.ConfigFile = f
 
 	// set this to avoid calling into puppet on non puppet machines
 	// later ConfigureProvisioning() will do all the right things
 	cfg.Choria.SecurityProvider = "file"
+
+	// in provision mode we do not yet have certs and stuff so we disable these checks
+	cfg.DisableSecurityProviderVerify = true
 
 	return cfg, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/nats-io/jsm.go v0.0.31-0.20220401122808-745078cafbd4
-	github.com/nats-io/nats-server/v2 v2.7.5-0.20220402001934-18bdabff35cf
+	github.com/nats-io/nats-server/v2 v2.7.5-0.20220406163040-3485dcf2b959
 	github.com/nats-io/nats.go v1.13.1-0.20220329232831-e076b0dcab31
 	github.com/nats-io/natscli v0.0.31-0.20220402184315-b98523fb59e1
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/nats-io/jsm.go v0.0.31-0.20220401122808-745078cafbd4/go.mod h1:Lyq+0M
 github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a h1:lem6QCvxR0Y28gth9P+wV2K/zYUUAkJ+55U8cpS0p5I=
 github.com/nats-io/jwt/v2 v2.2.1-0.20220330180145-442af02fd36a/go.mod h1:0tqz9Hlu6bCBFLWAASKhE5vUA4c24L9KPUUgvwumE/k=
 github.com/nats-io/nats-server/v2 v2.7.5-0.20220331232429-32b17f7a7e0f/go.mod h1:N0uJ7UmE2huQRl0kZbJfn12rHVva64E+uYzB/ORzT/0=
-github.com/nats-io/nats-server/v2 v2.7.5-0.20220402001934-18bdabff35cf h1:eb2NJO9bhm9g2dvOIwEb4ENSMs5slshJAF1Gjcr2Zs0=
-github.com/nats-io/nats-server/v2 v2.7.5-0.20220402001934-18bdabff35cf/go.mod h1:N0uJ7UmE2huQRl0kZbJfn12rHVva64E+uYzB/ORzT/0=
+github.com/nats-io/nats-server/v2 v2.7.5-0.20220406163040-3485dcf2b959 h1:gYVXPi4Qa1WIsNAB2xZn5R5vkZXIjzfU40xwc1ZF52s=
+github.com/nats-io/nats-server/v2 v2.7.5-0.20220406163040-3485dcf2b959/go.mod h1:N0uJ7UmE2huQRl0kZbJfn12rHVva64E+uYzB/ORzT/0=
 github.com/nats-io/nats.go v1.13.1-0.20220318132711-e0e03e374228/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=
 github.com/nats-io/nats.go v1.13.1-0.20220329232831-e076b0dcab31 h1:5KwkkpgAYQ/QhmXLsXyFWeEKccJxKpI+8tSZL33MIrQ=
 github.com/nats-io/nats.go v1.13.1-0.20220329232831-e076b0dcab31/go.mod h1:BPko4oXsySz4aSWeFgOHLZs3G4Jq4ZAyE6/zMCxRT6w=


### PR DESCRIPTION
This fixes a regression introduced in unreleased code
related to provisioning, without this startup fails
to find valid certificates and bails, but during prov
we do not yet have such certificates.

Signed-off-by: R.I.Pienaar <rip@devco.net>