### PR TITLE
(#1854) correct detection of empty filters

### DIFF
--- a/choria/connection.go
+++ b/choria/connection.go
@@ -439,7 +439,7 @@ func (conn *Connection) publishConnectedBroadcast(msg inter.Message, transport p
 
 	msg.NotifyPublish()
 
-	err = conn.PublishRaw(target, []byte(j))
+	err = conn.PublishRaw(target, j)
 	if err != nil {
 		return err
 	}
@@ -455,7 +455,7 @@ func (conn *Connection) publishConnectedDirect(msg inter.Message, transport prot
 		return err
 	}
 
-	rawmsg := []byte(j)
+	rawmsg := j
 
 	for _, host := range msg.DiscoveredHosts() {
 		target, err := conn.TargetForMessage(msg, host)

--- a/choria/protocol.go
+++ b/choria/protocol.go
@@ -124,7 +124,7 @@ func (fw *Framework) NewRequestFromMessage(version string, msg inter.Message) (r
 
 	req.SetMessage(msg.Payload())
 
-	if msg.Filter() == nil || msg.Filter().Empty() {
+	if msg.Filter() == nil {
 		req.NewFilter()
 	} else {
 		req.SetFilter(msg.Filter())

--- a/cmd/req.go
+++ b/cmd/req.go
@@ -76,7 +76,7 @@ that match the filter.
 
 `
 
-	r.cmd = cli.app.Command("req", "Invokes Choria RPC Actions").Alias("rpc")
+	r.cmd = cli.app.Command("req", "Invokes Choria RPC Actions").Alias("rpc").Alias("request")
 	r.cmd.HelpLong(help)
 	r.cmd.CheatFile(fs.FS, "req", "cheats/req.md")
 
@@ -299,7 +299,15 @@ func (r *reqCommand) Run(wg *sync.WaitGroup) (err error) {
 		opts = append(opts, rpc.Targets(nodes))
 	}
 
-	agent, err := rpc.New(c, r.agent, rpc.DDL(r.ddl))
+	rpcOpts := []rpc.Option{
+		rpc.DDL(r.ddl),
+	}
+
+	if publishOnly {
+		rpcOpts = append(rpcOpts, rpc.DiscoveryMethod(r.fo.DiscoveryMethod))
+	}
+
+	agent, err := rpc.New(c, r.agent, rpcOpts...)
 	if err != nil {
 		return fmt.Errorf("could not create client: %s", err)
 	}

--- a/protocol/filter.go
+++ b/protocol/filter.go
@@ -177,6 +177,8 @@ func (f *Filter) MatchCompound(facts json.RawMessage, knownClasses []string, kno
 
 // Empty determines if a filter is empty - that is all its contained filter arrays are empty
 func (f *Filter) Empty() bool {
+	// NOTE: Do not make empty return true when there is only 1 agent filter set, this breaks a bunch of things.
+
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -184,7 +186,7 @@ func (f *Filter) Empty() bool {
 		return true
 	}
 
-	if len(f.Fact) == 0 && len(f.Class) == 0 && (len(f.Agent) == 0 || len(f.Agent) == 1) && len(f.Identity) == 0 && len(f.Compound) == 0 {
+	if len(f.Fact) == 0 && len(f.Class) == 0 && len(f.Agent) == 0 && len(f.Identity) == 0 && len(f.Compound) == 0 {
 		return true
 	}
 

--- a/protocol/v1/constructors.go
+++ b/protocol/v1/constructors.go
@@ -88,17 +88,17 @@ func NewReplyFromSecureReply(sr protocol.SecureReply) (rep protocol.Reply, err e
 }
 
 // NewRequestFromSecureRequest creates a choria::request:1 based on the data contained in a SecureRequest
-func NewRequestFromSecureRequest(sr protocol.SecureRequest) (req protocol.Request, err error) {
+func NewRequestFromSecureRequest(sr protocol.SecureRequest) (protocol.Request, error) {
 	if sr.Version() != protocol.SecureRequestV1 {
 		return nil, fmt.Errorf("cannot create a version 1 SecureRequest from a %s SecureRequest", sr.Version())
 	}
 
-	req = &Request{
+	req := &Request{
 		Protocol: protocol.RequestV1,
 		Envelope: &RequestEnvelope{},
 	}
 
-	err = req.IsValidJSON(sr.Message())
+	err := req.IsValidJSON(sr.Message())
 	if err != nil {
 		return nil, fmt.Errorf("the JSON body from the SecureRequest is not a valid Request message: %s", err)
 	}

--- a/protocol/v1/request_test.go
+++ b/protocol/v1/request_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Request", func() {
 
 		filter.AddAgentFilter("rpcutil")
 		filter, filtered = request.Filter()
-		Expect(filtered).To(BeFalse())
+		Expect(filtered).To(BeTrue())
 		Expect(filter).ToNot(BeNil())
 
 		filter.AddAgentFilter("other")

--- a/protocol/v2/request_test.go
+++ b/protocol/v2/request_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Request", func() {
 
 		filter.AddAgentFilter("rpcutil")
 		filter, filtered = request.Filter()
-		Expect(filtered).To(BeFalse())
+		Expect(filtered).To(BeTrue())
 		Expect(filter).ToNot(BeNil())
 
 		filter.AddAgentFilter("other")


### PR DESCRIPTION
Filters were made to report empty when only 1 agent was set as for appbuilder that made sense.

This however was a bad idea and had the effect that a request with only agent filters set would be reported as empty to the server when filtering incoming requests meaning all would reply when they do not have the agent on them.

We fixed that and also setting the correct discovery method on the choria req client

Signed-off-by: R.I.Pienaar <rip@devco.net>