### PR TITLE
(#1740) extract schema validation from v1 to protocol

### DIFF
--- a/inter/security_provider.go
+++ b/inter/security_provider.go
@@ -34,7 +34,7 @@ type SecurityProvider interface {
 	SignBytes(b []byte) (signature []byte, err error)
 
 	// VerifyByteSignature verifies that dat signature was made using pubcert
-	VerifyByteSignature(dat []byte, sig []byte, pubcert []byte) (should bool, signer string)
+	VerifyByteSignature(dat []byte, sig []byte, public []byte) (should bool, signer string)
 
 	// RemoteSignRequest signs a choria request using a remote signer and returns a secure request
 	RemoteSignRequest(ctx context.Context, str []byte) (signed []byte, err error)

--- a/protocol/schemas.go
+++ b/protocol/schemas.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package protocol
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/choria-io/go-choria/internal/fs"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+var (
+	// ErrSchemaUnknown indicates the schema could not be found
+	ErrSchemaUnknown = errors.New("unknown schema")
+	// ErrSchemaValidationFailed indicates that the validator failed to perform validation, perhaps due to invalid schema
+	ErrSchemaValidationFailed = errors.New("validation failed")
+)
+
+// SchemaBytes returns the JSON schema matching a specific protocol definition like `ReplyV1`
+func SchemaBytes(protocol string) ([]byte, error) {
+	switch protocol {
+	case ReplyV1:
+		return fs.FS.ReadFile("protocol/v1/reply.json")
+	case RequestV1:
+		return fs.FS.ReadFile("protocol/v1/request.json")
+	case SecureReplyV1:
+		return fs.FS.ReadFile("protocol/v1/secure_reply.json")
+	case SecureRequestV1:
+		return fs.FS.ReadFile("protocol/v1/secure_request.json")
+	case TransportV1:
+		return fs.FS.ReadFile("protocol/v1/transport.json")
+	default:
+		return nil, ErrSchemaUnknown
+	}
+}
+
+// SchemaValidate validates data against the JSON schema for protocol
+func SchemaValidate(protocol string, data []byte) (valid bool, errors []string, err error) {
+	schema, err := SchemaBytes(protocol)
+	if err != nil {
+		return false, nil, err
+	}
+
+	js := gojsonschema.NewBytesLoader(schema)
+	d := gojsonschema.NewBytesLoader(data)
+
+	validation, err := gojsonschema.Validate(js, d)
+	if err != nil {
+		return false, errors, fmt.Errorf("%w: %v", ErrSchemaValidationFailed, err)
+	}
+
+	if !validation.Valid() {
+		for _, desc := range validation.Errors() {
+			errors = append(errors, desc.String())
+		}
+
+		return false, errors, nil
+	}
+
+	return true, errors, nil
+}

--- a/protocol/v1/reply.go
+++ b/protocol/v1/reply.go
@@ -128,7 +128,7 @@ func (r *Reply) IsValidJSON(data []byte) (err error) {
 		return nil
 	}
 
-	_, errors, err := schemaValidate(replySchema, data)
+	_, errors, err := schemaValidate(protocol.ReplyV1, data)
 	if err != nil {
 		return fmt.Errorf("could not validate Reply JSON data: %s", err)
 	}

--- a/protocol/v1/request.go
+++ b/protocol/v1/request.go
@@ -299,7 +299,7 @@ func (r *Request) Version() string {
 
 // IsValidJSON validates the given JSON data against the schema
 func (r *Request) IsValidJSON(data []byte) error {
-	_, errors, err := schemaValidate(requestSchema, data)
+	_, errors, err := schemaValidate(protocol.RequestV1, data)
 	if err != nil {
 		return fmt.Errorf("could not validate Request JSON data: %s", err)
 	}

--- a/protocol/v1/security_reply.go
+++ b/protocol/v1/security_reply.go
@@ -98,7 +98,7 @@ func (r *SecureReply) IsValidJSON(data []byte) (err error) {
 		return nil
 	}
 
-	_, errors, err := schemaValidate(secureReplySchema, data)
+	_, errors, err := schemaValidate(protocol.SecureReplyV1, data)
 	if err != nil {
 		return fmt.Errorf("could not validate SecureReply JSON data: %s", err)
 	}

--- a/protocol/v1/security_request.go
+++ b/protocol/v1/security_request.go
@@ -144,7 +144,7 @@ func (r *SecureRequest) Version() string {
 
 // IsValidJSON validates the given JSON data against the schema
 func (r *SecureRequest) IsValidJSON(data []byte) (err error) {
-	_, errors, err := schemaValidate(secureRequestSchema, data)
+	_, errors, err := schemaValidate(protocol.SecureRequestV1, data)
 	if err != nil {
 		protocolErrorCtr.Inc()
 		return fmt.Errorf("could not validate SecureRequest JSON data: %s", err)

--- a/protocol/v1/transport.go
+++ b/protocol/v1/transport.go
@@ -248,7 +248,7 @@ func (m *TransportMessage) IsValidJSON(data []byte) error {
 		return nil
 	}
 
-	_, errors, err := schemaValidate(transportSchema, data)
+	_, errors, err := schemaValidate(protocol.TransportV1, data)
 	if err != nil {
 		return fmt.Errorf("could not validate Transport JSON data: %s", err)
 	}

--- a/protocol/v2/ADR.md
+++ b/protocol/v2/ADR.md
@@ -312,4 +312,4 @@ There are some other improvements to be made also in addition but those we'd nee
   * Move the API to `[]byte` based API [#1844](https://github.com/choria-io/go-choria/pull/1844)
   * Remove some string orientated security apis [](https://github.com/choria-io/go-choria/pull/1843)
   * Make the JWT authoritative for the secure channel name so we can stop using md5
-  * Develop a tool that can decode and dump/view network packets
+  * Develop a tool that can decode and dump/view network packets [#1484](https://github.com/choria-io/go-choria/pull/1848)


### PR DESCRIPTION
This will allow us to use the same schema validation between protocols and in the traffic dumper/inspector.

Also remove some redundant struct from v2 and improve the traffic dumper with v1 internals awareness

Signed-off-by: R.I.Pienaar <rip@devco.net>