### PR TITLE
(#1740) Export the caller JWT to protocol.Request

### DIFF
--- a/client/client/client.go
+++ b/client/client/client.go
@@ -78,12 +78,7 @@ func New(fw inter.Framework, opts ...Option) (*Client, error) {
 	}
 
 	if c.name == "" {
-		rid, err := c.fw.NewRequestID()
-		if err != nil {
-			return nil, fmt.Errorf("could not generate unique name: %s", err)
-		}
-
-		c.name = fmt.Sprintf("%s-%s", c.fw.Certname(), rid)
+		c.name = c.fw.CallerID()
 	}
 
 	c.receiverReady = make(chan struct{}, c.receivers)

--- a/message/protocol_mock_test.go
+++ b/message/protocol_mock_test.go
@@ -219,6 +219,20 @@ func (mr *MockRequestMockRecorder) CallerID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerID", reflect.TypeOf((*MockRequest)(nil).CallerID))
 }
 
+// CallerPublicData mocks base method.
+func (m *MockRequest) CallerPublicData() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CallerPublicData")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CallerPublicData indicates an expected call of CallerPublicData.
+func (mr *MockRequestMockRecorder) CallerPublicData() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerPublicData", reflect.TypeOf((*MockRequest)(nil).CallerPublicData))
+}
+
 // Collective mocks base method.
 func (m *MockRequest) Collective() string {
 	m.ctrl.T.Helper()
@@ -896,6 +910,20 @@ func (m *MockSecureRequest) EXPECT() *MockSecureRequestMockRecorder {
 	return m.recorder
 }
 
+// CallerPublicData mocks base method.
+func (m *MockSecureRequest) CallerPublicData() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CallerPublicData")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CallerPublicData indicates an expected call of CallerPublicData.
+func (mr *MockSecureRequestMockRecorder) CallerPublicData() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerPublicData", reflect.TypeOf((*MockSecureRequest)(nil).CallerPublicData))
+}
+
 // IsValidJSON mocks base method.
 func (m *MockSecureRequest) IsValidJSON(data []byte) error {
 	m.ctrl.T.Helper()
@@ -951,6 +979,20 @@ func (m *MockSecureRequest) SetMessage(request protocol.Request) error {
 func (mr *MockSecureRequestMockRecorder) SetMessage(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMessage", reflect.TypeOf((*MockSecureRequest)(nil).SetMessage), request)
+}
+
+// SetSigner mocks base method.
+func (m *MockSecureRequest) SetSigner(signer []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetSigner", signer)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetSigner indicates an expected call of SetSigner.
+func (mr *MockSecureRequestMockRecorder) SetSigner(signer interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSigner", reflect.TypeOf((*MockSecureRequest)(nil).SetSigner), signer)
 }
 
 // Valid mocks base method.

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -140,6 +140,7 @@ type Request interface {
 	RequestID() string
 	SenderID() string
 	CallerID() string
+	CallerPublicData() string
 	Collective() string
 	Agent() string
 	TTL() int
@@ -181,6 +182,7 @@ type SecureRequest interface {
 	Version() ProtocolVersion
 	IsValidJSON(data []byte) error
 	Message() []byte
+	CallerPublicData() string
 }
 
 // SecureReply is a container for a Reply.  It's the reply counterpart of a

--- a/protocol/protocol_mock_test.go
+++ b/protocol/protocol_mock_test.go
@@ -218,6 +218,20 @@ func (mr *MockRequestMockRecorder) CallerID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerID", reflect.TypeOf((*MockRequest)(nil).CallerID))
 }
 
+// CallerPublicData mocks base method.
+func (m *MockRequest) CallerPublicData() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CallerPublicData")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CallerPublicData indicates an expected call of CallerPublicData.
+func (mr *MockRequestMockRecorder) CallerPublicData() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerPublicData", reflect.TypeOf((*MockRequest)(nil).CallerPublicData))
+}
+
 // Collective mocks base method.
 func (m *MockRequest) Collective() string {
 	m.ctrl.T.Helper()
@@ -893,6 +907,20 @@ func NewMockSecureRequest(ctrl *gomock.Controller) *MockSecureRequest {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSecureRequest) EXPECT() *MockSecureRequestMockRecorder {
 	return m.recorder
+}
+
+// CallerPublicData mocks base method.
+func (m *MockSecureRequest) CallerPublicData() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CallerPublicData")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// CallerPublicData indicates an expected call of CallerPublicData.
+func (mr *MockSecureRequestMockRecorder) CallerPublicData() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CallerPublicData", reflect.TypeOf((*MockSecureRequest)(nil).CallerPublicData))
 }
 
 // IsValidJSON mocks base method.

--- a/protocol/v1/request.go
+++ b/protocol/v1/request.go
@@ -310,3 +310,8 @@ func (r *Request) IsValidJSON(data []byte) error {
 
 	return nil
 }
+
+// CallerPublicData is not supported for version 1 messages and is always an empty string
+func (r *Request) CallerPublicData() string {
+	return ""
+}

--- a/protocol/v1/security_request.go
+++ b/protocol/v1/security_request.go
@@ -157,6 +157,13 @@ func (r *SecureRequest) IsValidJSON(data []byte) (err error) {
 	return nil
 }
 
-func (r *SecureRequest) SetSigner(signer []byte) error {
+func (r *SecureRequest) SetSigner(_ []byte) error {
 	return nil
+}
+
+func (r *SecureRequest) CallerPublicData() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.PublicCertificate
 }

--- a/protocol/v2/request.go
+++ b/protocol/v2/request.go
@@ -20,7 +20,8 @@ type Request struct {
 
 	ReqEnvelope
 
-	mu sync.Mutex
+	callerJWT string
+	mu        sync.Mutex
 }
 
 type ReqEnvelope struct {
@@ -64,7 +65,8 @@ func NewRequestFromSecureRequest(sr protocol.SecureRequest) (protocol.Request, e
 	}
 
 	req := &Request{
-		Protocol: protocol.RequestV2,
+		Protocol:  protocol.RequestV2,
+		callerJWT: sr.(*SecureRequest).CallerJWT,
 	}
 
 	err := req.IsValidJSON(sr.Message())
@@ -374,4 +376,12 @@ func (r *Request) isValidJSONUnlocked(data []byte) error {
 	}
 
 	return nil
+}
+
+// CallerPublicData is the JWT validated by the Secure Request, only set when a request is created from a SecureRequest
+func (r *Request) CallerPublicData() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.callerJWT
 }

--- a/protocol/v2/request_test.go
+++ b/protocol/v2/request_test.go
@@ -59,9 +59,10 @@ var _ = Describe("Request", func() {
 			j, err := req.JSON()
 			Expect(err).ToNot(HaveOccurred())
 
-			r, err := NewRequestFromSecureRequest(&SecureRequest{Protocol: protocol.SecureRequestV2, MessageBody: j})
+			r, err := NewRequestFromSecureRequest(&SecureRequest{Protocol: protocol.SecureRequestV2, MessageBody: j, CallerJWT: "caller.jwt"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r.RequestID()).To(Equal("a2f0ca717c694f2086cfa81b6c494648"))
+			Expect(r.CallerPublicData()).To(Equal("caller.jwt"))
 		})
 	})
 

--- a/protocol/v2/secure_request.go
+++ b/protocol/v2/secure_request.go
@@ -272,3 +272,10 @@ func (r *SecureRequest) SetSigner(signer []byte) error {
 
 	return nil
 }
+
+func (r *SecureRequest) CallerPublicData() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.CallerJWT
+}

--- a/providers/agent/mcorpc/client/options.go
+++ b/providers/agent/mcorpc/client/options.go
@@ -64,11 +64,6 @@ type RequestOption func(*RequestOptions)
 
 // NewRequestOptions creates a initialized request options
 func NewRequestOptions(fw inter.Framework, ddl *agent.DDL) (*RequestOptions, error) {
-	rid, err := fw.NewRequestID()
-	if err != nil {
-		return nil, err
-	}
-
 	cfg := fw.Configuration()
 
 	return &RequestOptions{
@@ -78,7 +73,7 @@ func NewRequestOptions(fw inter.Framework, ddl *agent.DDL) (*RequestOptions, err
 		Collective:      cfg.MainCollective,
 		ProcessReplies:  true,
 		Workers:         3,
-		ConnectionName:  fmt.Sprintf("%s-mcorpc-%s", fw.Certname(), rid),
+		ConnectionName:  fw.CallerID(),
 		stats:           NewStats(),
 		totalStats:      NewStats(),
 		LimitMethod:     cfg.RPCLimitMethod,


### PR DESCRIPTION
For protocol 2 requests this will include the validated JWT so that Opa policies and more can be processed by agent providers

Signed-off-by: R.I.Pienaar <rip@devco.net>