### PR TITLE
(#1740) remove the concept of a cache from security providers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -923,6 +923,8 @@ Path to a file holding tags for a Scout entity
 
 Always store new Public Keys to the cache overwriting existing ones
 
+**This setting is deprecated or already unused**
+
 ## plugin.security.certmanager.alt_names
 
  * **Type:** comma_split
@@ -986,6 +988,8 @@ When using file security provider, the path to the Certificate Authority public 
  * **Type:** path_string
 
 When using file security provider, the path to the client cache
+
+**This setting is deprecated or already unused**
 
 ## plugin.security.file.certificate
 

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -224,7 +224,6 @@ func (fw *Framework) ConfigureProvisioning() {
 	fw.Config.FactSourceFile = fw.bi.ProvisionFacts()
 	fw.Config.Choria.NatsUser = fw.bi.ProvisioningBrokerUsername()
 	fw.Config.Choria.NatsPass = fw.bi.ProvisioningBrokerPassword()
-	fw.Config.Choria.SecurityAlwaysOverwriteCache = true
 	fw.Config.Choria.SSLDir = filepath.Join(filepath.Dir(fw.Config.ConfigFile), "ssl")
 	fw.Config.Choria.SecurityProvider = "file"
 

--- a/cmd/tool_config.go
+++ b/cmd/tool_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -133,7 +133,6 @@ func (cc *tConfigCommand) Run(wg *sync.WaitGroup) (err error) {
 			fmt.Printf("           Certificate: %s (%s)\n", c.Config.Choria.FileSecurityCertificate, cc.checkFileExist(c.Config.Choria.FileSecurityCertificate))
 			fmt.Printf("                   Key: %s (%s)\n", c.Config.Choria.FileSecurityKey, cc.checkFileExist(c.Config.Choria.FileSecurityKey))
 			fmt.Printf("                    CA: %s (%s)\n", c.Config.Choria.FileSecurityCA, cc.checkFileExist(c.Config.Choria.FileSecurityCA))
-			fmt.Printf("                 Cache: %s (%s)\n", c.Config.Choria.FileSecurityCache, cc.checkFileExist(c.Config.Choria.FileSecurityCache))
 		}
 
 		if c.Config.Choria.RemoteSignerService {

--- a/config/choria.go
+++ b/config/choria.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2018-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -102,7 +102,7 @@ type ChoriaPluginConfig struct {
 	CertnameWhitelist            []string `confkey:"plugin.choria.security.certname_whitelist" type:"comma_split" default:"\\.mcollective$,\\.choria$"`                                                                     // Patterns of certificate names that are allowed to be clients
 	Serializer                   string   `confkey:"plugin.choria.security.serializer" validate:"enum=json,yaml" default:"json" deprecated:"1"`
 	SecurityProvider             string   `confkey:"plugin.security.provider" default:"puppet" validate:"enum=puppet,file,pkcs11,certmanager"`                      // The Security Provider to use
-	SecurityAlwaysOverwriteCache bool     `confkey:"plugin.security.always_overwrite_cache" default:"false"`                                                        // Always store new Public Keys to the cache overwriting existing ones
+	SecurityAlwaysOverwriteCache bool     `confkey:"plugin.security.always_overwrite_cache" default:"false" deprecated:"1"`                                         // Always store new Public Keys to the cache overwriting existing ones
 	SecurityAllowLegacyCerts     bool     `confkey:"plugin.security.support_legacy_certificates" default:"false"`                                                   // Allow certificates without SANs to be used
 	RemoteSignerTokenSeedFile    string   `confkey:"plugin.choria.security.request_signer.seed_file" type:"path_string" url:"https://github.com/choria-io/aaasvc"`  // Path to the seed file used to access a Central Authenticator
 	RemoteSignerTokenFile        string   `confkey:"plugin.choria.security.request_signer.token_file" type:"path_string" url:"https://github.com/choria-io/aaasvc"` // Path to the token used to access a Central Authenticator
@@ -115,10 +115,10 @@ type ChoriaPluginConfig struct {
 	ServerTokenFile              string   `confkey:"plugin.choria.security.server.token_file" type:"path_string"`                                                   // The server token file to use for authentication, defaults to serer.jwt in the same location as server.conf
 	ServerTokenSeedFile          string   `confkey:"plugin.choria.security.server.seed_file" type:"path_string"`                                                    // The server token seed to use for authentication, defaults to server.seed in the same location as server.conf
 
-	FileSecurityCertificate string `confkey:"plugin.security.file.certificate" type:"path_string"` // When using file security provider, the path to the public certificate
-	FileSecurityKey         string `confkey:"plugin.security.file.key" type:"path_string"`         // When using file security provider, the path to the private key
-	FileSecurityCA          string `confkey:"plugin.security.file.ca" type:"path_string"`          // When using file security provider, the path to the Certificate Authority public certificate
-	FileSecurityCache       string `confkey:"plugin.security.file.cache" type:"path_string"`       // When using file security provider, the path to the client cache
+	FileSecurityCertificate string `confkey:"plugin.security.file.certificate" type:"path_string"`          // When using file security provider, the path to the public certificate
+	FileSecurityKey         string `confkey:"plugin.security.file.key" type:"path_string"`                  // When using file security provider, the path to the private key
+	FileSecurityCA          string `confkey:"plugin.security.file.ca" type:"path_string"`                   // When using file security provider, the path to the Certificate Authority public certificate
+	FileSecurityCache       string `confkey:"plugin.security.file.cache" type:"path_string" deprecated:"1"` // When using file security provider, the path to the client cache
 
 	CertManagerSecurityNamespace  string   `confkey:"plugin.security.certmanager.namespace" default:"choria"`   // When using Cert Manager security provider, the namespace the issuer is in
 	CertManagerSecurityIssuer     string   `confkey:"plugin.security.certmanager.issuer"`                       // When using Cert Manager security provider, the name of the issuer

--- a/inter/imocks/framework.go
+++ b/inter/imocks/framework.go
@@ -5,25 +5,25 @@
 package imock
 
 import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"io"
-	"net/http"
-	"reflect"
-	"time"
+	context "context"
+	tls "crypto/tls"
+	x509 "crypto/x509"
+	io "io"
+	http "net/http"
+	reflect "reflect"
+	time "time"
 
-	"github.com/choria-io/go-choria/build"
-	"github.com/choria-io/go-choria/config"
-	"github.com/choria-io/go-choria/inter"
-	"github.com/choria-io/go-choria/protocol"
+	build "github.com/choria-io/go-choria/build"
+	config "github.com/choria-io/go-choria/config"
+	inter "github.com/choria-io/go-choria/inter"
+	protocol "github.com/choria-io/go-choria/protocol"
 	election "github.com/choria-io/go-choria/providers/election/streams"
 	governor "github.com/choria-io/go-choria/providers/governor/streams"
-	"github.com/choria-io/go-choria/providers/kv"
-	"github.com/choria-io/go-choria/srvcache"
-	"github.com/golang/mock/gomock"
-	"github.com/nats-io/nats.go"
-	"github.com/sirupsen/logrus"
+	kv "github.com/choria-io/go-choria/providers/kv"
+	srvcache "github.com/choria-io/go-choria/srvcache"
+	gomock "github.com/golang/mock/gomock"
+	nats "github.com/nats-io/nats.go"
+	logrus "github.com/sirupsen/logrus"
 )
 
 // MockConfigurationProvider is a mock of ConfigurationProvider interface.

--- a/inter/imocks/security.go
+++ b/inter/imocks/security.go
@@ -39,35 +39,6 @@ func (m *MockSecurityProvider) EXPECT() *MockSecurityProviderMockRecorder {
 	return m.recorder
 }
 
-// CachePublicData mocks base method.
-func (m *MockSecurityProvider) CachePublicData(arg0 []byte, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CachePublicData", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CachePublicData indicates an expected call of CachePublicData.
-func (mr *MockSecurityProviderMockRecorder) CachePublicData(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachePublicData", reflect.TypeOf((*MockSecurityProvider)(nil).CachePublicData), arg0, arg1)
-}
-
-// CachedPublicData mocks base method.
-func (m *MockSecurityProvider) CachedPublicData(arg0 string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CachedPublicData", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CachedPublicData indicates an expected call of CachedPublicData.
-func (mr *MockSecurityProviderMockRecorder) CachedPublicData(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedPublicData", reflect.TypeOf((*MockSecurityProvider)(nil).CachedPublicData), arg0)
-}
-
 // CallerIdentity mocks base method.
 func (m *MockSecurityProvider) CallerIdentity(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
@@ -197,34 +168,6 @@ func (mr *MockSecurityProviderMockRecorder) IsRemoteSigning() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRemoteSigning", reflect.TypeOf((*MockSecurityProvider)(nil).IsRemoteSigning))
 }
 
-// PrivilegedVerifyByteSignature mocks base method.
-func (m *MockSecurityProvider) PrivilegedVerifyByteSignature(arg0, arg1 []byte, arg2 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrivilegedVerifyByteSignature", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// PrivilegedVerifyByteSignature indicates an expected call of PrivilegedVerifyByteSignature.
-func (mr *MockSecurityProviderMockRecorder) PrivilegedVerifyByteSignature(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivilegedVerifyByteSignature", reflect.TypeOf((*MockSecurityProvider)(nil).PrivilegedVerifyByteSignature), arg0, arg1, arg2)
-}
-
-// PrivilegedVerifyStringSignature mocks base method.
-func (m *MockSecurityProvider) PrivilegedVerifyStringSignature(arg0 string, arg1 []byte, arg2 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrivilegedVerifyStringSignature", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// PrivilegedVerifyStringSignature indicates an expected call of PrivilegedVerifyStringSignature.
-func (mr *MockSecurityProviderMockRecorder) PrivilegedVerifyStringSignature(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivilegedVerifyStringSignature", reflect.TypeOf((*MockSecurityProvider)(nil).PrivilegedVerifyStringSignature), arg0, arg1, arg2)
-}
-
 // Provider mocks base method.
 func (m *MockSecurityProvider) Provider() string {
 	m.ctrl.T.Helper()
@@ -254,6 +197,21 @@ func (mr *MockSecurityProviderMockRecorder) PublicCert() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicCert", reflect.TypeOf((*MockSecurityProvider)(nil).PublicCert))
 }
 
+// PublicCertBytes mocks base method.
+func (m *MockSecurityProvider) PublicCertBytes() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublicCertBytes")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PublicCertBytes indicates an expected call of PublicCertBytes.
+func (mr *MockSecurityProviderMockRecorder) PublicCertBytes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicCertBytes", reflect.TypeOf((*MockSecurityProvider)(nil).PublicCertBytes))
+}
+
 // PublicCertPem mocks base method.
 func (m *MockSecurityProvider) PublicCertPem() (*pem.Block, error) {
 	m.ctrl.T.Helper()
@@ -267,21 +225,6 @@ func (m *MockSecurityProvider) PublicCertPem() (*pem.Block, error) {
 func (mr *MockSecurityProviderMockRecorder) PublicCertPem() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicCertPem", reflect.TypeOf((*MockSecurityProvider)(nil).PublicCertPem))
-}
-
-// PublicCertTXT mocks base method.
-func (m *MockSecurityProvider) PublicCertBytes() ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicCertBytes")
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PublicCertTXT indicates an expected call of PublicCertTXT.
-func (mr *MockSecurityProviderMockRecorder) PublicCertTXT() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicCertBytes", reflect.TypeOf((*MockSecurityProvider)(nil).PublicCertBytes))
 }
 
 // RemoteSignRequest mocks base method.
@@ -312,6 +255,21 @@ func (m *MockSecurityProvider) SSLContext() (*http.Transport, error) {
 func (mr *MockSecurityProviderMockRecorder) SSLContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSLContext", reflect.TypeOf((*MockSecurityProvider)(nil).SSLContext))
+}
+
+// ShouldAllowCaller mocks base method.
+func (m *MockSecurityProvider) ShouldAllowCaller(arg0 []byte, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldAllowCaller", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldAllowCaller indicates an expected call of ShouldAllowCaller.
+func (mr *MockSecurityProviderMockRecorder) ShouldAllowCaller(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldAllowCaller", reflect.TypeOf((*MockSecurityProvider)(nil).ShouldAllowCaller), arg0, arg1)
 }
 
 // SignBytes mocks base method.
@@ -375,11 +333,12 @@ func (mr *MockSecurityProviderMockRecorder) Validate() *gomock.Call {
 }
 
 // VerifyByteSignature mocks base method.
-func (m *MockSecurityProvider) VerifyByteSignature(arg0, arg1 []byte, arg2 string) bool {
+func (m *MockSecurityProvider) VerifyByteSignature(arg0, arg1, arg2 []byte) (bool, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VerifyByteSignature", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
 }
 
 // VerifyByteSignature indicates an expected call of VerifyByteSignature.
@@ -400,18 +359,4 @@ func (m *MockSecurityProvider) VerifyCertificate(arg0 []byte, arg1 string) error
 func (mr *MockSecurityProviderMockRecorder) VerifyCertificate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyCertificate", reflect.TypeOf((*MockSecurityProvider)(nil).VerifyCertificate), arg0, arg1)
-}
-
-// VerifyStringSignature mocks base method.
-func (m *MockSecurityProvider) VerifyStringSignature(arg0 string, arg1 []byte, arg2 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "VerifyStringSignature", arg0, arg1, arg2)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// VerifyStringSignature indicates an expected call of VerifyStringSignature.
-func (mr *MockSecurityProviderMockRecorder) VerifyStringSignature(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyStringSignature", reflect.TypeOf((*MockSecurityProvider)(nil).VerifyStringSignature), arg0, arg1, arg2)
 }

--- a/inter/security_provider.go
+++ b/inter/security_provider.go
@@ -33,9 +33,8 @@ type SecurityProvider interface {
 	// SignBytes signs bytes using the current active certificate
 	SignBytes(b []byte) (signature []byte, err error)
 
-	// VerifyByteSignature verifies that str when signed by identity would match signature.
-	// The certificate for identity should previously have been saved into the cache
-	VerifyByteSignature(str []byte, signature []byte, identity string) bool
+	// VerifyByteSignature verifies that dat signature was made using pubcert
+	VerifyByteSignature(dat []byte, sig []byte, pubcert []byte) (should bool, signer string)
 
 	// SignString signs a string using the current active certificate
 	SignString(s string) (signature []byte, err error)
@@ -45,18 +44,6 @@ type SecurityProvider interface {
 
 	// IsRemoteSigning reports if the security provider is signing using a remote
 	IsRemoteSigning() bool
-
-	// VerifyStringSignature verifies that str when signed by identity would match signature.
-	// The certificate for identity should previously have been saved into the cache
-	VerifyStringSignature(str string, signature []byte, identity string) bool
-
-	// PrivilegedVerifyByteSignature verifies that dat is a valid signature for identity
-	// or any of the privileged certificates
-	PrivilegedVerifyByteSignature(dat []byte, sig []byte, identity string) bool
-
-	// PrivilegedVerifyStringSignature verifies that dat is a valid signature for identity
-	// or any of the privileged certificates
-	PrivilegedVerifyStringSignature(dat string, sig []byte, identity string) bool
 
 	// ChecksumBytes produce a crypto checksum for data
 	ChecksumBytes(data []byte) []byte
@@ -89,13 +76,9 @@ type SecurityProvider interface {
 	// PublicCertBytes retrieves pem data in textual form for the public certificate of the current identity
 	PublicCertBytes() ([]byte, error)
 
-	// CachePublicData when given a pem encoded certificate and expected identity should validate
-	// the cert and then check against things like the certificate allow lists, privilege lists
-	// etc and only cache certificates that is completely acceptable by us
-	CachePublicData(data []byte, identity string) error
-
-	// CachedPublicData retrieves a previously cached certificate
-	CachedPublicData(identity string) ([]byte, error)
+	// ShouldAllowCaller validates the identity, the public data like certificate or JWT and checks
+	// against allowed lists and is privileged user aware
+	ShouldAllowCaller(data []byte, name string) (privileged bool, err error)
 
 	// Enroll creates a new cert with the active identity and attempt to enroll it with the security system
 	// if there's a process of waiting for the certificate to be signed for example this should wait

--- a/protocol/v1/security_request_test.go
+++ b/protocol/v1/security_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2017-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +38,7 @@ var _ = Describe("SecureRequest", func() {
 	})
 
 	It("Should support insecure mode", func() {
-		security.EXPECT().PublicCertTXT().Return([]byte{}, errors.New("simulated")).AnyTimes()
+		security.EXPECT().PublicCertBytes().Return([]byte{}, errors.New("simulated")).AnyTimes()
 
 		protocol.Secure = "false"
 
@@ -62,7 +62,7 @@ var _ = Describe("SecureRequest", func() {
 	})
 
 	It("Should create a valid SecureRequest", func() {
-		security.EXPECT().PublicCertTXT().Return(pub, nil).AnyTimes()
+		security.EXPECT().PublicCertBytes().Return(pub, nil).AnyTimes()
 
 		r, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		r.SetMessage(`{"test":1}`)

--- a/protocol/v1/transport_test.go
+++ b/protocol/v1/transport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2017-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -53,7 +53,7 @@ var _ = Describe("TransportMessage", func() {
 	})
 
 	It("Should support request data", func() {
-		security.EXPECT().PublicCertTXT().Return([]byte("stub cert"), nil).AnyTimes()
+		security.EXPECT().PublicCertBytes().Return([]byte("stub cert"), nil).AnyTimes()
 		security.EXPECT().SignString(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
 
 		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
@@ -78,7 +78,7 @@ var _ = Describe("TransportMessage", func() {
 		protocol.ClientStrictValidation = true
 		defer func() { protocol.ClientStrictValidation = false }()
 
-		security.EXPECT().PublicCertTXT().Return([]byte("stub cert"), nil).AnyTimes()
+		security.EXPECT().PublicCertBytes().Return([]byte("stub cert"), nil).AnyTimes()
 		security.EXPECT().SignString(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
 
 		request, err := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")

--- a/protocol/v2/ADR.md
+++ b/protocol/v2/ADR.md
@@ -35,6 +35,7 @@ In practise this works well for most users, but those with very large or complex
 * Newer technologies like ed25519 is attractive as they use small keys and signatures and can also do things like DH Key exchange
 * Using ed25519 opens the possibility of using ssh keys as signing keys, something many users have requested
 * Obtaining private CAs or intermediate CAs is often impossible forcing CA reuse and nullifying the usefulness of the mTLS security
+* Verification of certificates happen during caching rather than a separate check, more importantly the cache is used often as a means of retrieving privileged certs and more by id
 * The local cert cache is deeply embedded in the v1 protocol, but it's proven to be useless and most people disable its enforcing features - it cannot be disabled entirely
 * As Choria have evolved we need a much more granular role based permissions on each connection - can they use streams, can they admin streams, can they make rpc requests etc
 * More and more servers need to be able to make request either when publishing signed registration payloads or when interacting with Choria Services from within autonomous agents.  With v1 protocol this was not possible.
@@ -302,6 +303,8 @@ type SecurityProvider interface {
 }
 ```
 
-We would need to revisit these specific ones and potentially make them more generic, perhaps returning `any` or adding some new ones for ed25519 use. The cache ones should be removed, removing these from the current security protocols would result in a very large refactor.
+We would need to revisit these specific ones and potentially make them more generic, perhaps returning `any` or adding some new ones for ed25519 use. 
+
+The cache methods should be removed ([#1842](https://github.com/choria-io/go-choria/pull/1842)), removing these from the current security protocols would result in a very large refactor as the cache functions also perform verification steps. Additionally these are used to find all known privileged certificates in methods like `PrivilegedVerifyByteSignature()` and `VerifyByteSignature()`, this is obviously flawed but undoing this feature might break things significantly and prove to be impossible for v1 protocols.  V2 should not have this limitation.
 
 There are some other improvements to be made also in addition but those we'd need to see as we go along.

--- a/providers/security/certmanager/option.go
+++ b/providers/security/certmanager/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,16 +19,15 @@ type Option func(*CertManagerSecurity) error
 func WithChoriaConfig(c *config.Config) Option {
 	return func(p *CertManagerSecurity) error {
 		cfg := Config{
-			apiVersion:           c.Choria.CertManagerAPIVersion,
-			sslDir:               c.Choria.SSLDir,
-			privilegedUsers:      c.Choria.PrivilegedUsers,
-			alwaysOverwriteCache: c.Choria.SecurityAlwaysOverwriteCache,
-			namespace:            c.Choria.CertManagerSecurityNamespace,
-			issuer:               c.Choria.CertManagerSecurityIssuer,
-			replace:              c.Choria.CertManagerSecurityReplaceCSR,
-			altnames:             c.Choria.CertManagerSecurityAltNames,
-			identity:             c.Identity,
-			legacyCerts:          c.Choria.SecurityAllowLegacyCerts,
+			apiVersion:      c.Choria.CertManagerAPIVersion,
+			sslDir:          c.Choria.SSLDir,
+			privilegedUsers: c.Choria.PrivilegedUsers,
+			namespace:       c.Choria.CertManagerSecurityNamespace,
+			issuer:          c.Choria.CertManagerSecurityIssuer,
+			replace:         c.Choria.CertManagerSecurityReplaceCSR,
+			altnames:        c.Choria.CertManagerSecurityAltNames,
+			identity:        c.Identity,
+			legacyCerts:     c.Choria.SecurityAllowLegacyCerts,
 		}
 
 		if c.OverrideCertname == "" {

--- a/providers/security/filesec/file_security_test.go
+++ b/providers/security/filesec/file_security_test.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package filesec
 
 import (
-	"bytes"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/pem"
@@ -17,7 +16,6 @@ import (
 
 	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/inter"
-	"github.com/choria-io/go-choria/internal/util"
 	"github.com/choria-io/go-choria/tlssetup"
 
 	"github.com/choria-io/go-choria/config"
@@ -37,7 +35,6 @@ func setSSL(c *Config, parent string, id string, private_extension string) {
 	}
 	c.Certificate = filepath.Join(parent, "certs", fmt.Sprintf("%s.pem", id))
 	c.CA = filepath.Join(parent, "certs", "ca.pem")
-	c.Cache = filepath.Join(parent, "choria_security", "public_certs")
 	c.Key = filepath.Join(parent, "private_keys", fmt.Sprintf("%s.%s", id, private_extension))
 	c.AllowList = []string{"\\.mcollective$"}
 	c.PrivilegedUsers = []string{"\\.privileged.mcollective$"}
@@ -48,7 +45,7 @@ func setSSL(c *Config, parent string, id string, private_extension string) {
 	fakeUID = 500
 }
 
-var _ = Describe("FileSSL", func() {
+var _ = Describe("FileSecurity", func() {
 	var cfg *Config
 	var err error
 	var prov *FileSecurity
@@ -112,7 +109,6 @@ var _ = Describe("FileSSL", func() {
 
 			fakeUID = 0
 			c.Choria.FileSecurityCA = "stub/ca.pem"
-			c.Choria.FileSecurityCache = "stub/cache"
 			c.Choria.FileSecurityCertificate = "stub/cert.pem"
 			c.Choria.FileSecurityKey = "stub/key.pem"
 			c.DisableTLSVerify = true
@@ -124,7 +120,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$", "\\.choria$"}))
 			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$", "\\.privileged.choria$"}))
 			Expect(prov.conf.CA).To(Equal("stub/ca.pem"))
-			Expect(prov.conf.Cache).To(Equal("stub/cache"))
 			Expect(prov.conf.Certificate).To(Equal("stub/cert.pem"))
 			Expect(prov.conf.Key).To(Equal("stub/key.pem"))
 			Expect(prov.conf.DisableTLSVerify).To(BeTrue())
@@ -136,7 +131,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = "stub/ca.pem"
-			c.Choria.FileSecurityCache = "stub/cache"
 			c.Choria.FileSecurityCertificate = "stub/cert.pem"
 			c.Choria.FileSecurityKey = "stub/key.pem"
 			c.DisableTLSVerify = true
@@ -154,7 +148,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = "stub/ca.pem"
-			c.Choria.FileSecurityCache = "stub/cache"
 			c.Choria.FileSecurityCertificate = "stub/cert.pem"
 			c.Choria.FileSecurityKey = "stub/key.pem"
 			c.DisableTLSVerify = true
@@ -245,12 +238,12 @@ var _ = Describe("FileSSL", func() {
 			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
 			Expect(err).ToNot(HaveOccurred())
 
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "")
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), sig, nil)
 			Expect(valid).To(BeTrue())
 		})
 
 		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), "")
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), nil)
 			Expect(valid).To(BeFalse())
 		})
 
@@ -260,34 +253,11 @@ var _ = Describe("FileSSL", func() {
 			sig, err := base64.StdEncoding.DecodeString("Zq1F2bdXOAvB5Ca+iYCZ/BLYz2ZzbQP/V8kwQY0E3cuDrBDArX7UhUnBakzN+Msr7UyF+EkYmzvIi4KHnFBrgi7otM8Q5YMh5IT+IPaoHj3Rj/jorqD4g8ltZINqCUBWDN4wvSG98SxLyawV69gAK4SnP+oy7SU7zxuQiPwIMJ7lVoiQ3t+tiQAHUxeykQPw7WElLb+wPTb1k4DM3yRkijA9OeUk+3SVyl2sTCu5h/Lg0lcI372bkLDESlnhnvw7yuLD2SSncrEQrBdv/N2yEpY2fx1UKGlTrn9GH4MGA1GuzE1F87RH9P8ieeul6vI13BkBAlMk5KaGlmWpgiGri5UjCHHXMxEnXfwUcKFE+E6yVg4SbrJknkuJzNJduypMIep7YOnPHVLNIBZLuOUdJrRgBQ+Yb9mxPnEQHhOHeN0XHUcseRJEISqPkagpNx1xhOb7g3hsNyEvqibT/DZsc/2hyU2I/wG9fl26CnN9c12r1zInyCQYsU/wuIvjDtRZvTpLGJSJdgjSmTPzGmA/fKpAfOWObdsoLeorjF/pNweuc0x0JZMsBrZauldLL53wnnvllsFEmIAxs+RusoJ2UfW7WugZ7lXGISHTef6IHjukHgDBSbeGawVCnAgPbPz1dy42x04koUW3Bmz89fJ4/j+e49ijz7z3W/IercNeke4=")
 			Expect(err).ToNot(HaveOccurred())
 
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-	})
-
-	Describe("PrivilegedVerifyByteSignature", func() {
-		It("Should allow a privileged cert to act as someone else", func() {
-			sig, err := base64.StdEncoding.DecodeString("4dSmCRsnZzJjqSLdXxCRufw+wh9BrbqMZfEkB9c0yLkqjuc6r2b3tl5bh28l2lm50nPcIKeMyVHh2pkhvVsnjTYVhEYGTBcJdhAf/4PQCCqllHfiD0i+EZNTC916P4C2TVFNw5kOx/qjz6KYBuBV0K0U5JG1L7rHmlSoJ1La9vs/x1RMLly91NYnPOtCpwSsAwRG6uGMnCQK/vGg+NiwIQpQrchCpVf6rrXSqqUrJzZc/SeNl42AA2EYbkq8ys79sye1w91BF07gX6n/gK/472tlTh9OK49GmLdi15oGiEOPbkCbPYm2hcWAJzdqGprCQAsYjuMfUByswxkthEw72Bp9tmSuc6P6QPLswkAeVi4NivQCm81CFEB0ZKl0WluJp5xEL9/mO9/Z/iUuvMRGQSbfIzi+8PVJeNIWsY8rzsDMdoIdwPD+vqVU7BhHxKXjAHq2nnhQCj35HuV2dN7n0MOy4A6H5kA4a8d5UVTBRMsFZ5s6Bo4/leFOlylgU2DIWq+DXdg05Zr98H9JulDM0epKEjLeowo5z5f2s7/eQymaSzdoW2zUhe9Hp0G0D8CkQUXm/RzjzLBTZ1fNQYIQGA9U6n+ApwBNHW9ClmlbbvcUb+Bw2rRHVgKM6+kUam+TLpLljuZkOY6wkk+h97aHYJyO7tOezyTuPPM5L3CDQ+M=")
+			cert, err := os.ReadFile("../testdata/good/certs/2.mcollective.pem")
 			Expect(err).ToNot(HaveOccurred())
 
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), sig, cert)
 			Expect(valid).To(BeTrue())
-		})
-
-		It("Should allow a cert to act as itself", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should not allow a unmatched cert", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
-			Expect(valid).To(BeFalse())
 		})
 	})
 
@@ -297,21 +267,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
 
-		})
-	})
-
-	Describe("VerifyStringSignature", func() {
-		It("Should validate correctly", func() {
-			sig, err := base64.StdEncoding.DecodeString("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.VerifyStringSignature("too many secrets", sig, "")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyStringSignature("too many secrets", []byte("meh"), "")
-			Expect(valid).To(BeFalse())
 		})
 	})
 
@@ -394,7 +349,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 
 			prov, err := New(WithChoriaConfig(&build.Info{}, c), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
@@ -411,7 +365,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca_chain_ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 
 			prov, err := New(WithChoriaConfig(&build.Info{}, c), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
@@ -428,7 +381,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca_chain_ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 
 			prov, err := New(WithChoriaConfig(&build.Info{}, c), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
@@ -445,7 +397,6 @@ var _ = Describe("FileSSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca_chain_ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 
 			prov, err := New(WithChoriaConfig(&build.Info{}, c), WithLog(l.WithFields(logrus.Fields{})))
 			Expect(err).ToNot(HaveOccurred())
@@ -471,230 +422,65 @@ var _ = Describe("FileSSL", func() {
 		})
 	})
 
-	Describe("shouldCacheClientCert", func() {
+	Describe("ShouldAllowCaller", func() {
 		It("Should only accept valid certs signed by our ca", func() {
 			pd, err := os.ReadFile(filepath.Join("..", "testdata", "foreign.pem"))
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err := prov.shouldCacheClientCert(pd, "foo")
+			priv, err := prov.ShouldAllowCaller(pd, "foo")
 			Expect(err).To(HaveOccurred())
-			Expect(should).To(BeFalse())
 			Expect(priv).To(BeFalse())
-			Expect(name).To(Equal("foo"))
 
 			pub := prov.publicCertPath()
 			pd, err = os.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err = prov.shouldCacheClientCert(pd, "rip.mcollective")
+			priv, err = prov.ShouldAllowCaller(pd, "rip.mcollective")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(should).To(BeTrue())
 			Expect(priv).To(BeFalse())
-			Expect(name).To(Equal("rip.mcollective"))
 		})
 
-		It("Should cache privileged certs", func() {
+		It("Should accept privileged certs", func() {
 			pd, err := os.ReadFile(filepath.Join("..", "testdata", "good", "certs", "1.privileged.mcollective.pem"))
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err := prov.shouldCacheClientCert(pd, "bob")
+			priv, err := prov.ShouldAllowCaller(pd, "bob")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(should).To(BeTrue())
 			Expect(priv).To(BeTrue())
-			Expect(name).To(Equal("1.privileged.mcollective"))
 		})
 
-		It("Should not cache certs with wrong names", func() {
+		It("Should not accept certs with wrong names", func() {
 			pub := prov.publicCertPath()
 
 			pd, err := os.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err := prov.shouldCacheClientCert(pd, "bob")
+			priv, err := prov.ShouldAllowCaller(pd, "bob")
 			Expect(err).To(HaveOccurred())
-			Expect(should).To(BeFalse())
 			Expect(priv).To(BeFalse())
-			Expect(name).To(Equal("bob"))
 		})
 
-		It("Should only cache certs thats on the allowed list", func() {
+		It("Should only accept certs that's on the allowed list", func() {
 			cfg.AllowList = []string{"bob"}
 			pub := prov.publicCertPath()
 
 			pd, err := os.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err := prov.shouldCacheClientCert(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(should).To(BeFalse())
+			priv, err := prov.ShouldAllowCaller(pd, "rip.mcollective")
 			Expect(priv).To(BeFalse())
-			Expect(name).To(Equal("rip.mcollective"))
+			Expect(err).To(MatchError("not on allow list"))
 		})
 
-		It("Should cache valid certs", func() {
+		It("Should accept valid certs", func() {
 			pub := prov.publicCertPath()
 
 			pd, err := os.ReadFile(pub)
 			Expect(err).ToNot(HaveOccurred())
 
-			should, priv, name, err := prov.shouldCacheClientCert(pd, "rip.mcollective")
+			priv, err := prov.ShouldAllowCaller(pd, "rip.mcollective")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(should).To(BeTrue())
 			Expect(priv).To(BeFalse())
-			Expect(name).To(Equal("rip.mcollective"))
-		})
-	})
-
-	Describe("CachePublicData", func() {
-		It("Should not write untrusted files to disk", func() {
-			cfg.Cache = os.TempDir()
-			pd, err := os.ReadFile(filepath.Join("..", "testdata", "foreign.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			err = prov.CachePublicData(pd, "foreign")
-			Expect(err).To(MatchError("certificate 'foreign' did not pass validation: x509: certificate signed by unknown authority"))
-
-			cpath, err := prov.cachePath("foreign")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			Expect(util.FileExist(cpath)).To(BeFalse())
-		})
-
-		It("Should write trusted files to disk", func() {
-			cfg.Cache = os.TempDir()
-			pub := prov.publicCertPath()
-
-			pd, err := os.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			cpath, err := prov.cachePath("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			Expect(util.FileExist(cpath)).To(BeTrue())
-		})
-
-		It("Should not overwrite existing files", func() {
-			cfg.Cache = os.TempDir()
-			pub := prov.publicCertPath()
-
-			pd, err := os.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			cpath, err := prov.cachePath("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			// deliberately change the file so that we can figure out if its being changed
-			// I'd check time stamps but they are per second so not much use
-			err = os.WriteFile(cpath, []byte("too many secrets"), os.FileMode(int(0644)))
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			stat, err := os.Stat(cpath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stat.Size()).To(Equal(int64(16)))
-		})
-
-		It("Should support always overwrite files", func() {
-			c, err := config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			identity := "rip.mcollective"
-
-			// These certs both have the same hostname.  First we cache the first one, then we attempt to cache the second one.
-			// This should result in the caching layer storing the second certificate.
-			firstcert := filepath.Join("..", "testdata", "intermediate", "certs", identity+".pem")
-			secondcert := filepath.Join("..", "testdata", "intermediate", "certs", "second."+identity+".pem")
-
-			c.Choria.FileSecurityCertificate = firstcert
-			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
-			c.Choria.SecurityAlwaysOverwriteCache = true
-
-			c.Choria.FileSecurityCache, err = os.MkdirTemp("", "cache-always")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(c.Choria.FileSecurityCache)
-
-			prov, err := New(WithChoriaConfig(&build.Info{}, c), WithLog(l.WithFields(logrus.Fields{})))
-			Expect(err).ToNot(HaveOccurred())
-
-			fpd, err := os.ReadFile(firstcert)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(fpd, identity)
-			Expect(err).ToNot(HaveOccurred())
-
-			spd, err := os.ReadFile(secondcert)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(spd, identity)
-			Expect(err).ToNot(HaveOccurred())
-
-			cpd, err := prov.CachedPublicData(identity)
-			Expect(err).ToNot(HaveOccurred())
-
-			res := bytes.Compare(spd, cpd)
-			Expect(res).To(BeZero())
-		})
-
-		It("Should fail cache validation if allow lists change", func() {
-			cfg.Cache = os.TempDir()
-			cfg.Cache = os.TempDir()
-			pub := prov.publicCertPath()
-
-			pd, err := os.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			cfg.AllowList = []string{"^bees$"}
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("CachedPublicData", func() {
-		It("Should read the correct file", func() {
-			cfg.Cache = os.TempDir()
-
-			pub := prov.publicCertPath()
-
-			pd, err := os.ReadFile(pub)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pd, "rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-
-			dat, err := prov.CachedPublicData("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(dat).To(Equal(pd))
-		})
-	})
-
-	Describe("privilegedCerts", func() {
-		It("Should find the right certs", func() {
-			cfg.PrivilegedUsers = []string{"\\.privileged.mcollective$", "\\.super.mcollective$"}
-			cfg.AllowList = []string{"\\.mcollective$"}
-
-			expected := []string{
-				"1.privileged.mcollective",
-				"1.super.mcollective",
-				"2.privileged.mcollective",
-				"2.super.mcollective",
-			}
-
-			Expect(prov.privilegedCerts()).To(Equal(expected))
 		})
 	})
 
@@ -764,5 +550,4 @@ var _ = Describe("FileSSL", func() {
 			Expect(prov.conf.TLSConfig.CurvePreferences).To(Equal(tlssetup.DefaultCurvePreferences()))
 		})
 	})
-
 })

--- a/providers/security/filesec/option.go
+++ b/providers/security/filesec/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,13 +28,11 @@ func WithChoriaConfig(bi BuildInfoProvider, c *config.Config) Option {
 	cfg := Config{
 		AllowList:                  c.Choria.CertnameWhitelist,
 		CA:                         c.Choria.FileSecurityCA,
-		Cache:                      c.Choria.FileSecurityCache,
 		Certificate:                c.Choria.FileSecurityCertificate,
 		DisableTLSVerify:           c.DisableTLSVerify,
 		Key:                        c.Choria.FileSecurityKey,
 		PrivilegedUsers:            c.Choria.PrivilegedUsers,
 		Identity:                   c.Identity,
-		AlwaysOverwriteCache:       c.Choria.SecurityAlwaysOverwriteCache,
 		RemoteSignerURL:            c.Choria.RemoteSignerURL,
 		RemoteSignerTokenFile:      c.Choria.RemoteSignerTokenFile,
 		TLSConfig:                  tlssetup.TLSConfig(c),

--- a/providers/security/filesec/util.go
+++ b/providers/security/filesec/util.go
@@ -1,12 +1,10 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package filesec
 
 import (
-	"crypto/sha256"
-	"io"
 	"os"
 	"regexp"
 	"runtime"
@@ -14,7 +12,7 @@ import (
 )
 
 // MatchAnyRegex checks str against a list of possible regex, if any match true is returned
-func MatchAnyRegex(str []byte, regex []string) bool {
+func MatchAnyRegex(str string, regex []string) bool {
 	matcher := regexp.MustCompile("^/.+/$")
 
 	for _, reg := range regex {
@@ -23,7 +21,7 @@ func MatchAnyRegex(str []byte, regex []string) bool {
 			reg = strings.TrimRight(reg, "/")
 		}
 
-		if matched, _ := regexp.Match(reg, str); matched {
+		if matched, _ := regexp.MatchString(reg, str); matched {
 			return true
 		}
 	}
@@ -45,20 +43,4 @@ func runtimeOs() string {
 	}
 
 	return runtime.GOOS
-}
-
-func fsha256(file string) ([]byte, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	h := sha256.New()
-	_, err = io.Copy(h, f)
-	if err != nil {
-		return nil, err
-	}
-
-	return h.Sum(nil), nil
 }

--- a/providers/security/filesec/util_test.go
+++ b/providers/security/filesec/util_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,8 +16,8 @@ var _ = Describe("MatchAnyRegex", func() {
 			"/this.+other/",
 		}
 
-		Expect(MatchAnyRegex([]byte("this is a bare word sentence"), patterns)).To(BeTrue())
-		Expect(MatchAnyRegex([]byte("this, that and the other"), patterns)).To(BeTrue())
-		Expect(MatchAnyRegex([]byte("no match"), patterns)).To(BeFalse())
+		Expect(MatchAnyRegex("this is a bare word sentence", patterns)).To(BeTrue())
+		Expect(MatchAnyRegex("this, that and the other", patterns)).To(BeTrue())
+		Expect(MatchAnyRegex("no match", patterns)).To(BeFalse())
 	})
 })

--- a/providers/security/pkcs11sec/option.go
+++ b/providers/security/pkcs11sec/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,14 +15,12 @@ type Option func(*Pkcs11Security) error
 func WithChoriaConfig(c *config.Config) Option {
 	return func(p *Pkcs11Security) error {
 		cfg := Config{
-			AllowList:            c.Choria.CertnameWhitelist,
-			DisableTLSVerify:     c.DisableTLSVerify,
-			PrivilegedUsers:      c.Choria.PrivilegedUsers,
-			CAFile:               c.Choria.FileSecurityCA,
-			CertCacheDir:         c.Choria.FileSecurityCache,
-			AlwaysOverwriteCache: c.Choria.SecurityAlwaysOverwriteCache,
-			PKCS11DriverFile:     c.Choria.PKCS11DriverFile,
-			PKCS11Slot:           uint(c.Choria.PKCS11Slot),
+			AllowList:        c.Choria.CertnameWhitelist,
+			DisableTLSVerify: c.DisableTLSVerify,
+			PrivilegedUsers:  c.Choria.PrivilegedUsers,
+			CAFile:           c.Choria.FileSecurityCA,
+			PKCS11DriverFile: c.Choria.PKCS11DriverFile,
+			PKCS11Slot:       uint(c.Choria.PKCS11Slot),
 		}
 
 		p.conf = &cfg

--- a/providers/security/pkcs11sec/pkcs11_security_test.go
+++ b/providers/security/pkcs11sec/pkcs11_security_test.go
@@ -1,11 +1,10 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package pkcs11sec
 
 import (
-	"bytes"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -13,8 +12,6 @@ import (
 	"testing"
 
 	"github.com/choria-io/go-choria/config"
-	"github.com/choria-io/go-choria/inter"
-	"github.com/choria-io/go-choria/internal/util"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -23,11 +20,11 @@ import (
 func TestFileSecurity(t *testing.T) {
 	RegisterFailHandler(Fail)
 	if runPkcs11 := os.Getenv("RUN_PKCS11_TESTS"); runPkcs11 == "1" {
-		RunSpecs(t, "Security/Pkcs11")
+		RunSpecs(t, "Security/Pkcs11Security")
 	}
 }
 
-var _ = Describe("Pkcs11SSL", func() {
+var _ = Describe("Pkcs11Security", func() {
 	var err error
 	var prov *Pkcs11Security
 	var l *logrus.Logger
@@ -36,7 +33,7 @@ var _ = Describe("Pkcs11SSL", func() {
 	var c *config.Config
 	var testSlot = 374292918
 
-	var genericBeforeEach = func() {
+	BeforeEach(func() {
 		lib = "/usr/lib/softhsm/libsofthsm2.so"
 		if envLib := os.Getenv("SOFTHSM_LIB"); envLib != "" {
 			lib = envLib
@@ -53,27 +50,19 @@ var _ = Describe("Pkcs11SSL", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "good", "certs", "ca.pem")
-		c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "good", "certs")
 		c.Choria.PKCS11Slot = testSlot
 		c.Choria.PKCS11DriverFile = lib
 
 		prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
 		Expect(err).ToNot(HaveOccurred())
-	}
-
-	BeforeEach(genericBeforeEach)
-	It("Should implement the provider interface", func() {
-		f := func(p inter.SecurityProvider) {}
-		f(prov)
-		Expect(prov.Provider()).To(Equal("pkcs11"))
 	})
+
 	Describe("WithChoriaConfig", func() {
 		It("Should copy all the relevant settings", func() {
 			c, err := config.NewDefaultConfig()
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "good", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "good", "certs")
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
 			c.DisableTLSVerify = true
@@ -84,10 +73,10 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(prov.conf.AllowList).To(Equal([]string{"\\.mcollective$", "\\.choria$"}))
 			Expect(prov.conf.PrivilegedUsers).To(Equal([]string{"\\.privileged.mcollective$", "\\.privileged.choria$"}))
 			Expect(prov.conf.CAFile).To(Equal("../testdata/good/certs/ca.pem"))
-			Expect(prov.conf.CertCacheDir).To(Equal("../testdata/good/certs"))
 			Expect(prov.conf.DisableTLSVerify).To(BeTrue())
 		})
 	})
+
 	Describe("Validate", func() {
 		It("Should return true if provider was successfully initialized", func() {
 			errs, ok := prov.Validate()
@@ -99,7 +88,6 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = "stub/ca.pem"
-			c.Choria.FileSecurityCache = "stub/cache"
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
 
@@ -109,26 +97,29 @@ var _ = Describe("Pkcs11SSL", func() {
 			errs, ok := prov.Validate()
 			Expect(ok).To(BeFalse())
 			Expect(errs).To(HaveLen(2))
-			Expect(errs[0]).To(Equal(fmt.Sprintf("stat %s: no such file or directory", prov.conf.CertCacheDir)))
-			Expect(errs[1]).To(Equal(fmt.Sprintf("stat %s: no such file or directory", prov.conf.CAFile)))
+			Expect(errs[0]).To(Equal(fmt.Sprintf("stat %s: no such file or directory", prov.conf.CAFile)))
 		})
 	})
+
 	Describe("Identity", func() {
 		It("Should return the identity", func() {
 			Expect(prov.Identity()).To(Equal("joeuser"))
 		})
 	})
+
 	Describe("CallerName", func() {
 		It("Should return the right caller name", func() {
 			Expect(prov.CallerName()).To(Equal("choria=joeuser"))
 		})
 	})
+
 	Describe("CallerIdentity", func() {
 		It("Should return the right caller ident, no matter the input", func() {
 			Expect(prov.CallerIdentity("choria=test.choria")).To(Equal("test.choria"))
 			Expect(prov.CallerIdentity("foo=test1.choria")).To(Equal("test1.choria"))
 		})
 	})
+
 	Describe("SignBytes", func() {
 		It("Should produce the right signature", func() {
 			sig, err := prov.SignBytes([]byte("too many secrets"))
@@ -136,17 +127,18 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PQlGnXt8jQ9N2WbghvKhH4qNTJcmTpbfspkT+9aSabivRbMGNIlMwDGMg8PQEC5AMF9eoxdaXuR/t2rbgUfqQrB3oI2YMD2clUtdVI1MIJ81ww90o0KHZa3C0N/OlshJVCDg1mUiget7rdfE5K3HARKbPZZbQFe/q5yPnjA7FGHEb1K+qnPyLGKD8WKIDTjHza16O6QWAcbyAWk2CP9ziLH5flVGMP0zMkdXQPiFfzexUG6iTIi64zVJ2k6E3k1JOGzRLeQfvUDNEQnmekH4w0iK0+uTZzBsQPr3jbd8xraTInv+v1CzrpBwoIP36Qlr296vxKngaqDSN2K3uSyKWg=="))
 		})
 	})
+
 	Describe("VerifyByteSignature", func() {
 		It("Should validate correctly", func() {
 			sig, err := base64.StdEncoding.DecodeString("PQlGnXt8jQ9N2WbghvKhH4qNTJcmTpbfspkT+9aSabivRbMGNIlMwDGMg8PQEC5AMF9eoxdaXuR/t2rbgUfqQrB3oI2YMD2clUtdVI1MIJ81ww90o0KHZa3C0N/OlshJVCDg1mUiget7rdfE5K3HARKbPZZbQFe/q5yPnjA7FGHEb1K+qnPyLGKD8WKIDTjHza16O6QWAcbyAWk2CP9ziLH5flVGMP0zMkdXQPiFfzexUG6iTIi64zVJ2k6E3k1JOGzRLeQfvUDNEQnmekH4w0iK0+uTZzBsQPr3jbd8xraTInv+v1CzrpBwoIP36Qlr296vxKngaqDSN2K3uSyKWg==")
 			Expect(err).ToNot(HaveOccurred())
 
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "")
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), sig, nil)
 			Expect(valid).To(BeTrue())
 		})
 
 		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), "")
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), []byte("meh"), nil)
 			Expect(valid).To(BeFalse())
 		})
 
@@ -157,61 +149,14 @@ var _ = Describe("Pkcs11SSL", func() {
 			sig, err := base64.StdEncoding.DecodeString("Zq1F2bdXOAvB5Ca+iYCZ/BLYz2ZzbQP/V8kwQY0E3cuDrBDArX7UhUnBakzN+Msr7UyF+EkYmzvIi4KHnFBrgi7otM8Q5YMh5IT+IPaoHj3Rj/jorqD4g8ltZINqCUBWDN4wvSG98SxLyawV69gAK4SnP+oy7SU7zxuQiPwIMJ7lVoiQ3t+tiQAHUxeykQPw7WElLb+wPTb1k4DM3yRkijA9OeUk+3SVyl2sTCu5h/Lg0lcI372bkLDESlnhnvw7yuLD2SSncrEQrBdv/N2yEpY2fx1UKGlTrn9GH4MGA1GuzE1F87RH9P8ieeul6vI13BkBAlMk5KaGlmWpgiGri5UjCHHXMxEnXfwUcKFE+E6yVg4SbrJknkuJzNJduypMIep7YOnPHVLNIBZLuOUdJrRgBQ+Yb9mxPnEQHhOHeN0XHUcseRJEISqPkagpNx1xhOb7g3hsNyEvqibT/DZsc/2hyU2I/wG9fl26CnN9c12r1zInyCQYsU/wuIvjDtRZvTpLGJSJdgjSmTPzGmA/fKpAfOWObdsoLeorjF/pNweuc0x0JZMsBrZauldLL53wnnvllsFEmIAxs+RusoJ2UfW7WugZ7lXGISHTef6IHjukHgDBSbeGawVCnAgPbPz1dy42x04koUW3Bmz89fJ4/j+e49ijz7z3W/IercNeke4=")
 			Expect(err).ToNot(HaveOccurred())
 
-			valid := prov.VerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
+			cert, err := os.ReadFile("../testdata/good/certs/2.mcollective.pem")
+			Expect(err).ToNot(HaveOccurred())
+
+			valid, _ := prov.VerifyByteSignature([]byte("too many secrets"), sig, cert)
 			Expect(valid).To(BeTrue())
 		})
 	})
 
-	Describe("PrivilegedVerifyByteSignature", func() {
-		It("Should allow a privileged cert to act as someone else", func() {
-
-			c, err := config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "good", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "good", "certs")
-			c.Choria.PrivilegedUsers = []string{"\\.privileged.mcollective$", "\\.super.mcollective$"}
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-			Expect(err).ToNot(HaveOccurred())
-
-			sig, err := base64.StdEncoding.DecodeString("4dSmCRsnZzJjqSLdXxCRufw+wh9BrbqMZfEkB9c0yLkqjuc6r2b3tl5bh28l2lm50nPcIKeMyVHh2pkhvVsnjTYVhEYGTBcJdhAf/4PQCCqllHfiD0i+EZNTC916P4C2TVFNw5kOx/qjz6KYBuBV0K0U5JG1L7rHmlSoJ1La9vs/x1RMLly91NYnPOtCpwSsAwRG6uGMnCQK/vGg+NiwIQpQrchCpVf6rrXSqqUrJzZc/SeNl42AA2EYbkq8ys79sye1w91BF07gX6n/gK/472tlTh9OK49GmLdi15oGiEOPbkCbPYm2hcWAJzdqGprCQAsYjuMfUByswxkthEw72Bp9tmSuc6P6QPLswkAeVi4NivQCm81CFEB0ZKl0WluJp5xEL9/mO9/Z/iUuvMRGQSbfIzi+8PVJeNIWsY8rzsDMdoIdwPD+vqVU7BhHxKXjAHq2nnhQCj35HuV2dN7n0MOy4A6H5kA4a8d5UVTBRMsFZ5s6Bo4/leFOlylgU2DIWq+DXdg05Zr98H9JulDM0epKEjLeowo5z5f2s7/eQymaSzdoW2zUhe9Hp0G0D8CkQUXm/RzjzLBTZ1fNQYIQGA9U6n+ApwBNHW9ClmlbbvcUb+Bw2rRHVgKM6+kUam+TLpLljuZkOY6wkk+h97aHYJyO7tOezyTuPPM5L3CDQ+M=")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "rip.mcollective")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should allow a cert to act as itself", func() {
-			c, err := config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-
-			Expect(err).ToNot(HaveOccurred())
-
-			sig, err := base64.StdEncoding.DecodeString("PQlGnXt8jQ9N2WbghvKhH4qNTJcmTpbfspkT+9aSabivRbMGNIlMwDGMg8PQEC5AMF9eoxdaXuR/t2rbgUfqQrB3oI2YMD2clUtdVI1MIJ81ww90o0KHZa3C0N/OlshJVCDg1mUiget7rdfE5K3HARKbPZZbQFe/q5yPnjA7FGHEb1K+qnPyLGKD8WKIDTjHza16O6QWAcbyAWk2CP9ziLH5flVGMP0zMkdXQPiFfzexUG6iTIi64zVJ2k6E3k1JOGzRLeQfvUDNEQnmekH4w0iK0+uTZzBsQPr3jbd8xraTInv+v1CzrpBwoIP36Qlr296vxKngaqDSN2K3uSyKWg==")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "joeuser")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should not allow a unmatched cert", func() {
-			sig, err := base64.StdEncoding.DecodeString("PQlGnXt8jQ9N2WbghvKhH4qNTJcmTpbfspkT+9aSabivRbMGNIlMwDGMg8PQEC5AMF9eoxdaXuR/t2rbgUfqQrB3oI2YMD2clUtdVI1MIJ81ww90o0KHZa3C0N/OlshJVCDg1mUiget7rdfE5K3HARKbPZZbQFe/q5yPnjA7FGHEb1K+qnPyLGKD8WKIDTjHza16O6QWAcbyAWk2CP9ziLH5flVGMP0zMkdXQPiFfzexUG6iTIi64zVJ2k6E3k1JOGzRLeQfvUDNEQnmekH4w0iK0+uTZzBsQPr3jbd8xraTInv+v1CzrpBwoIP36Qlr296vxKngaqDSN2K3uSyKWg==")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.PrivilegedVerifyByteSignature([]byte("too many secrets"), sig, "2.mcollective")
-			Expect(valid).To(BeFalse())
-		})
-	})
 	Describe("SignString", func() {
 		It("Should produce the right signature", func() {
 			sig, err := prov.SignString("too many secrets")
@@ -223,31 +168,7 @@ var _ = Describe("Pkcs11SSL", func() {
 
 		})
 	})
-	Describe("VerifyStringSignature", func() {
-		It("Should validate correctly", func() {
-			c, err := config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
 
-			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-			Expect(err).ToNot(HaveOccurred())
-
-			sig, err := base64.StdEncoding.DecodeString("PQlGnXt8jQ9N2WbghvKhH4qNTJcmTpbfspkT+9aSabivRbMGNIlMwDGMg8PQEC5AMF9eoxdaXuR/t2rbgUfqQrB3oI2YMD2clUtdVI1MIJ81ww90o0KHZa3C0N/OlshJVCDg1mUiget7rdfE5K3HARKbPZZbQFe/q5yPnjA7FGHEb1K+qnPyLGKD8WKIDTjHza16O6QWAcbyAWk2CP9ziLH5flVGMP0zMkdXQPiFfzexUG6iTIi64zVJ2k6E3k1JOGzRLeQfvUDNEQnmekH4w0iK0+uTZzBsQPr3jbd8xraTInv+v1CzrpBwoIP36Qlr296vxKngaqDSN2K3uSyKWg==")
-			Expect(err).ToNot(HaveOccurred())
-
-			valid := prov.VerifyStringSignature("too many secrets", sig, "")
-			Expect(valid).To(BeTrue())
-		})
-
-		It("Should fail for invalid sigs", func() {
-			valid := prov.VerifyStringSignature("too many secrets", []byte("meh"), "")
-			Expect(valid).To(BeFalse())
-		})
-	})
 	Describe("ChecksumBytes", func() {
 		It("Should produce the right checksum", func() {
 			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
@@ -256,6 +177,7 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(prov.ChecksumBytes([]byte("too many secrets"))).To(Equal(sum))
 		})
 	})
+
 	Describe("ChecksumString", func() {
 		It("Should produce the right checksum", func() {
 			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
@@ -264,13 +186,13 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(prov.ChecksumString("too many secrets")).To(Equal(sum))
 		})
 	})
+
 	Describe("TLSConfig", func() {
 		It("Should produce a valid TLS Config", func() {
 			c, err := config.NewDefaultConfig()
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
 
@@ -294,7 +216,6 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
 			c.DisableTLSVerify = true
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
@@ -310,6 +231,7 @@ var _ = Describe("Pkcs11SSL", func() {
 
 		})
 	})
+
 	Describe("VerifyCertificate", func() {
 		var pem []byte
 		var inter *config.Config
@@ -319,7 +241,6 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			inter.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca_chain_ca.pem")
-			inter.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 			inter.Choria.PKCS11Slot = testSlot
 			inter.Choria.PKCS11DriverFile = lib
 
@@ -348,7 +269,6 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
 
@@ -364,7 +284,6 @@ var _ = Describe("Pkcs11SSL", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
 			c.Choria.SSLDir = filepath.Join("..", "testdata", "intermediate")
 			c.Choria.PKCS11Slot = testSlot
 			c.Choria.PKCS11DriverFile = lib
@@ -410,141 +329,6 @@ var _ = Describe("Pkcs11SSL", func() {
 
 			err = prov.VerifyCertificate(pem, "email:bad@choria-io.com")
 			Expect(err).To(HaveOccurred())
-		})
-	})
-	Describe("CachePublicData", func() {
-
-		var pem []byte
-
-		BeforeEach(func() {
-			c, err = config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = os.TempDir()
-			c.Choria.CertnameWhitelist = []string{"joeuser"}
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-			Expect(err).ToNot(HaveOccurred())
-
-			pem, err = prov.PublicCertBytes()
-			Expect(err).ToNot(HaveOccurred())
-		})
-		It("Should not write untrusted files to disk", func() {
-			pd, err := os.ReadFile(filepath.Join("..", "testdata", "foreign.pem"))
-			Expect(err).ToNot(HaveOccurred())
-			err = prov.CachePublicData(pd, "foreign")
-			Expect(err).To(MatchError("certificate 'foreign' did not pass validation"))
-
-			cpath, err := prov.cachePath("foreign")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			Expect(util.FileExist(cpath)).To(BeTrue())
-		})
-
-		It("Should write trusted files to disk", func() {
-			err = prov.CachePublicData(pem, "joeuser")
-			Expect(err).ToNot(HaveOccurred())
-
-			cpath, err := prov.cachePath("joeuser")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			Expect(util.FileExist(cpath)).To(BeTrue())
-		})
-
-		It("Should not overwrite existing files", func() {
-			err = prov.CachePublicData(pem, "joeuser")
-			Expect(err).ToNot(HaveOccurred())
-
-			cpath, err := prov.cachePath("joeuser")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.Remove(cpath)
-
-			// deliberately change the file so that we can figure out if its being changed
-			// I'd check time stamps but they are per second so not much use
-			err = os.WriteFile(cpath, []byte("too many secrets"), os.FileMode(int(0644)))
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pem, "joeuser")
-			Expect(err).ToNot(HaveOccurred())
-
-			stat, err := os.Stat(cpath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stat.Size()).To(Equal(int64(16)))
-		})
-
-		It("Should support always overwrite files", func() {
-			c, err = config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			identity := "rip.mcollective"
-
-			// These certs both have the same hostname.  First we cache the first one, then we attempt to cache the second one.
-			// This should result in the caching layer storing the second certificate.
-			firstcert := filepath.Join("..", "testdata", "intermediate", "certs", identity+".pem")
-			secondcert := filepath.Join("..", "testdata", "intermediate", "certs", "second."+identity+".pem")
-
-			// c.Choria.FileSecurityCertificate = firstcert
-			c.Choria.FileSecurityCA = filepath.Join("..", "testdata", "intermediate", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("..", "testdata", "intermediate", "certs")
-			c.Choria.SecurityAlwaysOverwriteCache = true
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			c.Choria.FileSecurityCache, err = os.MkdirTemp("", "cache-always")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(c.Choria.FileSecurityCache)
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-			Expect(err).ToNot(HaveOccurred())
-
-			fpd, err := os.ReadFile(firstcert)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(fpd, identity)
-			Expect(err).ToNot(HaveOccurred())
-
-			spd, err := os.ReadFile(secondcert)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(spd, identity)
-			Expect(err).To(BeNil())
-
-			cpd, err := prov.CachedPublicData(identity)
-			Expect(err).ToNot(HaveOccurred())
-
-			res := bytes.Compare(spd, cpd)
-			Expect(res).To(BeZero())
-		})
-	})
-	Describe("CachedPublicData", func() {
-		It("Should read the correct file", func() {
-
-			c, err := config.NewDefaultConfig()
-			Expect(err).ToNot(HaveOccurred())
-
-			c.Choria.FileSecurityCA = filepath.Join("test_data", "ssl_dir", "certs", "ca.pem")
-			c.Choria.FileSecurityCache = filepath.Join("test_data", "ssl_dir", "certs")
-			c.Choria.CertnameWhitelist = []string{"joeuser"}
-			c.Choria.PKCS11Slot = testSlot
-			c.Choria.PKCS11DriverFile = lib
-
-			prov, err = New(WithChoriaConfig(c), WithLog(l.WithFields(logrus.Fields{})), WithPin(pin))
-			Expect(err).ToNot(HaveOccurred())
-
-			pem, err := prov.PublicCertBytes()
-			Expect(err).ToNot(HaveOccurred())
-
-			err = prov.CachePublicData(pem, "joeuser")
-			Expect(err).ToNot(HaveOccurred())
-
-			dat, err := prov.CachedPublicData("joeuser")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(dat).To(Equal(pem))
 		})
 	})
 })

--- a/providers/security/puppetsec/option.go
+++ b/providers/security/puppetsec/option.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +30,6 @@ func WithChoriaConfig(bi BuildInfoProvider, c *config.Config) Option {
 			PuppetCAHost:          c.Choria.PuppetCAHost,
 			PuppetCAPort:          c.Choria.PuppetCAPort,
 			Identity:              c.Identity,
-			AlwaysOverwriteCache:  c.Choria.SecurityAlwaysOverwriteCache,
 			RemoteSignerURL:       c.Choria.RemoteSignerURL,
 			RemoteSignerTokenFile: c.Choria.RemoteSignerTokenFile,
 			TLSConfig:             tlssetup.TLSConfig(c),

--- a/providers/security/puppetsec/puppet_security_test.go
+++ b/providers/security/puppetsec/puppet_security_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -170,23 +170,6 @@ var _ = Describe("PuppetSSL", func() {
 			prov.reinit()
 
 			Expect(prov.Identity()).To(Equal("bob.choria"))
-		})
-	})
-
-	Describe("cachePath", func() {
-		It("Should get the right cache path", func() {
-			path := prov.cachePath("rip.mcollective")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(path).To(Equal(filepath.FromSlash(filepath.Join(cfg.SSLDir, "choria_security", "public_certs", "rip.mcollective.pem"))))
-		})
-	})
-
-	Describe("certCacheDir", func() {
-		It("Should determine the right directory", func() {
-			path := prov.certCacheDir()
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(path).To(Equal(filepath.FromSlash(filepath.Join(cfg.SSLDir, "choria_security", "public_certs"))))
 		})
 	})
 

--- a/providers/security/puppetsec/util.go
+++ b/providers/security/puppetsec/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2020-2022, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
The cache was mainly used to find all privileged certificates and then verify signatures against all known privileged certificates.

This was a useless effort since the privileged certificate was already attached with the message.

So this remove the cache entirely and remove privileged checks that was using the cache.

We pulled out the validation that was done during cache save into a new security method and call that instead of save to gain the validation benefits.

Follow up work is to write some integration tests to ensure the security remains safe.

Signed-off-by: R.I.Pienaar <rip@devco.net>