### PR TITLE
(#1713) allow system access with a jwt over unverified tls

### DIFF
--- a/integration/suites/broker_auth/broker_auth_test.go
+++ b/integration/suites/broker_auth/broker_auth_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Authentication", func() {
 				nats.UserInfo("system", "systemS3cret"),
 				nats.Secure(&tls.Config{InsecureSkipVerify: true}))
 			Expect(err).To(MatchError("nats: Authorization Violation"))
-			Expect(logbuff).To(gbytes.Say("System user is only allowed over verified TLS connections"))
+			Expect(logbuff).To(gbytes.Say("Handling unverified TLS system user failed, denying: no JWT token received"))
 			Expect(logbuff).ToNot(gbytes.Say("Registering user"))
 		})
 

--- a/tokens/client_id.go
+++ b/tokens/client_id.go
@@ -29,6 +29,9 @@ type ClientPermissions struct {
 	// ElectionUser allows using leader elections
 	ElectionUser bool `json:"election_user,omitempty"`
 
+	// SystemUser allows accessing the Choria Broker system account without verifiedTLS
+	SystemUser bool `json:"system_user,omitempty"`
+
 	// Governor enables access to Governors, cannot make new ones, also requires Streams permission
 	Governor bool `json:"governor"`
 


### PR DESCRIPTION
Previously we insisted that system access needed verified TLS.
We still support that mode of access but now we extended the
client JWT with a claim allowing system access.

When a connection comes in over unverified TLS - however TLS
is required - and that connection has this claim set true
and that connection did the correct nonce signing and that
connection set system user/pass correctly then we join him
to the system account.

Signed-off-by: R.I.Pienaar <rip@devco.net>