### PR TITLE
(#1740) simplify security interface

### DIFF
--- a/inter/imocks/security.go
+++ b/inter/imocks/security.go
@@ -82,20 +82,6 @@ func (mr *MockSecurityProviderMockRecorder) ChecksumBytes(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChecksumBytes", reflect.TypeOf((*MockSecurityProvider)(nil).ChecksumBytes), arg0)
 }
 
-// ChecksumString mocks base method.
-func (m *MockSecurityProvider) ChecksumString(arg0 string) []byte {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChecksumString", arg0)
-	ret0, _ := ret[0].([]byte)
-	return ret0
-}
-
-// ChecksumString indicates an expected call of ChecksumString.
-func (mr *MockSecurityProviderMockRecorder) ChecksumString(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChecksumString", reflect.TypeOf((*MockSecurityProvider)(nil).ChecksumString), arg0)
-}
-
 // ClientTLSConfig mocks base method.
 func (m *MockSecurityProvider) ClientTLSConfig() (*tls.Config, error) {
 	m.ctrl.T.Helper()
@@ -285,21 +271,6 @@ func (m *MockSecurityProvider) SignBytes(arg0 []byte) ([]byte, error) {
 func (mr *MockSecurityProviderMockRecorder) SignBytes(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignBytes", reflect.TypeOf((*MockSecurityProvider)(nil).SignBytes), arg0)
-}
-
-// SignString mocks base method.
-func (m *MockSecurityProvider) SignString(arg0 string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SignString", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SignString indicates an expected call of SignString.
-func (mr *MockSecurityProviderMockRecorder) SignString(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignString", reflect.TypeOf((*MockSecurityProvider)(nil).SignString), arg0)
 }
 
 // TLSConfig mocks base method.

--- a/inter/security_provider.go
+++ b/inter/security_provider.go
@@ -36,9 +36,6 @@ type SecurityProvider interface {
 	// VerifyByteSignature verifies that dat signature was made using pubcert
 	VerifyByteSignature(dat []byte, sig []byte, pubcert []byte) (should bool, signer string)
 
-	// SignString signs a string using the current active certificate
-	SignString(s string) (signature []byte, err error)
-
 	// RemoteSignRequest signs a choria request using a remote signer and returns a secure request
 	RemoteSignRequest(ctx context.Context, str []byte) (signed []byte, err error)
 
@@ -47,9 +44,6 @@ type SecurityProvider interface {
 
 	// ChecksumBytes produce a crypto checksum for data
 	ChecksumBytes(data []byte) []byte
-
-	// ChecksumString produce a crypto checksum for data
-	ChecksumString(data string) []byte
 
 	// TLSConfig produce a tls.Config for the current identity using it's certificates etc
 	TLSConfig() (*tls.Config, error)

--- a/protocol/v1/security_reply.go
+++ b/protocol/v1/security_reply.go
@@ -37,7 +37,7 @@ func (r *secureReply) SetMessage(reply protocol.Reply) (err error) {
 		return fmt.Errorf("could not JSON encode reply message to store it in the Secure Reply: %s", err)
 	}
 
-	hash := r.security.ChecksumString(j)
+	hash := r.security.ChecksumBytes([]byte(j))
 	r.MessageBody = j
 	r.Hash = base64.StdEncoding.EncodeToString(hash[:])
 
@@ -57,7 +57,7 @@ func (r *secureReply) Valid() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	hash := r.security.ChecksumString(r.MessageBody)
+	hash := r.security.ChecksumBytes([]byte(r.MessageBody))
 	if base64.StdEncoding.EncodeToString(hash[:]) == r.Hash {
 		validCtr.Inc()
 		return true

--- a/protocol/v1/security_reply_test.go
+++ b/protocol/v1/security_reply_test.go
@@ -42,7 +42,7 @@ var _ = Describe("SecureReply", func() {
 
 		sha := sha256.Sum256([]byte(rj))
 
-		security.EXPECT().ChecksumString(rj).Return(sha[:]).AnyTimes()
+		security.EXPECT().ChecksumBytes([]byte(rj)).Return(sha[:]).AnyTimes()
 
 		sreply, _ := NewSecureReply(reply, security)
 		sj, err := sreply.JSON()

--- a/protocol/v1/security_request.go
+++ b/protocol/v1/security_request.go
@@ -43,7 +43,7 @@ func (r *secureRequest) SetMessage(request protocol.Request) (err error) {
 	if protocol.IsSecure() && !protocol.IsRemoteSignerAgent(request.Agent()) {
 		var signature []byte
 
-		signature, err = r.security.SignString(j)
+		signature, err = r.security.SignBytes([]byte(j))
 		if err != nil {
 			// registration when doing anon tls might not have a certificate - so we allow that to go unsigned
 			if !protocol.IsRegistrationAgent(request.Agent()) {

--- a/protocol/v1/security_request_test.go
+++ b/protocol/v1/security_request_test.go
@@ -47,7 +47,7 @@ var _ = Describe("SecureRequest", func() {
 		rj, err := r.JSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		security.EXPECT().SignString(gomock.Any()).Times(0)
+		security.EXPECT().SignBytes(gomock.Any()).Times(0)
 
 		sr, err := NewSecureRequest(r, security)
 		Expect(err).ToNot(HaveOccurred())
@@ -69,7 +69,7 @@ var _ = Describe("SecureRequest", func() {
 		rj, err := r.JSON()
 		Expect(err).ToNot(HaveOccurred())
 
-		security.EXPECT().SignString(rj).Return([]byte("stub.sig"), nil)
+		security.EXPECT().SignBytes([]byte(rj)).Return([]byte("stub.sig"), nil)
 
 		sr, err := NewSecureRequest(r, security)
 		Expect(err).ToNot(HaveOccurred())

--- a/protocol/v1/transport_test.go
+++ b/protocol/v1/transport_test.go
@@ -27,7 +27,7 @@ var _ = Describe("TransportMessage", func() {
 	})
 
 	It("Should support reply data", func() {
-		security.EXPECT().ChecksumString(gomock.Any()).Return([]byte("stub checksum")).AnyTimes()
+		security.EXPECT().ChecksumBytes(gomock.Any()).Return([]byte("stub checksum")).AnyTimes()
 
 		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		request.SetMessage(`{"message":1}`)
@@ -54,7 +54,7 @@ var _ = Describe("TransportMessage", func() {
 
 	It("Should support request data", func() {
 		security.EXPECT().PublicCertBytes().Return([]byte("stub cert"), nil).AnyTimes()
-		security.EXPECT().SignString(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
+		security.EXPECT().SignBytes(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
 
 		request, _ := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		request.SetMessage(`{"message":1}`)
@@ -79,7 +79,7 @@ var _ = Describe("TransportMessage", func() {
 		defer func() { protocol.ClientStrictValidation = false }()
 
 		security.EXPECT().PublicCertBytes().Return([]byte("stub cert"), nil).AnyTimes()
-		security.EXPECT().SignString(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
+		security.EXPECT().SignBytes(gomock.Any()).Return([]byte("stub sig"), nil).AnyTimes()
 
 		request, err := NewRequest("test", "go.tests", "rip.mcollective", 120, "a2f0ca717c694f2086cfa81b6c494648", "mcollective")
 		Expect(err).ToNot(HaveOccurred())

--- a/providers/security/certmanager/certmanager_security.go
+++ b/providers/security/certmanager/certmanager_security.go
@@ -494,10 +494,6 @@ func (cm *CertManagerSecurity) VerifyByteSignature(dat []byte, sig []byte, pubce
 	return cm.fsec.VerifyByteSignature(dat, sig, pubcert)
 }
 
-func (cm *CertManagerSecurity) SignString(s string) (signature []byte, err error) {
-	return cm.fsec.SignString(s)
-}
-
 func (cm *CertManagerSecurity) RemoteSignRequest(ctx context.Context, str []byte) (signed []byte, err error) {
 	return cm.fsec.RemoteSignRequest(ctx, str)
 }
@@ -508,10 +504,6 @@ func (cm *CertManagerSecurity) IsRemoteSigning() bool {
 
 func (cm *CertManagerSecurity) ChecksumBytes(data []byte) []byte {
 	return cm.fsec.ChecksumBytes(data)
-}
-
-func (cm *CertManagerSecurity) ChecksumString(data string) []byte {
-	return cm.fsec.ChecksumString(data)
 }
 
 func (cm *CertManagerSecurity) ClientTLSConfig() (*tls.Config, error) {

--- a/providers/security/filesec/file_security.go
+++ b/providers/security/filesec/file_security.go
@@ -200,11 +200,6 @@ func (s *FileSecurity) ChecksumBytes(data []byte) []byte {
 	return sum[:]
 }
 
-// ChecksumString calculates a sha256 checksum for data
-func (s *FileSecurity) ChecksumString(data string) []byte {
-	return s.ChecksumBytes([]byte(data))
-}
-
 // SignBytes signs a message using a SHA256 PKCS1v15 protocol
 func (s *FileSecurity) SignBytes(str []byte) ([]byte, error) {
 	sig := []byte{}
@@ -237,6 +232,7 @@ func (s *FileSecurity) SignBytes(str []byte) ([]byte, error) {
 	if err != nil {
 		err = fmt.Errorf("could not sign message: %s", err)
 	}
+
 	return sig, err
 }
 
@@ -284,11 +280,6 @@ func (s *FileSecurity) VerifyByteSignature(dat []byte, sig []byte, pubcert []byt
 	s.log.Debugf("Verified signature from %s", strings.Join(names, ", "))
 
 	return true, names[0]
-}
-
-// SignString signs a message using a SHA256 PKCS1v15 protocol
-func (s *FileSecurity) SignString(str string) ([]byte, error) {
-	return s.SignBytes([]byte(str))
 }
 
 // CallerName creates a choria like caller name in the form of choria=identity

--- a/providers/security/filesec/file_security_test.go
+++ b/providers/security/filesec/file_security_test.go
@@ -261,30 +261,12 @@ var _ = Describe("FileSecurity", func() {
 		})
 	})
 
-	Describe("SignString", func() {
-		It("Should produce the right signature", func() {
-			sig, err := prov.SignString("too many secrets")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(base64.StdEncoding.EncodeToString(sig)).To(Equal("PXj4RDHHt1oS1zF7r6EKiPyQ9oHlY4qyDP4DemZT26Hcr1A84l1p3nOVNMoksACrCdB1mW47FAwatgCB7cfCaOHsIiGOW/LQsmyE8eRpCYrV2gAHNsU6hA/CeIATwCq0Wtzp7Vc4PWR2VgrlSmihuK7sYGBJHEkillUG7F+P9c+epGJvLleM+nP7pTZVkrPqzwQ1tXFHgCNS2di5wTc5tCoJ0HHU3b31tuLGwROny3g3SsOjirrqdLDxciHYe/WzOGKByzTiqj1jjPZuuvkCzL9myr4anMBkwn1qtuqGtQ8FSwXLfgOKEwlLyf83rQ1OYWQFP+hdPJHaOlBm4iuVGjDEjla6MG081W8wpho6SqwhD1x2U9CUofQj2e0kNLQmjNK0xbIJUGSiStMcNFhIx5qoJYub40uJZkbfTE3hVp6cuOk9+yswGxfRO/RA88DBW679v8QoGeB+3RehggL2qGyRjdiPtxJj4Jt/pUAgBofrbausiIi8SUOnRSgYqpt0CLeYIiVgiNHa2EbYRfLgCsGGdVb+owAQ2Xh2VpMCelakgEBLXxBDBQ5CU8a+K992eUqDCWN6k70hDAsxXqjL+Li1J6yFjg8mAIaPLBUYgbttu47wItFZPpqlJ82cM01mELc2LyS1mChZHlo+h1q4GEbUevt0Q/VMpGNaa/WyeSQ="))
-
-		})
-	})
-
 	Describe("ChecksumBytes", func() {
 		It("Should produce the right checksum", func() {
 			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(prov.ChecksumBytes([]byte("too many secrets"))).To(Equal(sum))
-		})
-	})
-
-	Describe("ChecksumString", func() {
-		It("Should produce the right checksum", func() {
-			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(prov.ChecksumString("too many secrets")).To(Equal(sum))
 		})
 	})
 

--- a/providers/security/pkcs11sec/pkcs11_security.go
+++ b/providers/security/pkcs11sec/pkcs11_security.go
@@ -327,11 +327,6 @@ func (p *Pkcs11Security) ChecksumBytes(data []byte) []byte {
 	return p.fsec.ChecksumBytes(data)
 }
 
-// ChecksumString calculates a sha256 checksum for data
-func (p *Pkcs11Security) ChecksumString(data string) []byte {
-	return p.fsec.ChecksumBytes([]byte(data))
-}
-
 // SignBytes signs a message using a SHA256 PKCS1v15 protocol
 func (p *Pkcs11Security) SignBytes(str []byte) ([]byte, error) {
 	hashed := p.ChecksumBytes(str)
@@ -386,11 +381,6 @@ func (p *Pkcs11Security) VerifyByteSignature(dat []byte, sig []byte, pubcert []b
 	p.log.Debugf("Verified signature from %s", strings.Join(names, ", "))
 
 	return true, names[0]
-}
-
-// SignString signs a message using a SHA256 PKCS1v15 protocol
-func (p *Pkcs11Security) SignString(str string) ([]byte, error) {
-	return p.SignBytes([]byte(str))
 }
 
 // CallerName creates a choria like caller name in the form of choria=identity

--- a/providers/security/pkcs11sec/pkcs11_security_test.go
+++ b/providers/security/pkcs11sec/pkcs11_security_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Pkcs11Security", func() {
 
 	Describe("SignString", func() {
 		It("Should produce the right signature", func() {
-			sig, err := prov.SignString("too many secrets")
+			sig, err := prov.SignBytes([]byte("too many secrets"))
 			Expect(err).ToNot(HaveOccurred())
 
 			l.Infof("target str: %s", base64.StdEncoding.EncodeToString(sig))
@@ -175,15 +175,6 @@ var _ = Describe("Pkcs11Security", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(prov.ChecksumBytes([]byte("too many secrets"))).To(Equal(sum))
-		})
-	})
-
-	Describe("ChecksumString", func() {
-		It("Should produce the right checksum", func() {
-			sum, err := base64.StdEncoding.DecodeString("Yk+jdKdZ3v8E2p6dmbfn+ZN9lBBAHEIcOMp4lzuYKTo=")
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(prov.ChecksumString("too many secrets")).To(Equal(sum))
 		})
 	})
 

--- a/providers/security/puppetsec/puppet_security.go
+++ b/providers/security/puppetsec/puppet_security.go
@@ -294,11 +294,6 @@ func (s *PuppetSecurity) ChecksumBytes(data []byte) []byte {
 	return s.fsec.ChecksumBytes(data)
 }
 
-// ChecksumString calculates a sha256 checksum for data
-func (s *PuppetSecurity) ChecksumString(data string) []byte {
-	return s.fsec.ChecksumBytes([]byte(data))
-}
-
 // SignBytes signs a message using a SHA256 PKCS1v15 protocol
 func (s *PuppetSecurity) SignBytes(str []byte) ([]byte, error) {
 	return s.fsec.SignBytes(str)
@@ -307,11 +302,6 @@ func (s *PuppetSecurity) SignBytes(str []byte) ([]byte, error) {
 // VerifyByteSignature verify that dat matches signature sig made by the key, if pub cert is empty the active public key will be used
 func (s *PuppetSecurity) VerifyByteSignature(dat []byte, sig []byte, pubcert []byte) (should bool, signer string) {
 	return s.fsec.VerifyByteSignature(dat, sig, pubcert)
-}
-
-// SignString signs a message using a SHA256 PKCS1v15 protocol
-func (s *PuppetSecurity) SignString(str string) ([]byte, error) {
-	return s.fsec.SignString(str)
 }
 
 // CallerName creates a choria like caller name in the form of choria=identity


### PR DESCRIPTION
This removes some convenience functions from the security interface
that just seems like a bad idea now

A follow up PR will move the API in general to []byte

Signed-off-by: R.I.Pienaar <rip@devco.net>