### PR TITLE
(#1900) adds a basic chain of trust in tokens

### DIFF
--- a/broker/network/choria_auth.go
+++ b/broker/network/choria_auth.go
@@ -553,11 +553,13 @@ func (a *ChoriaAuth) parseServerJWT(jwts string) (claims *tokens.ServerClaims, e
 		} else {
 			claims, err = tokens.ParseServerTokenWithKeyfile(jwts, s)
 		}
+
 		switch {
 		case len(a.serverJwtSigners) == 1 && err != nil:
 			// just a bit friendlier than saying a generic error with 1 failure
 			return nil, err
 		case errors.Is(err, jwt.ErrTokenExpired), errors.Is(err, tokens.ErrNotAServerToken):
+			// These are fatal errors that no further trying will resolve
 			return nil, err
 		case err != nil:
 			continue

--- a/cmd/jwt_provisioner.go
+++ b/cmd/jwt_provisioner.go
@@ -27,6 +27,7 @@ type jWTCreateProvCommand struct {
 	provDefault bool
 	extensions  string
 	urls        []string
+	org         string
 
 	command
 }
@@ -46,6 +47,7 @@ func (p *jWTCreateProvCommand) Setup() (err error) {
 		p.cmd.Flag("username", "Username to connect to the provisioning broker with").StringVar(&p.uname)
 		p.cmd.Flag("password", "Password to connect to the provisioning broker with").StringVar(&p.password)
 		p.cmd.Flag("extensions", "Adds additional extensions to the token, accepts JSON data").PlaceHolder("JSON").StringVar(&p.extensions)
+		p.cmd.Flag("org", "Adds the node to a specific organization for trust validation").Default("choria").StringVar(&p.org)
 	}
 
 	return nil
@@ -82,7 +84,7 @@ func (p *jWTCreateProvCommand) createJWT() error {
 	if p.srvDomain == "" && len(p.urls) == 0 {
 		return fmt.Errorf("URLs or a SRV Domain is required")
 	}
-	claims, err := tokens.NewProvisioningClaims(!p.insecure, p.provDefault, p.token, p.uname, p.password, p.urls, p.srvDomain, p.regData, p.facts, "Choria CLI", 0)
+	claims, err := tokens.NewProvisioningClaims(!p.insecure, p.provDefault, p.token, p.uname, p.password, p.urls, p.srvDomain, p.regData, p.facts, p.org, "", 0)
 	if err != nil {
 		return err
 	}

--- a/cmd/jwt_server.go
+++ b/cmd/jwt_server.go
@@ -94,7 +94,7 @@ func (s *jWTCreateServerCommand) createJWT() error {
 		return err
 	}
 
-	claims, err := tokens.NewServerClaims(s.identity, s.collectives, s.org, perms, s.subjects, pk, "Choria CLI", s.validity)
+	claims, err := tokens.NewServerClaims(s.identity, s.collectives, s.org, perms, s.subjects, pk, "", s.validity)
 	if err != nil {
 		return err
 	}

--- a/providers/security/choria/choria_security_test.go
+++ b/providers/security/choria/choria_security_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Providers/Security/Choria", func() {
 			Expect(tokens.SaveAndSignTokenWithKeyFile(serverToken, signerSeedFile, serverJWTFile, 0600)).To(Succeed())
 
 			// a provisioner purpose token
-			provToken, err := tokens.NewProvisioningClaims(true, true, "x", "x", "x", nil, "example.net", "", "", "ginkgo", time.Minute)
+			provToken, err := tokens.NewProvisioningClaims(true, true, "x", "x", "x", nil, "example.net", "", "", "ginkgo", "", time.Minute)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(provToken.Purpose).To(Equal(tokens.ProvisioningPurpose))
 			Expect(tokens.SaveAndSignTokenWithKeyFile(provToken, signerSeedFile, provJWTFile, 0600)).To(Succeed())

--- a/tokens/client_id_test.go
+++ b/tokens/client_id_test.go
@@ -56,7 +56,7 @@ var _ = Describe("ClientIDClaims", func() {
 		It("Should set an issuer when none is given", func() {
 			claims, err := NewClientIDClaims("up=ginkgo", []string{"rpcutil"}, "choria", map[string]string{"group": "admins"}, "// opa policy", "", time.Hour, perms, pubK)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(claims.Issuer).To(Equal("Choria"))
+			Expect(claims.Issuer).To(Equal(defaultIssuer))
 		})
 
 		It("Should ensure a callerid is set", func() {

--- a/tokens/provisioning_test.go
+++ b/tokens/provisioning_test.go
@@ -32,13 +32,13 @@ var _ = Describe("ProvisioningClaims", func() {
 		clientToken, err = SignToken(claims, loadRSAPriKey("testdata/rsa/signer-key.pem"))
 		Expect(err).ToNot(HaveOccurred())
 
-		pclaims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "Ginkgo", time.Hour)
+		pclaims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "", "Ginkgo", time.Hour)
 		Expect(err).ToNot(HaveOccurred())
 		pclaims.Extensions = MapClaims{"hello": "world"}
 		validToken, err = SignToken(pclaims, loadRSAPriKey("testdata/rsa/signer-key.pem"))
 		Expect(err).ToNot(HaveOccurred())
 
-		pclaims, err = NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "Ginkgo", time.Hour)
+		pclaims, err = NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "", "Ginkgo", time.Hour)
 		Expect(err).ToNot(HaveOccurred())
 		pclaims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
 		expiredToken, err = SignToken(pclaims, loadRSAPriKey("testdata/rsa/signer-key.pem"))
@@ -47,19 +47,19 @@ var _ = Describe("ProvisioningClaims", func() {
 
 	Describe("NewProvisioningClaims", func() {
 		It("Should set an issuer if not set", func() {
-			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "", time.Hour)
+			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "", "", time.Hour)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(claims.Issuer).To(Equal("Choria"))
+			Expect(claims.Issuer).To(Equal(defaultIssuer))
 		})
 
 		It("Should require url or srv domain", func() {
-			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", nil, "", "/reg.data", "/facts.json", "", time.Hour)
+			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", nil, "", "/reg.data", "/facts.json", "", "", time.Hour)
 			Expect(err).To(MatchError("srv domain or urls required"))
 			Expect(claims).To(BeNil())
 		})
 
 		It("Should create correct claims", func() {
-			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "Ginkgo", time.Hour)
+			claims, err := NewProvisioningClaims(true, true, "x", "usr", "toomanysecrets", []string{"nats://example.net:4222"}, "example.net", "/reg.data", "/facts.json", "", "Ginkgo", time.Hour)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(claims.Issuer).To(Equal("Ginkgo"))
 			Expect(claims.Purpose).To(Equal(ProvisioningPurpose))

--- a/tokens/standard.go
+++ b/tokens/standard.go
@@ -5,11 +5,253 @@
 package tokens
 
 import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	iu "github.com/choria-io/go-choria/internal/util"
 	"github.com/golang-jwt/jwt/v4"
 )
 
 type StandardClaims struct {
+	// Purpose indicates the type of JWT for type discovery
 	Purpose Purpose `json:"purpose"`
 
+	// TrustChainSignature is a structure that helps to verify a chain of trust to a org issuer
+	TrustChainSignature string `json:"tcs,omitempty"`
+
+	// PublicKey is a ED25519 public key associated with this token
+	PublicKey string `json:"public_key,omitempty"`
+
+	// IssuerExpiresAt is the expiry time of the issuer, if set will be checked in addition to the expiry time of the token itself
+	IssuerExpiresAt *jwt.NumericDate `json:"issexp,omitempty"`
+
 	jwt.RegisteredClaims
+}
+
+func (c *StandardClaims) verifyIssuerExpiry(req bool) bool {
+	// org issuer tokens has a tcs but the org issuer has no expiry time so we can skip
+	if !strings.HasPrefix(c.Issuer, ChainIssuerPrefix) {
+		return !req
+	}
+
+	// without a tcs this isnt a chained token so there's no point in validating
+	if c.TrustChainSignature == "" {
+		return !req
+	}
+
+	if c.IssuerExpiresAt == nil {
+		return !req
+	}
+
+	return c.IssuerExpiresAt.After(time.Now())
+}
+
+// IsChainedIssuer determines if this is a token capable of issuing users as part of a chain
+// without verify being true one can not be 100% certain it's valid to do that but its a strong hint
+func (c *StandardClaims) IsChainedIssuer(verify bool) bool {
+	if len(c.TrustChainSignature) == 0 {
+		return false
+	}
+
+	if !strings.HasPrefix(c.Issuer, OrgIssuerPrefix) {
+		return false
+	}
+
+	if !verify {
+		return true
+	}
+
+	dat, err := c.OrgIssuerChainData()
+	if err != nil {
+		return false
+	}
+
+	pubK, err := hex.DecodeString(strings.TrimPrefix(c.Issuer, OrgIssuerPrefix))
+	if err != nil {
+		return false
+	}
+
+	sig, err := hex.DecodeString(c.TrustChainSignature)
+	if err != nil {
+		return false
+	}
+
+	ok, _ := iu.Ed24419Verify(pubK, dat, sig)
+
+	return ok
+}
+
+// OrgIssuerChainData creates data that the org issuer would sign and embed in the token as TrustChainSignature
+func (c *StandardClaims) OrgIssuerChainData() ([]byte, error) {
+	if c.ID == "" {
+		return nil, fmt.Errorf("no token id set")
+	}
+	if c.PublicKey == "" {
+		return nil, fmt.Errorf("no public key set")
+	}
+
+	return []byte(fmt.Sprintf("%s.%s", c.ID, c.PublicKey)), nil
+}
+
+// SetOrgIssuer sets the issuer field for users issued by the Org Issuer
+func (c *StandardClaims) SetOrgIssuer(pk ed25519.PublicKey) {
+	c.Issuer = fmt.Sprintf("%s%s", OrgIssuerPrefix, hex.EncodeToString(pk))
+}
+
+// SetChainIssuer used by Login Handlers that create users in a chain to set an appropriate issuer on created users
+func (c *StandardClaims) SetChainIssuer(ci *ClientIDClaims) error {
+	if ci.ID == "" {
+		return fmt.Errorf("id not set")
+	}
+	if ci.PublicKey == "" {
+		return fmt.Errorf("public key not set")
+	}
+
+	c.Issuer = fmt.Sprintf("%s%s.%s", ChainIssuerPrefix, ci.ID, ci.PublicKey)
+	c.IssuerExpiresAt = ci.ExpiresAt
+
+	return nil
+}
+
+// ChainIssuerData is the data that should be signed on a user to create a chain of trust between Org Issuer, Client Login Handler and Client.
+//
+// The Issuer should already be set using SetChainIssuer()
+func (c *StandardClaims) ChainIssuerData(chainSig string) ([]byte, error) {
+	if c.ID == "" {
+		return nil, fmt.Errorf("id not set")
+	}
+	if c.Issuer == "" {
+		return nil, fmt.Errorf("issuer not set")
+	}
+	if !strings.HasPrefix(c.Issuer, ChainIssuerPrefix) {
+		return nil, fmt.Errorf("invalid issuer prefix")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(c.Issuer, ChainIssuerPrefix), ".")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid issuer data")
+	}
+
+	return []byte(fmt.Sprintf("%s.%s", c.ID, chainSig)), nil
+}
+
+// SetChainUserTrustSignature sets the TrustChainSignature for a user issued by a ChainIssuer like AAA Login Server
+func (c *StandardClaims) SetChainUserTrustSignature(h *ClientIDClaims, sig []byte) {
+	c.TrustChainSignature = fmt.Sprintf("%s.%s", h.TrustChainSignature, hex.EncodeToString(sig))
+}
+
+// SetChainIssuerTrustSignature sets the TrustChainSignature for a user who may issue others like a AAA Login Server
+func (c *StandardClaims) SetChainIssuerTrustSignature(sig []byte) {
+	c.TrustChainSignature = hex.EncodeToString(sig)
+}
+
+// IsSignedByIssuer uses the chain data in Issuer and TrustChainSignature to determine if an issuer signed a token
+func (c *StandardClaims) IsSignedByIssuer(pk ed25519.PublicKey) (bool, error) {
+	if c.Issuer == "" {
+		return false, fmt.Errorf("no issuer set")
+	}
+	if c.PublicKey == "" {
+		return false, fmt.Errorf("no public key set")
+	}
+	if c.TrustChainSignature == "" {
+		return false, fmt.Errorf("no trust chain signature set")
+	}
+	if c.ID == "" {
+		return false, fmt.Errorf("id not set")
+	}
+
+	switch {
+	case strings.HasPrefix(c.Issuer, OrgIssuerPrefix):
+		// This would be a token that is allowed to create clients in a chain.
+		//
+		// Its Issuer is set to I-issuerPubk
+		// Its chain sig is signed by the issuer "<id>.<pubk>" of this token, obtained from OrgIssuerChainData()
+		//
+		// So we simply check if the signature in the TrustChainSignature match the data if signed by the
+		// supplied issuer public key
+
+		if c.Issuer != fmt.Sprintf("%s%s", OrgIssuerPrefix, hex.EncodeToString(pk)) {
+			return false, fmt.Errorf("public keys do not match")
+		}
+
+		sig, err := hex.DecodeString(c.TrustChainSignature)
+		if err != nil {
+			return false, fmt.Errorf("invalid trust chain signature: %w", err)
+		}
+
+		dat, err := c.OrgIssuerChainData()
+		if err != nil {
+			return false, err
+		}
+
+		return iu.Ed24419Verify(pk, dat, sig)
+
+	case strings.HasPrefix(c.Issuer, ChainIssuerPrefix):
+		// This is a token that was created by one in the chain - not the org issuer.
+		//
+		// Its Issuer is set to C-<creator id>.<creator pubk>
+		// Its chain sig is set to <creator tcs>.hex(sign(creatorId,<creator tcs>))
+		//
+		// We know what the content of tcs unsigned is from the Issuer field
+		// and we are given the issuer public key, so we can confirm the issuer
+		// we are interested in signed the tcs.
+		//
+		// We know the holder of the creator private key made it because we have
+		// it's public key and can confirm that, we know its the public key of
+		// the creator since its in the tcs set there by our trusted issuer.
+		//
+		// We can confirm the tcs is valid and matches whats in the sig made by
+		// the creator because we verify it using the requested issuer pubk
+
+		// get details of the login handler or provisioner
+		issuerChainData := strings.TrimPrefix(c.Issuer, ChainIssuerPrefix)
+
+		parts := strings.Split(issuerChainData, ".")
+		if len(parts) != 2 {
+			return false, fmt.Errorf("invalid issuer content")
+		}
+
+		if len(parts[0]) == 0 {
+			return false, fmt.Errorf("invalid id in issuer")
+		}
+		if len(parts[1]) == 0 {
+			return false, fmt.Errorf("invalid public key in issuer")
+		}
+
+		hPubk, err := hex.DecodeString(parts[1])
+		if err != nil {
+			return false, fmt.Errorf("invalid public key in issuer data")
+		}
+
+		// now we check the signature is data + "." + sig(id+ "." + data)
+		parts = strings.Split(c.TrustChainSignature, ".")
+		if len(parts) != 2 {
+			return false, fmt.Errorf("invalid trust chain signature")
+		}
+		if len(parts[0]) == 0 || len(parts[1]) == 0 {
+			return false, fmt.Errorf("invalid trust chain signature")
+		}
+
+		sig, err := hex.DecodeString(parts[1])
+		if err != nil {
+			return false, fmt.Errorf("invalid signature in chain signature: %w", err)
+		}
+
+		// this is the signature from the handler
+		ok, err := iu.Ed24419Verify(hPubk, []byte(fmt.Sprintf("%s.%s", c.ID, parts[0])), sig)
+		if err != nil {
+			return false, fmt.Errorf("chain signature validation failed: %w", err)
+		}
+		if !ok {
+			return false, fmt.Errorf("invalid chain signature")
+		}
+
+		return true, nil
+
+	default:
+		return false, fmt.Errorf("unsupported issuer format")
+	}
 }

--- a/tokens/standard_test.go
+++ b/tokens/standard_test.go
@@ -1,0 +1,362 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tokens
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	iu "github.com/choria-io/go-choria/internal/util"
+	"github.com/golang-jwt/jwt/v4"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StandardClaims", func() {
+	var (
+		c    StandardClaims
+		priK ed25519.PrivateKey
+		pubK ed25519.PublicKey
+		err  error
+	)
+
+	BeforeEach(func() {
+		c = StandardClaims{}
+		pubK, priK, err = iu.Ed25519KeyPair()
+		Expect(err).ToNot(HaveOccurred())
+
+	})
+
+	Describe("Chain Issuer", func() {
+		BeforeEach(func() {
+			c = StandardClaims{}
+			c.ID = iu.UniqueID()
+		})
+
+		Describe("verifyIssuerExpiry", func() {
+			BeforeEach(func() {
+				c = StandardClaims{}
+				c.Issuer = "C-x.x"
+				c.TrustChainSignature = "stub.sig"
+				c.IssuerExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Minute))
+			})
+
+			It("Should only verify on tokens issues by a chain issues", func() {
+				c.Issuer = "I-x.x"
+				Expect(c.verifyIssuerExpiry(false)).To(BeTrue())
+				Expect(c.verifyIssuerExpiry(true)).To(BeFalse())
+			})
+
+			It("Should detect missing tcs", func() {
+				c.TrustChainSignature = ""
+				Expect(c.verifyIssuerExpiry(true)).To(BeFalse())
+				Expect(c.verifyIssuerExpiry(false)).To(BeTrue())
+			})
+
+			It("Should detect missing issuer expiry", func() {
+				c.IssuerExpiresAt = nil
+				Expect(c.verifyIssuerExpiry(true)).To(BeFalse())
+				Expect(c.verifyIssuerExpiry(false)).To(BeTrue())
+			})
+
+			It("Should correctly detect expiry", func() {
+				Expect(c.verifyIssuerExpiry(true)).To(BeTrue())
+				Expect(c.verifyIssuerExpiry(false)).To(BeTrue())
+
+				c.IssuerExpiresAt = jwt.NewNumericDate(time.Now().Add(-1 * time.Minute))
+				Expect(c.verifyIssuerExpiry(true)).To(BeFalse())
+				Expect(c.verifyIssuerExpiry(false)).To(BeFalse())
+			})
+		})
+
+		Describe("SetChainIssuer", func() {
+			It("Should require basic data", func() {
+				ci := &ClientIDClaims{}
+				Expect(c.SetChainIssuer(ci)).To(MatchError("id not set"))
+
+				ci.ID = "x"
+				Expect(c.SetChainIssuer(ci)).To(MatchError("public key not set"))
+			})
+
+			It("Should set the correct issuer", func() {
+				ci := &ClientIDClaims{}
+				ci.ID = iu.UniqueID()
+				ci.PublicKey = hex.EncodeToString(pubK[:])
+				Expect(c.SetChainIssuer(ci)).To(Succeed())
+				Expect(c.Issuer).To(Equal(fmt.Sprintf("C-%s.%s", ci.ID, ci.PublicKey)))
+			})
+		})
+
+		Describe("ChainIssuerData", func() {
+			It("Should require minimal data", func() {
+				c.ID = ""
+				_, err = c.ChainIssuerData("x")
+				Expect(err).To(MatchError("id not set"))
+
+				c.ID = iu.UniqueID()
+				_, err = c.ChainIssuerData("x")
+				Expect(err).To(MatchError("issuer not set"))
+
+				c.Issuer = "X-Issuer"
+				_, err = c.ChainIssuerData("x")
+				Expect(err).To(MatchError("invalid issuer prefix"))
+
+				c.Issuer = "C-x"
+				_, err = c.ChainIssuerData("x")
+				Expect(err).To(MatchError("invalid issuer data"))
+			})
+
+			It("Should issue the correct data", func() {
+				ci := &ClientIDClaims{}
+				ci.ID = iu.UniqueID()
+				ci.PublicKey = hex.EncodeToString(pubK[:])
+				Expect(c.SetChainIssuer(ci)).To(Succeed())
+
+				dat, err := c.ChainIssuerData("x")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dat).To(Equal([]byte(fmt.Sprintf("%s.x", c.ID))))
+			})
+		})
+
+		Describe("IsSignedByIssuer", func() {
+			It("Should detect badly formed issuers", func() {
+				c.Issuer = "C-x"
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.TrustChainSignature = "x"
+				c.ID = "ID"
+
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid issuer content"))
+				Expect(ok).To(BeFalse())
+
+				c.Issuer = "C-.x"
+				ok, err = c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid id in issuer"))
+				Expect(ok).To(BeFalse())
+
+				c.Issuer = "C-y."
+				ok, err = c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid public key in issuer"))
+				Expect(ok).To(BeFalse())
+
+				c.Issuer = "C-!.y"
+				ok, err = c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid public key in issuer data"))
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect badly formed trust chain sigs", func() {
+				c.Issuer = "C-x." + hex.EncodeToString(pubK)
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.ID = iu.UniqueID()
+				c.TrustChainSignature = "X"
+
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid trust chain signature"))
+				Expect(ok).To(BeFalse())
+
+				c.TrustChainSignature = "."
+				ok, err = c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid trust chain signature"))
+				Expect(ok).To(BeFalse())
+
+				c.TrustChainSignature = "foo.!!"
+				ok, err = c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid signature in chain signature: encoding/hex: invalid byte: U+0021 '!'"))
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect incorrect signatures", func() {
+				// the org issuer
+				issuePubK, issuerPriK, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				handlerPubK, _, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				userPubK, _, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				// the handler signed by the org issuer
+				handler, err := NewClientIDClaims("choria=handler", nil, "", nil, "", "", time.Minute, nil, handlerPubK)
+				Expect(err).ToNot(HaveOccurred())
+				handler.SetOrgIssuer(issuePubK)
+				hdat, err := handler.OrgIssuerChainData()
+				Expect(err).ToNot(HaveOccurred())
+				hsig, err := iu.Ed25519Sign(issuerPriK, hdat)
+				Expect(err).ToNot(HaveOccurred())
+				handler.TrustChainSignature = "invalid"
+
+				// it looks good so it passes but with verify fails
+				Expect(handler.IsChainedIssuer(false)).To(BeTrue())
+				Expect(handler.IsChainedIssuer(true)).To(BeFalse())
+
+				handler.TrustChainSignature = hex.EncodeToString(hsig)
+
+				// now it looks good and it is good
+				Expect(handler.IsChainedIssuer(false)).To(BeTrue())
+				Expect(handler.IsChainedIssuer(true)).To(BeTrue())
+
+				// a user issued by the handler
+				user, err := NewClientIDClaims("choria=user", nil, "", nil, "", "", time.Minute, nil, userPubK)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.SetChainIssuer(handler)).To(Succeed())
+				user.SetChainUserTrustSignature(handler, []byte("invalid sig"))
+				ok, err := user.IsSignedByIssuer(issuePubK)
+				Expect(err).To(MatchError("invalid chain signature"))
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect correct signatures", func() {
+				// the org issuer
+				issuePubK, issuerPriK, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				handlerPubK, handlerPrik, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				userPubK, _, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				// the handler signed by the org issuer
+				handler, err := NewClientIDClaims("choria=handler", nil, "", nil, "", "", time.Minute, nil, handlerPubK)
+				Expect(err).ToNot(HaveOccurred())
+				handler.SetOrgIssuer(issuePubK)
+				hdat, err := handler.OrgIssuerChainData()
+				Expect(err).ToNot(HaveOccurred())
+				hsig, err := iu.Ed25519Sign(issuerPriK, hdat)
+				Expect(err).ToNot(HaveOccurred())
+				handler.TrustChainSignature = hex.EncodeToString(hsig)
+
+				// a user issued by the handler
+				user, err := NewClientIDClaims("choria=user", nil, "", nil, "", "", time.Minute, nil, userPubK)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(user.SetChainIssuer(handler)).To(Succeed())
+				udat, err := user.ChainIssuerData(handler.TrustChainSignature)
+				Expect(err).ToNot(HaveOccurred())
+				usig, err := iu.Ed25519Sign(handlerPrik, udat)
+				Expect(err).ToNot(HaveOccurred())
+				user.SetChainUserTrustSignature(handler, usig)
+				ok, err := user.IsSignedByIssuer(issuePubK)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Organization Issuer", func() {
+		Describe("IsSignedByIssuer", func() {
+			It("Should expect minimally correct data", func() {
+				check := func(pk ed25519.PublicKey, expect error) {
+					ok, err := c.IsSignedByIssuer(pk)
+					if expect == nil && !ok {
+						Fail(fmt.Sprintf("Expected to be ok but got %v", err))
+					}
+
+					Expect(err).To(MatchError(expect))
+					Expect(ok).To(BeFalse())
+				}
+
+				check(nil, fmt.Errorf("no issuer set"))
+				c.Issuer = "issuer"
+
+				check(nil, fmt.Errorf("no public key set"))
+				c.PublicKey = hex.EncodeToString(pubK)
+
+				check(pubK, fmt.Errorf("no trust chain signature set"))
+				c.TrustChainSignature = "x"
+
+				check(pubK, fmt.Errorf("id not set"))
+			})
+
+			It("Should detect invalid issuers", func() {
+				c.Issuer = "issuer"
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.TrustChainSignature = "x"
+				c.ID = "ID"
+
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("unsupported issuer format"))
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect invalid signatures", func() {
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.Issuer = fmt.Sprintf("I-%s", c.PublicKey)
+				c.TrustChainSignature = "X"
+				c.ID = "ID"
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).To(MatchError("invalid trust chain signature: encoding/hex: invalid byte: U+0058 'X'"))
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect wrong signatures", func() {
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.Issuer = fmt.Sprintf("I-%s", c.PublicKey)
+				c.ID = iu.UniqueID()
+
+				sig, err := iu.Ed25519Sign(priK, []byte("wrong"))
+				Expect(err).ToNot(HaveOccurred())
+				c.TrustChainSignature = hex.EncodeToString(sig)
+
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+
+			It("Should detect correct signatures", func() {
+				c.PublicKey = hex.EncodeToString(pubK)
+				c.Issuer = fmt.Sprintf("I-%s", c.PublicKey)
+				c.ID = iu.UniqueID()
+
+				dat, err := c.OrgIssuerChainData()
+				Expect(err).ToNot(HaveOccurred())
+
+				sig, err := iu.Ed25519Sign(priK, dat)
+				Expect(err).ToNot(HaveOccurred())
+				c.TrustChainSignature = hex.EncodeToString(sig)
+
+				ok, err := c.IsSignedByIssuer(pubK)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		Describe("SetOrgIssuer", func() {
+			It("Should set the correct issuer", func() {
+				pubK, _, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				c.SetOrgIssuer(pubK)
+				Expect(c.Issuer).To(Equal(fmt.Sprintf("I-%x", pubK)))
+			})
+		})
+
+		Describe("OrgIssuerChainData", func() {
+			It("Should fail for no ID", func() {
+				d, err := c.OrgIssuerChainData()
+				Expect(d).To(HaveLen(0))
+				Expect(err).To(MatchError("no token id set"))
+			})
+
+			It("Should fail for no PublicKey", func() {
+				c.ID = "x"
+				d, err := c.OrgIssuerChainData()
+				Expect(d).To(HaveLen(0))
+				Expect(err).To(MatchError("no public key set"))
+			})
+
+			It("Should create the correct data", func() {
+				c.ID = "id"
+				c.PublicKey = "pubk"
+				d, err := c.OrgIssuerChainData()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(d).To(Equal([]byte("id.pubk")))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This adds a chain of trust as described in #1900, it uses signatures to pass data from Org Issuer to Chain Issuer to Client or Server and pass Chain Issuer expiry into the clients.

Validation verifies the issuer expiry in addition to the expiry of the token itself and will fail should it be expired

The CLI can issue chain issuers using --issuer and will show some information on clients for now, will expand later.

No work done yet on brokers or servers to be aware of this.

Signed-off-by: R.I.Pienaar <rip@devco.net>