### PR TITLE
(#1795) Build proper (and more) Debian armel packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -125,6 +125,26 @@ jobs:
           packager_tag: bullseye-go1.18
           version: tag
 
+  bullseye_armel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: choria-io/actions/packager@main
+        with:
+          build_package: bullseye_armel
+          packager_tag: bullseye-go1.18
+          version: tag
+
+  bullseye_armhf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        uses: choria-io/actions/packager@main
+        with:
+          build_package: bullseye_armhf
+          packager_tag: bullseye-go1.18
+          version: tag
+
   bionic_64:
     runs-on: ubuntu-latest
     steps:

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -239,6 +239,18 @@ foss:
       binary: aarch64_linux
       distro: buster
 
+    bullseye_armel:
+      template: debian/generic
+      target_arch: arm-linux-gnueabi
+      binary: armv5_linux
+      distro: bullseye
+
+    bullseye_armhf:
+      template: debian/generic
+      target_arch: arm-linux-gnueabihf
+      binary: armv7_linux
+      distro: bullseye
+
     bullseye_64:
       template: debian/generic
       target_arch: x86_64-linux-gnu

--- a/packager/buildspec.yaml
+++ b/packager/buildspec.yaml
@@ -223,7 +223,7 @@ foss:
 
     buster_armel:
       template: debian/generic
-      target_arch: arm-linux-gnu
+      target_arch: arm-linux-gnueabi
       binary: armv5_linux
       distro: buster
 


### PR DESCRIPTION
This should result in proper deb packages that can be installed on an armel system;

```console
root@pi-zero:~# cat /sys/firmware/devicetree/base/model; echo
Raspberry Pi Zero W Rev 1.1
root@pi-zero:~# ls 
choria_0.26.1+bullseye_armel.deb
root@pi-zero:~# dpkg -i choria_0.26.1+bullseye_armel.deb 
(Reading database ... 54474 files and directories currently installed.)
Preparing to unpack choria_0.26.1+bullseye_armel.deb ...
Unpacking choria (0.26.1+bullseye) over (0.26.1+bullseye) ...
Setting up choria (0.26.1+bullseye) ...
root@pi-zero:~# choria --version
0.26.1
```

The deb-files that the host-type `arm-linux-gnu` results in have the invalid architecture "arm" attached to them, instead of "armel". Which means that apt/dpkg will refuse to install them.