### PR TITLE
(#1774) improve handling of server seed and jwt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 | Date       | Issue | Description                                                                                                        |
 |------------|-------|--------------------------------------------------------------------------------------------------------------------|
-| 2022/07/10 | 1760  | Add a `gossip` watcher to publish regulary to the Choria Broker                                                    |
-| 2022/07/06 |       | Upgrade `appbuilder` to `v0.2.0`                                                                                   |
+| 2022/08/02 | 1774  | When generating a new ed25519 server seed, remove the invalidated JWT from disk                                    |
+| 2022/08/02 | 1774  | Detect JWT and Server seed mismatches, trigger reprovision if possible                                             |
+| 2022/08/01 |       | Upgrade `appbuilder` to `v0.3.0`                                                                                   |
+| 2022/08/01 | 1722  | Allow in-process connections to bypass TLS, use them to configure Choria Streams                                   |
+| 2022/07/07 | 1756  | Allow governors to control executions per period                                                                   |
+| 2022/07/07 | 1755  | Add various election based tools for command execution, cron jobs and more, also various management tools          |
+| 2022/07/10 | 1760  | Add a `gossip` watcher to publish regular to the Choria Broker, including basic service registration               |
 | 2022/07/05 | 1712  | Switch to a new help template                                                                                      |
 | 2022/06/27 | 1732  | Improved detection of STDIN avoiding some unexpected switches in discovery method and improving running under cron |
 | 2022/06/27 | 1528  | Improve reliability of removing self-managed autonomous agents                                                     |

--- a/choria/ed25519.go
+++ b/choria/ed25519.go
@@ -8,6 +8,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"os"
 )
 
@@ -39,6 +40,10 @@ func Ed25519KeyPairFromSeedFile(f string) (ed25519.PublicKey, ed25519.PrivateKey
 }
 
 func Ed25519KeyPairFromSeed(seed []byte) (ed25519.PublicKey, ed25519.PrivateKey, error) {
+	if len(seed) != ed25519.SeedSize {
+		return nil, nil, fmt.Errorf("invalid seed length")
+	}
+
 	priK := ed25519.NewKeyFromSeed(seed)
 	pubK := priK.Public().(ed25519.PublicKey)
 	return pubK, priK, nil

--- a/providers/agent/mcorpc/golang/provision/provision_test.go
+++ b/providers/agent/mcorpc/golang/provision/provision_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/choria-io/go-choria/choria"
 	"github.com/choria-io/go-choria/config"
 	"github.com/choria-io/go-choria/inter"
+	iu "github.com/choria-io/go-choria/internal/util"
 	"github.com/choria-io/go-choria/lifecycle"
 	"github.com/choria-io/go-choria/providers/agent/mcorpc"
 	"github.com/choria-io/go-choria/server/agents"
@@ -145,8 +146,12 @@ var _ = Describe("Provision/Agent", func() {
 			build.ProvisionToken = "toomanysecrets"
 
 			cfg.ConfigFile = filepath.Join(td, "server.conf")
+			jwtPath := filepath.Join(td, "server.jwt")
+			Expect(os.WriteFile(jwtPath, []byte("x"), 0700)).To(Succeed())
+
 			ed25519Action(ctx, req, reply, prov, nil)
 			Expect(reply.Statuscode).To(Equal(mcorpc.OK))
+			Expect(iu.FileExist(jwtPath)).To(BeFalse())
 
 			resp := reply.Data.(*ED25519Reply)
 			Expect(resp.PublicKey).To(HaveLen(64))


### PR DESCRIPTION
This detects invalid server seed and jwt combinations and triggers
reprovisioning as a remediation.

Also removes the invalid JWT during provisioning after generating
a new server seed file

Signed-off-by: R.I.Pienaar <rip@devco.net>