### PR TITLE
(#1697) Support subject remappings

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -44,58 +44,59 @@ A few special types are defined, the rest map to standard Go types
 |[plugin.choria.network.deny_server_connections](#pluginchorianetworkdeny_server_connections)|[plugin.choria.network.gateway_name](#pluginchorianetworkgateway_name)|
 |[plugin.choria.network.gateway_port](#pluginchorianetworkgateway_port)|[plugin.choria.network.gateway_remotes](#pluginchorianetworkgateway_remotes)|
 |[plugin.choria.network.leafnode_port](#pluginchorianetworkleafnode_port)|[plugin.choria.network.leafnode_remotes](#pluginchorianetworkleafnode_remotes)|
-|[plugin.choria.network.listen_address](#pluginchorianetworklisten_address)|[plugin.choria.network.peer_password](#pluginchorianetworkpeer_password)|
-|[plugin.choria.network.peer_port](#pluginchorianetworkpeer_port)|[plugin.choria.network.peer_user](#pluginchorianetworkpeer_user)|
-|[plugin.choria.network.peers](#pluginchorianetworkpeers)|[plugin.choria.network.pprof_port](#pluginchorianetworkpprof_port)|
-|[plugin.choria.network.provisioning.client_password](#pluginchorianetworkprovisioningclient_password)|[plugin.choria.network.provisioning.signer_cert](#pluginchorianetworkprovisioningsigner_cert)|
-|[plugin.choria.network.public_url](#pluginchorianetworkpublic_url)|[plugin.choria.network.server_signer_cert](#pluginchorianetworkserver_signer_cert)|
-|[plugin.choria.network.stream.advisory_replicas](#pluginchorianetworkstreamadvisory_replicas)|[plugin.choria.network.stream.advisory_retention](#pluginchorianetworkstreamadvisory_retention)|
-|[plugin.choria.network.stream.event_replicas](#pluginchorianetworkstreamevent_replicas)|[plugin.choria.network.stream.event_retention](#pluginchorianetworkstreamevent_retention)|
-|[plugin.choria.network.stream.leader_election_replicas](#pluginchorianetworkstreamleader_election_replicas)|[plugin.choria.network.stream.leader_election_ttl](#pluginchorianetworkstreamleader_election_ttl)|
-|[plugin.choria.network.stream.machine_replicas](#pluginchorianetworkstreammachine_replicas)|[plugin.choria.network.stream.machine_retention](#pluginchorianetworkstreammachine_retention)|
-|[plugin.choria.network.stream.manage_streams](#pluginchorianetworkstreammanage_streams)|[plugin.choria.network.stream.store](#pluginchorianetworkstreamstore)|
-|[plugin.choria.network.system.password](#pluginchorianetworksystempassword)|[plugin.choria.network.system.user](#pluginchorianetworksystemuser)|
-|[plugin.choria.network.tls_timeout](#pluginchorianetworktls_timeout)|[plugin.choria.network.websocket_advertise](#pluginchorianetworkwebsocket_advertise)|
-|[plugin.choria.network.websocket_port](#pluginchorianetworkwebsocket_port)|[plugin.choria.network.write_deadline](#pluginchorianetworkwrite_deadline)|
-|[plugin.choria.prometheus_textfile_directory](#pluginchoriaprometheus_textfile_directory)|[plugin.choria.puppetca_host](#pluginchoriapuppetca_host)|
-|[plugin.choria.puppetca_port](#pluginchoriapuppetca_port)|[plugin.choria.puppetdb_host](#pluginchoriapuppetdb_host)|
-|[plugin.choria.puppetdb_port](#pluginchoriapuppetdb_port)|[plugin.choria.puppetserver_host](#pluginchoriapuppetserver_host)|
-|[plugin.choria.puppetserver_port](#pluginchoriapuppetserver_port)|[plugin.choria.randomize_middleware_hosts](#pluginchoriarandomize_middleware_hosts)|
-|[plugin.choria.registration.file_content.compression](#pluginchoriaregistrationfile_contentcompression)|[plugin.choria.registration.file_content.data](#pluginchoriaregistrationfile_contentdata)|
-|[plugin.choria.registration.file_content.target](#pluginchoriaregistrationfile_contenttarget)|[plugin.choria.registration.inventory_content.compression](#pluginchoriaregistrationinventory_contentcompression)|
-|[plugin.choria.registration.inventory_content.target](#pluginchoriaregistrationinventory_contenttarget)|[plugin.choria.require_client_filter](#pluginchoriarequire_client_filter)|
-|[plugin.choria.security.certname_whitelist](#pluginchoriasecuritycertname_whitelist)|[plugin.choria.security.privileged_users](#pluginchoriasecurityprivileged_users)|
-|[plugin.choria.security.request_signer.seed_file](#pluginchoriasecurityrequest_signerseed_file)|[plugin.choria.security.request_signer.service](#pluginchoriasecurityrequest_signerservice)|
-|[plugin.choria.security.request_signer.token_file](#pluginchoriasecurityrequest_signertoken_file)|[plugin.choria.security.request_signer.url](#pluginchoriasecurityrequest_signerurl)|
-|[plugin.choria.security.request_signing_certificate](#pluginchoriasecurityrequest_signing_certificate)|[plugin.choria.security.serializer](#pluginchoriasecurityserializer)|
-|[plugin.choria.security.server.seed_file](#pluginchoriasecurityserverseed_file)|[plugin.choria.security.server.token_file](#pluginchoriasecurityservertoken_file)|
-|[plugin.choria.server.provision](#pluginchoriaserverprovision)|[plugin.choria.services.registry.cache](#pluginchoriaservicesregistrycache)|
-|[plugin.choria.services.registry.store](#pluginchoriaservicesregistrystore)|[plugin.choria.srv_domain](#pluginchoriasrv_domain)|
-|[plugin.choria.ssldir](#pluginchoriassldir)|[plugin.choria.stats_address](#pluginchoriastats_address)|
-|[plugin.choria.stats_port](#pluginchoriastats_port)|[plugin.choria.status_file_path](#pluginchoriastatus_file_path)|
-|[plugin.choria.status_update_interval](#pluginchoriastatus_update_interval)|[plugin.choria.submission.max_spool_size](#pluginchoriasubmissionmax_spool_size)|
-|[plugin.choria.submission.spool](#pluginchoriasubmissionspool)|[plugin.choria.use_srv](#pluginchoriause_srv)|
-|[plugin.login.aaasvc.login.url](#pluginloginaaasvcloginurl)|[plugin.nats.credentials](#pluginnatscredentials)|
-|[plugin.nats.ngs](#pluginnatsngs)|[plugin.nats.pass](#pluginnatspass)|
-|[plugin.nats.user](#pluginnatsuser)|[plugin.scout.agent_disabled](#pluginscoutagent_disabled)|
-|[plugin.scout.overrides](#pluginscoutoverrides)|[plugin.scout.tags](#pluginscouttags)|
-|[plugin.security.always_overwrite_cache](#pluginsecurityalways_overwrite_cache)|[plugin.security.certmanager.alt_names](#pluginsecuritycertmanageralt_names)|
-|[plugin.security.certmanager.api_version](#pluginsecuritycertmanagerapi_version)|[plugin.security.certmanager.issuer](#pluginsecuritycertmanagerissuer)|
-|[plugin.security.certmanager.namespace](#pluginsecuritycertmanagernamespace)|[plugin.security.certmanager.replace](#pluginsecuritycertmanagerreplace)|
-|[plugin.security.cipher_suites](#pluginsecuritycipher_suites)|[plugin.security.client_anon_tls](#pluginsecurityclient_anon_tls)|
-|[plugin.security.ecc_curves](#pluginsecurityecc_curves)|[plugin.security.file.ca](#pluginsecurityfileca)|
-|[plugin.security.file.cache](#pluginsecurityfilecache)|[plugin.security.file.certificate](#pluginsecurityfilecertificate)|
-|[plugin.security.file.key](#pluginsecurityfilekey)|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|
-|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|[plugin.security.provider](#pluginsecurityprovider)|
-|[plugin.security.server_anon_tls](#pluginsecurityserver_anon_tls)|[plugin.security.support_legacy_certificates](#pluginsecuritysupport_legacy_certificates)|
-|[plugin.yaml](#pluginyaml)|[publish_timeout](#publish_timeout)|
-|[registerinterval](#registerinterval)|[registration](#registration)|
-|[registration_collective](#registration_collective)|[registration_splay](#registration_splay)|
-|[rpcaudit](#rpcaudit)|[rpcauditprovider](#rpcauditprovider)|
-|[rpcauthorization](#rpcauthorization)|[rpcauthprovider](#rpcauthprovider)|
-|[rpclimitmethod](#rpclimitmethod)|[securityprovider](#securityprovider)|
-|[soft_shutdown](#soft_shutdown)|[soft_shutdown_timeout](#soft_shutdown_timeout)|
-|[threaded](#threaded)|[ttl](#ttl)|
+|[plugin.choria.network.listen_address](#pluginchorianetworklisten_address)|[plugin.choria.network.mapping.names](#pluginchorianetworkmappingnames)|
+|[plugin.choria.network.peer_password](#pluginchorianetworkpeer_password)|[plugin.choria.network.peer_port](#pluginchorianetworkpeer_port)|
+|[plugin.choria.network.peer_user](#pluginchorianetworkpeer_user)|[plugin.choria.network.peers](#pluginchorianetworkpeers)|
+|[plugin.choria.network.pprof_port](#pluginchorianetworkpprof_port)|[plugin.choria.network.provisioning.client_password](#pluginchorianetworkprovisioningclient_password)|
+|[plugin.choria.network.provisioning.signer_cert](#pluginchorianetworkprovisioningsigner_cert)|[plugin.choria.network.public_url](#pluginchorianetworkpublic_url)|
+|[plugin.choria.network.server_signer_cert](#pluginchorianetworkserver_signer_cert)|[plugin.choria.network.stream.advisory_replicas](#pluginchorianetworkstreamadvisory_replicas)|
+|[plugin.choria.network.stream.advisory_retention](#pluginchorianetworkstreamadvisory_retention)|[plugin.choria.network.stream.event_replicas](#pluginchorianetworkstreamevent_replicas)|
+|[plugin.choria.network.stream.event_retention](#pluginchorianetworkstreamevent_retention)|[plugin.choria.network.stream.leader_election_replicas](#pluginchorianetworkstreamleader_election_replicas)|
+|[plugin.choria.network.stream.leader_election_ttl](#pluginchorianetworkstreamleader_election_ttl)|[plugin.choria.network.stream.machine_replicas](#pluginchorianetworkstreammachine_replicas)|
+|[plugin.choria.network.stream.machine_retention](#pluginchorianetworkstreammachine_retention)|[plugin.choria.network.stream.manage_streams](#pluginchorianetworkstreammanage_streams)|
+|[plugin.choria.network.stream.store](#pluginchorianetworkstreamstore)|[plugin.choria.network.system.password](#pluginchorianetworksystempassword)|
+|[plugin.choria.network.system.user](#pluginchorianetworksystemuser)|[plugin.choria.network.tls_timeout](#pluginchorianetworktls_timeout)|
+|[plugin.choria.network.websocket_advertise](#pluginchorianetworkwebsocket_advertise)|[plugin.choria.network.websocket_port](#pluginchorianetworkwebsocket_port)|
+|[plugin.choria.network.write_deadline](#pluginchorianetworkwrite_deadline)|[plugin.choria.prometheus_textfile_directory](#pluginchoriaprometheus_textfile_directory)|
+|[plugin.choria.puppetca_host](#pluginchoriapuppetca_host)|[plugin.choria.puppetca_port](#pluginchoriapuppetca_port)|
+|[plugin.choria.puppetdb_host](#pluginchoriapuppetdb_host)|[plugin.choria.puppetdb_port](#pluginchoriapuppetdb_port)|
+|[plugin.choria.puppetserver_host](#pluginchoriapuppetserver_host)|[plugin.choria.puppetserver_port](#pluginchoriapuppetserver_port)|
+|[plugin.choria.randomize_middleware_hosts](#pluginchoriarandomize_middleware_hosts)|[plugin.choria.registration.file_content.compression](#pluginchoriaregistrationfile_contentcompression)|
+|[plugin.choria.registration.file_content.data](#pluginchoriaregistrationfile_contentdata)|[plugin.choria.registration.file_content.target](#pluginchoriaregistrationfile_contenttarget)|
+|[plugin.choria.registration.inventory_content.compression](#pluginchoriaregistrationinventory_contentcompression)|[plugin.choria.registration.inventory_content.target](#pluginchoriaregistrationinventory_contenttarget)|
+|[plugin.choria.require_client_filter](#pluginchoriarequire_client_filter)|[plugin.choria.security.certname_whitelist](#pluginchoriasecuritycertname_whitelist)|
+|[plugin.choria.security.privileged_users](#pluginchoriasecurityprivileged_users)|[plugin.choria.security.request_signer.seed_file](#pluginchoriasecurityrequest_signerseed_file)|
+|[plugin.choria.security.request_signer.service](#pluginchoriasecurityrequest_signerservice)|[plugin.choria.security.request_signer.token_file](#pluginchoriasecurityrequest_signertoken_file)|
+|[plugin.choria.security.request_signer.url](#pluginchoriasecurityrequest_signerurl)|[plugin.choria.security.request_signing_certificate](#pluginchoriasecurityrequest_signing_certificate)|
+|[plugin.choria.security.serializer](#pluginchoriasecurityserializer)|[plugin.choria.security.server.seed_file](#pluginchoriasecurityserverseed_file)|
+|[plugin.choria.security.server.token_file](#pluginchoriasecurityservertoken_file)|[plugin.choria.server.provision](#pluginchoriaserverprovision)|
+|[plugin.choria.services.registry.cache](#pluginchoriaservicesregistrycache)|[plugin.choria.services.registry.store](#pluginchoriaservicesregistrystore)|
+|[plugin.choria.srv_domain](#pluginchoriasrv_domain)|[plugin.choria.ssldir](#pluginchoriassldir)|
+|[plugin.choria.stats_address](#pluginchoriastats_address)|[plugin.choria.stats_port](#pluginchoriastats_port)|
+|[plugin.choria.status_file_path](#pluginchoriastatus_file_path)|[plugin.choria.status_update_interval](#pluginchoriastatus_update_interval)|
+|[plugin.choria.submission.max_spool_size](#pluginchoriasubmissionmax_spool_size)|[plugin.choria.submission.spool](#pluginchoriasubmissionspool)|
+|[plugin.choria.use_srv](#pluginchoriause_srv)|[plugin.login.aaasvc.login.url](#pluginloginaaasvcloginurl)|
+|[plugin.nats.credentials](#pluginnatscredentials)|[plugin.nats.ngs](#pluginnatsngs)|
+|[plugin.nats.pass](#pluginnatspass)|[plugin.nats.user](#pluginnatsuser)|
+|[plugin.scout.agent_disabled](#pluginscoutagent_disabled)|[plugin.scout.overrides](#pluginscoutoverrides)|
+|[plugin.scout.tags](#pluginscouttags)|[plugin.security.always_overwrite_cache](#pluginsecurityalways_overwrite_cache)|
+|[plugin.security.certmanager.alt_names](#pluginsecuritycertmanageralt_names)|[plugin.security.certmanager.api_version](#pluginsecuritycertmanagerapi_version)|
+|[plugin.security.certmanager.issuer](#pluginsecuritycertmanagerissuer)|[plugin.security.certmanager.namespace](#pluginsecuritycertmanagernamespace)|
+|[plugin.security.certmanager.replace](#pluginsecuritycertmanagerreplace)|[plugin.security.cipher_suites](#pluginsecuritycipher_suites)|
+|[plugin.security.client_anon_tls](#pluginsecurityclient_anon_tls)|[plugin.security.ecc_curves](#pluginsecurityecc_curves)|
+|[plugin.security.file.ca](#pluginsecurityfileca)|[plugin.security.file.cache](#pluginsecurityfilecache)|
+|[plugin.security.file.certificate](#pluginsecurityfilecertificate)|[plugin.security.file.key](#pluginsecurityfilekey)|
+|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|
+|[plugin.security.provider](#pluginsecurityprovider)|[plugin.security.server_anon_tls](#pluginsecurityserver_anon_tls)|
+|[plugin.security.support_legacy_certificates](#pluginsecuritysupport_legacy_certificates)|[plugin.yaml](#pluginyaml)|
+|[publish_timeout](#publish_timeout)|[registerinterval](#registerinterval)|
+|[registration](#registration)|[registration_collective](#registration_collective)|
+|[registration_splay](#registration_splay)|[rpcaudit](#rpcaudit)|
+|[rpcauditprovider](#rpcauditprovider)|[rpcauthorization](#rpcauthorization)|
+|[rpcauthprovider](#rpcauthprovider)|[rpclimitmethod](#rpclimitmethod)|
+|[securityprovider](#securityprovider)|[soft_shutdown](#soft_shutdown)|
+|[soft_shutdown_timeout](#soft_shutdown_timeout)|[threaded](#threaded)|
+|[ttl](#ttl)|[](#)|
 
 
 ## activate_agents
@@ -445,6 +446,12 @@ Remote networks to connect to as a Leafnode
  * **Default Value:** ::
 
 Address the Network Broker will listen on
+
+## plugin.choria.network.mapping.names
+
+ * **Type:** comma_split
+
+List of subject remappings to apply
 
 ## plugin.choria.network.peer_password
 

--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -117,6 +117,11 @@ func NewServer(c inter.Framework, bi BuildInfoProvider, debug bool) (s *Server, 
 		return s, fmt.Errorf("could not set up accounts: %s", err)
 	}
 
+	err = s.setupMappings()
+	if err != nil {
+		s.log.Errorf("Network Mapping setup failed: %v", err)
+	}
+
 	err = s.setupWebSockets()
 	if err != nil {
 		return s, fmt.Errorf("could not set up WebSocket: %s", err)

--- a/broker/network/network_mapping.go
+++ b/broker/network/network_mapping.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package network
+
+import (
+	"fmt"
+)
+
+func (s *Server) setupMappings() (err error) {
+	if len(s.config.Choria.NetworkMappings) == 0 {
+		return nil
+	}
+
+	if s.choriaAccount == nil {
+		return fmt.Errorf("choria account is not set")
+	}
+
+	for _, m := range s.config.Choria.NetworkMappings {
+		source := s.extractKeyedConfigString("mapping", m, "source", "")
+		dest := s.extractKeyedConfigString("mapping", m, "destination", "")
+
+		s.log.Debugf("Attempting to add network mapping %q to %q", source, dest)
+		if source == "" || dest == "" {
+			s.log.Errorf("Network mapping %s need both a source and destination", m)
+			continue
+		}
+
+		err = s.choriaAccount.AddMapping(source, dest)
+		if err != nil {
+			s.log.Errorf("Network mapping %s could not be added: %v", m, err)
+		}
+	}
+
+	return nil
+}

--- a/config/choria.go
+++ b/config/choria.go
@@ -56,6 +56,7 @@ type ChoriaPluginConfig struct {
 	NetworkPeers                       []string      `confkey:"plugin.choria.network.peers" type:"comma_split" url:"https://choria.io/docs/deployment/broker/"`    // List of cluster peers in host:port format
 	NetworkLeafPort                    int           `confkey:"plugin.choria.network.leafnode_port" default:"0"`                                                   // Port to listen on for Leafnode connections, disabled with 0
 	NetworkLeafRemotes                 []string      `confkey:"plugin.choria.network.leafnode_remotes" type:"comma_split"`                                         // Remote networks to connect to as a Leafnode
+	NetworkMappings                    []string      `confkey:"plugin.choria.network.mapping.names" type:"comma_split"`                                            // List of subject remappings to apply
 	NetworkGatewayPort                 int           `confkey:"plugin.choria.network.gateway_port" default:"0"`                                                    // Port to listen on for Super Cluster connections
 	NetworkGatewayName                 string        `confkey:"plugin.choria.network.gateway_name" default:"CHORIA"`                                               // Name for the Super Cluster
 	NetworkGatewayRemotes              []string      `confkey:"plugin.choria.network.gateway_remotes" type:"comma_split"`                                          // List of remote Super Clusters to connect to

--- a/config/docstrings.go
+++ b/config/docstrings.go
@@ -68,6 +68,7 @@ var docStrings = map[string]string{
 	"plugin.choria.network.peers":                              "List of cluster peers in host:port format",
 	"plugin.choria.network.leafnode_port":                      "Port to listen on for Leafnode connections, disabled with 0",
 	"plugin.choria.network.leafnode_remotes":                   "Remote networks to connect to as a Leafnode",
+	"plugin.choria.network.mapping.names":                      "List of subject remappings to apply",
 	"plugin.choria.network.gateway_port":                       "Port to listen on for Super Cluster connections",
 	"plugin.choria.network.gateway_name":                       "Name for the Super Cluster",
 	"plugin.choria.network.gateway_remotes":                    "List of remote Super Clusters to connect to",

--- a/integration/suites/broker_mappings/broker_mappings_test.go
+++ b/integration/suites/broker_mappings/broker_mappings_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package broker_mappings
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/choria-io/go-choria/integration/testbroker"
+	"github.com/choria-io/go-choria/integration/testutil"
+	"github.com/nats-io/nats.go"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/sirupsen/logrus"
+)
+
+func TestBrokerRemapping(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Broker Remapping")
+}
+
+var _ = Describe("Authentication", func() {
+	var (
+		ctx     context.Context
+		cancel  context.CancelFunc
+		wg      sync.WaitGroup
+		logger  *logrus.Logger
+		logbuff *gbytes.Buffer
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 45*time.Second)
+		DeferCleanup(func() {
+			cancel()
+			Eventually(logbuff, 5).Should(gbytes.Say("Choria Network Broker shut down"))
+		})
+
+		logbuff, logger = testutil.GbytesLogger(logrus.DebugLevel)
+	})
+
+	Describe("Mappings", func() {
+		BeforeEach(func() {
+			_, err := testbroker.StartNetworkBrokerWithConfigFile(ctx, &wg, "testdata/mappings.conf", logger)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(logbuff, 2).Should(gbytes.Say("TLS required for client connections"))
+			Eventually(logbuff, 1).Should(gbytes.Say("Server is ready"))
+		})
+
+		It("Should add correct mappings", func() {
+			nc, err := nats.Connect("tls://localhost:4222",
+				nats.ClientCert(testutil.CertPath("one", "rip.mcollective"), testutil.KeyPath("one", "rip.mcollective")),
+				nats.RootCAs(testutil.CertPath("one", "ca")),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			defer nc.Close()
+
+			Eventually(logbuff, 1).Should(gbytes.Say("Registering user '' in account 'choria'"))
+			Expect(nc.ConnectedUrl()).To(Equal("tls://localhost:4222"))
+
+			sub, err := nc.SubscribeSync("registration.>")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(nc.Publish("in.registration.dev1.example.net", []byte("dev1.example.net"))).To(Succeed())
+			Expect(nc.Publish("in.registration.dev2.example.net", []byte("dev2.example.net"))).To(Succeed())
+			Expect(nc.Publish("in.registration.dev3.example.net", []byte("dev3.example.net"))).To(Succeed())
+			Expect(nc.Publish("in.registration.dev4.example.net", []byte("dev4.example.net"))).To(Succeed())
+			Expect(nc.Publish("in.registration.dev5.example.net", []byte("dev5.example.net"))).To(Succeed())
+			Expect(nc.Publish("in.registration.dev1.example.net", []byte("dev1.example.net"))).To(Succeed())
+
+			check := func(body, subj string) {
+				msg, err := sub.NextMsg(time.Second)
+				ExpectWithOffset(1, err).ToNot(HaveOccurred())
+				ExpectWithOffset(1, msg.Data).To(Equal([]byte(body)))
+				ExpectWithOffset(1, msg.Subject).To(Equal(subj))
+			}
+
+			check("dev1.example.net", "registration.2.dev1.example.net")
+			check("dev2.example.net", "registration.1.dev2.example.net")
+			check("dev3.example.net", "registration.0.dev3.example.net")
+			check("dev4.example.net", "registration.2.dev4.example.net")
+			check("dev5.example.net", "registration.1.dev5.example.net")
+			check("dev1.example.net", "registration.2.dev1.example.net")
+		})
+	})
+})

--- a/integration/suites/broker_mappings/testdata/mappings.conf
+++ b/integration/suites/broker_mappings/testdata/mappings.conf
@@ -1,0 +1,15 @@
+identity = localhost
+plugin.choria.broker_network = true
+plugin.choria.network.client_port = 4222
+plugin.choria.network.system.user = system
+plugin.choria.network.system.password = system
+plugin.security.provider = file
+plugin.security.file.certificate = ../../ca/one/certs/localhost.pem
+plugin.security.file.key = ../../ca/one/localhost-key.pem
+plugin.security.file.ca = ../../ca/one/certs/ca.pem
+plugin.choria.network.client_signer_cert = ../../ca/signer-cert.pem
+plugin.choria.use_srv = false
+
+plugin.choria.network.mapping.names = registration
+plugin.choria.network.mapping.registration.source = in.registration.*.>
+plugin.choria.network.mapping.registration.destination = registration.{{partition(5,1)}}.{{wildcard(1)}}.>


### PR DESCRIPTION
Configuring settings like this:

```
plugin.choria.network.mapping.names = registration
plugin.choria.network.mapping.registration.source = in.registration.*.>
plugin.choria.network.mapping.registration.destination = registration.{{partition(5,1)}}.{{wildcard(1)}}.>
```

Will remap `in.registration.example.net` into `registration.1.example.net`
where the "1" in the new subject is a determiniscally determined
partition, meaning there will be 5 paritions of message subjects
but example.net will always be assigned to parition 1, this will
assist tools like stream replicator to scale while maintaining order

Signed-off-by: R.I.Pienaar <rip@devco.net>