### PR TITLE
(#1840) Create fleet access permissions on client tokens

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,14 +4,8 @@ ENV['MCOLLECTIVE_CERTNAME'] = 'rip.mcollective'
 
 desc "Run just tests no measurements"
 task :test do
-  sh "ginkgo -r -skipMeasurements ."
-end
-
-desc "Run tests including measure tests"
-task :test_and_measure do
   sh "ginkgo -r ."
 end
-
 
 desc "Builds packages"
 task :build do

--- a/broker/network/choria_auth.go
+++ b/broker/network/choria_auth.go
@@ -555,6 +555,17 @@ func (a *ChoriaAuth) parseClientIDJWT(jwts string) (claims *tokens.ClientIDClaim
 	return claims, nil
 }
 
+func (a *ChoriaAuth) setClientFleetManagementPermissions(subs []string, pubs []string) ([]string, []string) {
+	pubs = append(pubs,
+		"*.broadcast.agent.>",
+		"*.broadcast.service.>",
+		"*.node.>",
+		"choria.federation.*.federation",
+	)
+
+	return subs, pubs
+}
+
 func (a *ChoriaAuth) setMinimalClientPermissions(_ *server.User, caller string, subs []string, pubs []string) ([]string, []string) {
 	replys := "*.reply.>"
 	if caller != emptyString {
@@ -563,12 +574,6 @@ func (a *ChoriaAuth) setMinimalClientPermissions(_ *server.User, caller string, 
 	}
 
 	subs = append(subs, replys)
-	pubs = append(pubs,
-		"*.broadcast.agent.>",
-		"*.broadcast.service.>",
-		"*.node.>",
-		"choria.federation.*.federation",
-	)
 
 	return subs, pubs
 }
@@ -692,6 +697,11 @@ func (a *ChoriaAuth) setClientTokenPermissions(user *server.User, caller string,
 	if perms.Governor && (perms.StreamsUser || perms.StreamsAdmin) {
 		log.Infof("Granting user Governor access")
 		subs, pubs = a.setClientGovernorPermissions(user, subs, pubs)
+	}
+
+	if perms.FleetManagement || perms.SignedFleetManagement {
+		log.Infof("Granding user fleet management access")
+		subs, pubs = a.setClientFleetManagementPermissions(subs, pubs)
 	}
 
 	return pubs, subs, nil

--- a/broker/network/choria_auth_test.go
+++ b/broker/network/choria_auth_test.go
@@ -715,14 +715,7 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 					Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
 						Allow: []string{"*.reply.e33bf0376d4accbb4a8fd24b2f840b2e.>"},
 					}))
-					Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
-						Allow: []string{
-							"*.broadcast.agent.>",
-							"*.broadcast.service.>",
-							"*.node.>",
-							"choria.federation.*.federation",
-						},
-					}))
+					Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
 				})
 
 				verified, err := auth.handleDefaultConnection(mockClient, verifiedConn, true, log)
@@ -1153,11 +1146,6 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 			log.Logger.SetOutput(GinkgoWriter)
 
 			minSub = []string{"*.reply.>"}
-			minPub = []string{
-				"*.broadcast.agent.>",
-				"*.broadcast.service.>",
-				"*.node.>",
-				"choria.federation.*.federation"}
 		})
 
 		Describe("System User", func() {
@@ -1179,9 +1167,7 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
 					Allow: minSub,
 				}))
-				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
-					Allow: minPub,
-				}))
+				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
 			})
 
 			It("Should set correct permissions for the choria user", func() {
@@ -1336,21 +1322,12 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 			})
 		})
 
-		Describe("Minimal Permissions", func() {
-			It("Should support caller private reply subjects", func() {
-				auth.setClientPermissions(user, "u=ginkgo", nil, log)
+		Describe("Fleet Management", func() {
+			It("Should set correct permissions for fleet management users", func() {
+				user.Account = auth.choriaAccount
+				auth.setClientPermissions(user, "", &tokens.ClientIDClaims{Permissions: &tokens.ClientPermissions{FleetManagement: true}}, log)
 				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
-					Allow: []string{"*.reply.0f47cbbd2accc01a51e57261d6e64b8b.>"},
-				}))
-				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
-					Allow: minPub,
-				}))
-			})
-
-			It("Should support standard reply subjects", func() {
-				auth.setClientPermissions(user, "", nil, log)
-				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
-					Allow: []string{"*.reply.>"},
+					Allow: minSub,
 				}))
 				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
 					Allow: []string{
@@ -1360,6 +1337,24 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 						"choria.federation.*.federation",
 					},
 				}))
+			})
+		})
+
+		Describe("Minimal Permissions", func() {
+			It("Should support caller private reply subjects", func() {
+				auth.setClientPermissions(user, "u=ginkgo", nil, log)
+				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
+					Allow: []string{"*.reply.0f47cbbd2accc01a51e57261d6e64b8b.>"},
+				}))
+				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
+			})
+
+			It("Should support standard reply subjects", func() {
+				auth.setClientPermissions(user, "", nil, log)
+				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
+					Allow: []string{"*.reply.>"},
+				}))
+				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
 			})
 		})
 	})

--- a/cmd/jwt_client.go
+++ b/cmd/jwt_client.go
@@ -15,23 +15,25 @@ import (
 )
 
 type jWTCreateClientCommand struct {
-	file          string
-	signingKey    string
-	identity      string
-	agents        []string
-	org           string
-	opaPolicyFile string
-	opaPolicy     string
-	validity      time.Duration
-	streamAdmin   bool
-	streamUser    bool
-	eventViewer   bool
-	electionUser  bool
-	orgAdmin      bool
-	service       bool
-	system        bool
-	authDelegate  bool
-	pk            string
+	file                  string
+	signingKey            string
+	identity              string
+	agents                []string
+	org                   string
+	opaPolicyFile         string
+	opaPolicy             string
+	validity              time.Duration
+	streamAdmin           bool
+	streamUser            bool
+	eventViewer           bool
+	electionUser          bool
+	orgAdmin              bool
+	service               bool
+	system                bool
+	authDelegate          bool
+	fleetManagement       bool
+	signedFleetManagement bool
+	pk                    string
 
 	command
 }
@@ -55,6 +57,8 @@ func (c *jWTCreateClientCommand) Setup() (err error) {
 		c.cmd.Flag("service", "Indicates that the user can have long validity tokens").UnNegatableBoolVar(&c.service)
 		c.cmd.Flag("system", "Allow the user to access the broker system account").UnNegatableBoolVar(&c.system)
 		c.cmd.Flag("auth-delegation", "Allow the user to sign requests for other users").UnNegatableBoolVar(&c.authDelegate)
+		c.cmd.Flag("fleet-management", "Allows access to the Choria fleet using RPC").Default("true").BoolVar(&c.fleetManagement)
+		c.cmd.Flag("signed-fleet-management", "Requires that all fleet management requests are signed by an authority like AAA Service").UnNegatableBoolVar(&c.signedFleetManagement)
 	}
 
 	return nil
@@ -105,6 +109,8 @@ func (c *jWTCreateClientCommand) createJWT() error {
 		ExtendedServiceLifetime: c.service,
 		SystemUser:              c.system,
 		AuthenticationDelegator: c.authDelegate,
+		FleetManagement:         c.fleetManagement,
+		SignedFleetManagement:   c.signedFleetManagement,
 	}
 
 	claims, err := tokens.NewClientIDClaims(c.identity, c.agents, c.org, nil, string(opa), "Choria CLI", c.validity, perms, []byte(c.pk))

--- a/cmd/jwt_view.go
+++ b/cmd/jwt_view.go
@@ -213,7 +213,14 @@ func (v *tJWTViewCommand) validateClientToken(token string) error {
 		fmt.Printf("         Expires At: %s (%s)\n", claims.ExpiresAt.Time, iu.RenderDuration(time.Until(claims.ExpiresAt.Time)))
 	}
 	if claims.Permissions != nil {
-		fmt.Println(" Broker Permissions:")
+		fmt.Println(" Client Permissions:")
+		if claims.Permissions.FleetManagement || claims.Permissions.SignedFleetManagement {
+			if claims.Permissions.SignedFleetManagement {
+				fmt.Println("      Can manage Choria fleet nodes subject to authorizing signature")
+			} else {
+				fmt.Println("      Can manage Choria fleet nodes")
+			}
+		}
 		if claims.Permissions.ElectionUser {
 			fmt.Println("      Can use Leader Elections")
 		}

--- a/tokens/client_id.go
+++ b/tokens/client_id.go
@@ -37,6 +37,12 @@ type ClientPermissions struct {
 	// OrgAdmin has access to all subjects
 	OrgAdmin bool `json:"org_admin,omitempty"`
 
+	// FleetManagement enables access to the choria server fleet for RPCs
+	FleetManagement bool `json:"fleet_management,omitempty"`
+
+	// SignedFleetManagement requires a user to have a valid signature by an AuthenticationDelegator to interact with the fleet
+	SignedFleetManagement bool `json:"signed_fleet_management,omitempty"`
+
 	// ExtendedServiceLifetime allows a token to have a longer than common lifetime, suitable for services users
 	ExtendedServiceLifetime bool `json:"service,omitempty"`
 


### PR DESCRIPTION
This changes JWT based auth to default deny fleet access and adds 2 booleans, one to permit fleet access in general and one to require a signature to access the fleet, for now only the first has meaning until protocol 2 work is complete

Signed-off-by: R.I.Pienaar <rip@devco.net>