### PR TITLE
(misc) Speed up machines watcher

### DIFF
--- a/aagent/watchers/machineswatcher/machines.go
+++ b/aagent/watchers/machineswatcher/machines.go
@@ -130,7 +130,7 @@ func New(machine model.Machine, name string, states []string, failEvent string, 
 			return nil, fmt.Errorf("invalid interval: %v", err)
 		}
 
-		if machines.interval < 10*time.Second {
+		if machines.interval < 2*time.Second {
 			return nil, fmt.Errorf("interval %v is too small", machines.interval)
 		}
 	}
@@ -549,7 +549,7 @@ func (w *Watcher) validate() error {
 	}
 
 	if w.properties.MachineManageInterval == 0 {
-		w.properties.MachineManageInterval = 5 * time.Minute
+		w.properties.MachineManageInterval = 2 * time.Minute
 	}
 
 	return nil

--- a/aagent/watchers/machineswatcher/manager/machine.yaml
+++ b/aagent/watchers/machineswatcher/manager/machine.yaml
@@ -1,5 +1,5 @@
 name: machine_manager
-version: 0.0.1
+version: 0.0.2
 initial_state: INITIAL
 
 # States
@@ -24,7 +24,7 @@ transitions:
 watchers:
   - name: initial_specification
     type: kv
-    interval: 10m
+    interval: 30s
     state_match: [ INITIAL ]
     success_transition: to_manage
     properties:
@@ -36,7 +36,7 @@ watchers:
 
   - name: specification
     type: kv
-    interval: 10m
+    interval: 5m
     state_match: [ MANAGE ]
     properties:
       bucket: MACHINES
@@ -47,8 +47,8 @@ watchers:
   - name: manage_machines
     state_match: [ MANAGE ]
     type: machines
-    interval: 5m
+    interval: 2m
     properties:
       data_item: spec
       purge_unknown: true
-      machine_manage_interval: 10m
+      machine_manage_interval: 2m


### PR DESCRIPTION
With the new vastly optimised KV get we can be
more aggresive in getting KV data and managing
our instances, so we drop the initial delay from
10 minutes to 30 seconds and drop the KV poll
interval from 10 minutes to 5

Signed-off-by: R.I.Pienaar <rip@devco.net>