### PR TITLE
(#1900) Fully verify chained tokens

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -84,16 +84,16 @@ A few special types are defined, the rest map to standard Go types
 |[plugin.security.client_anon_tls](#pluginsecurityclient_anon_tls)|[plugin.security.ecc_curves](#pluginsecurityecc_curves)|
 |[plugin.security.file.ca](#pluginsecurityfileca)|[plugin.security.file.cache](#pluginsecurityfilecache)|
 |[plugin.security.file.certificate](#pluginsecurityfilecertificate)|[plugin.security.file.key](#pluginsecurityfilekey)|
-|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|
-|[plugin.security.provider](#pluginsecurityprovider)|[plugin.security.server_anon_tls](#pluginsecurityserver_anon_tls)|
-|[plugin.security.support_legacy_certificates](#pluginsecuritysupport_legacy_certificates)|[plugin.yaml](#pluginyaml)|
-|[publish_timeout](#publish_timeout)|[registerinterval](#registerinterval)|
-|[registration](#registration)|[registration_collective](#registration_collective)|
-|[registration_splay](#registration_splay)|[rpcaudit](#rpcaudit)|
-|[rpcauditprovider](#rpcauditprovider)|[rpcauthorization](#rpcauthorization)|
-|[rpcauthprovider](#rpcauthprovider)|[rpclimitmethod](#rpclimitmethod)|
-|[soft_shutdown_timeout](#soft_shutdown_timeout)|[threaded](#threaded)|
-|[ttl](#ttl)|[](#)|
+|[plugin.security.issuer.names](#pluginsecurityissuernames)|[plugin.security.pkcs11.driver_file](#pluginsecuritypkcs11driver_file)|
+|[plugin.security.pkcs11.slot](#pluginsecuritypkcs11slot)|[plugin.security.provider](#pluginsecurityprovider)|
+|[plugin.security.server_anon_tls](#pluginsecurityserver_anon_tls)|[plugin.security.support_legacy_certificates](#pluginsecuritysupport_legacy_certificates)|
+|[plugin.yaml](#pluginyaml)|[publish_timeout](#publish_timeout)|
+|[registerinterval](#registerinterval)|[registration](#registration)|
+|[registration_collective](#registration_collective)|[registration_splay](#registration_splay)|
+|[rpcaudit](#rpcaudit)|[rpcauditprovider](#rpcauditprovider)|
+|[rpcauthorization](#rpcauthorization)|[rpcauthprovider](#rpcauthprovider)|
+|[rpclimitmethod](#rpclimitmethod)|[soft_shutdown_timeout](#soft_shutdown_timeout)|
+|[threaded](#threaded)|[ttl](#ttl)|
 
 
 ## classesfile
@@ -972,6 +972,12 @@ When using file security provider, the path to the public certificate
  * **Type:** path_string
 
 When using file security provider, the path to the private key
+
+## plugin.security.issuer.names
+
+ * **Type:** comma_split
+
+List of names of valid issuers this server will accept, set indvidiaul issuer data using plugin.security.issuer.<name>.public
 
 ## plugin.security.pkcs11.driver_file
 

--- a/choria/ed25519.go
+++ b/choria/ed25519.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Ed24419Verify(pk ed25519.PublicKey, msg []byte, sig []byte) (bool, error) {
-	return iu.Ed24419Verify(pk, msg, sig)
+	return iu.Ed25519Verify(pk, msg, sig)
 }
 
 func Ed25519SignWithSeedFile(f string, msg []byte) ([]byte, error) {

--- a/cmd/jwt_client.go
+++ b/cmd/jwt_client.go
@@ -136,23 +136,15 @@ func (c *jWTCreateClientCommand) createJWT() error {
 	claims.AdditionalPublishSubjects = c.additionalPub
 
 	if c.chain {
-		spubk, sprik, err := iu.Ed25519KeyPairFromSeedFile(c.signingKey)
+		_, sprik, err := iu.Ed25519KeyPairFromSeedFile(c.signingKey)
 		if err != nil {
 			return err
 		}
 
-		dat, err := claims.OrgIssuerChainData()
-		if err != nil {
-			return fmt.Errorf("could not determine chain data to sign: %w", err)
-		}
-
-		sig, err := iu.Ed25519Sign(sprik, dat)
+		err = claims.AddOrgIssuerData(sprik)
 		if err != nil {
 			return err
 		}
-
-		claims.SetOrgIssuer(spubk)
-		claims.SetChainIssuerTrustSignature(sig)
 	}
 
 	err = tokens.SaveAndSignTokenWithKeyFile(claims, c.signingKey, c.file, 0600)

--- a/config/choria.go
+++ b/config/choria.go
@@ -103,6 +103,7 @@ type ChoriaPluginConfig struct {
 	AAAServiceLoginURLs []string `confkey:"plugin.login.aaasvc.login.url" url:"https://github.com/choria-io/aaasvc"`                         // List of URLs to attempt to login against when the remote signer is enabled
 	CipherSuites        []string `confkey:"plugin.security.cipher_suites" type:"comma_split"`                                                // List of allowed cipher suites
 	ECCCurves           []string `confkey:"plugin.security.ecc_curves" type:"comma_split"`                                                   // List of allowed ECC curves
+	IssuerNames         []string `confkey:"plugin.security.issuer.names" type:"comma_split"`                                                 // List of names of valid issuers this server will accept, set indvidiaul issuer data using plugin.security.issuer.<name>.public
 	ServerTokenFile     string   `confkey:"plugin.choria.security.server.token_file" type:"path_string"`                                     // The server token file to use for authentication, defaults to serer.jwt in the same location as server.conf
 	ServerTokenSeedFile string   `confkey:"plugin.choria.security.server.seed_file" type:"path_string"`                                      // The server token seed to use for authentication, defaults to server.seed in the same location as server.conf
 

--- a/config/config.go
+++ b/config/config.go
@@ -415,7 +415,7 @@ func (c *Config) Option(option string, deflt string) string {
 	return v
 }
 
-// SetOption sets a raw string option, can be used to programatically
+// SetOption sets a raw string option, can be used to programmatically
 // set plugin options etc, setting a main config item value here does
 // not update the values in the strings, so this is only really useful
 // for setting plugin options

--- a/config/docstrings.go
+++ b/config/docstrings.go
@@ -110,6 +110,7 @@ var docStrings = map[string]string{
 	"plugin.login.aaasvc.login.url":                            "List of URLs to attempt to login against when the remote signer is enabled",
 	"plugin.security.cipher_suites":                            "List of allowed cipher suites",
 	"plugin.security.ecc_curves":                               "List of allowed ECC curves",
+	"plugin.security.issuer.names":                             "List of names of valid issuers this server will accept, set indvidiaul issuer data using plugin.security.issuer.<name>.public",
 	"plugin.choria.security.server.token_file":                 "The server token file to use for authentication, defaults to serer.jwt in the same location as server.conf",
 	"plugin.choria.security.server.seed_file":                  "The server token seed to use for authentication, defaults to server.seed in the same location as server.conf",
 	"plugin.choria.ssldir":                                     "The SSL directory, auto detected via Puppet, when specifically set Puppet will not be consulted",

--- a/internal/util/ed25519.go
+++ b/internal/util/ed25519.go
@@ -21,7 +21,7 @@ func Ed25519SignWithSeedFile(f string, msg []byte) ([]byte, error) {
 	return Ed25519Sign(pri, msg)
 }
 
-func Ed24419Verify(pk ed25519.PublicKey, msg []byte, sig []byte) (bool, error) {
+func Ed25519Verify(pk ed25519.PublicKey, msg []byte, sig []byte) (bool, error) {
 	if len(pk) != ed25519.PublicKeySize {
 		return false, fmt.Errorf("invalid public key size")
 	}

--- a/internal/util/ed25519_test.go
+++ b/internal/util/ed25519_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Ed25519", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hex.EncodeToString(sig)).To(Equal("5971db5ce8eec72d586b0630e2cdd9464e6800b973e6c58575a4072018ca51a93f2e1988d47e058bb19c18d57a44ffa9931b6b7e2f70b5e44ddc50339a8c790b"))
 
-			verify, err := Ed24419Verify(pub, []byte("too many secrets"), sig)
+			verify, err := Ed25519Verify(pub, []byte("too many secrets"), sig)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(verify).To(BeTrue())
 

--- a/providers/security/choria/choria_security_test.go
+++ b/providers/security/choria/choria_security_test.go
@@ -148,7 +148,15 @@ var _ = Describe("Providers/Security/Choria", func() {
 
 			cfg.InitiatedByServer = true
 			errs, ok = prov.Validate()
-			Expect(errs).To(Equal([]string{"no trusted token signers configured"}))
+			Expect(errs).To(Equal([]string{"no trusted token signers or issuers configured"}))
+			Expect(ok).To(BeFalse())
+		})
+
+		It("Should prevent issuers and trusted signers from being used concurrently", func() {
+			cfg.Issuers = map[string]ed25519.PublicKey{"choria": cfg.TrustedTokenSigners[0]}
+			cfg.InitiatedByServer = true
+			errs, ok := prov.Validate()
+			Expect(errs).To(Equal([]string{"can only configure one of trusted token signers or issuers"}))
 			Expect(ok).To(BeFalse())
 		})
 	})
@@ -175,224 +183,476 @@ var _ = Describe("Providers/Security/Choria", func() {
 	})
 
 	Describe("VerifySignatureBytes", func() {
-		var (
-			// a delegator that signs other users requests, has no fleet management feature access
-			delegateSeedFile, delegateWTFile string
+		Describe("Issuer Based", func() {
+			var (
+				// the issuer seed
+				issuerSeedFile string
+				issuerPubk     ed25519.PublicKey
+				issuerPrik     ed25519.PrivateKey
 
-			// a caller that may only access the fleet via delegator signature
-			delegatedCallerSeedFile, delegatedCallerJWTFile string
+				// aaa login service can make new clients
+				aaaSvcSeedFile, aaaSvcJWTFile string
+				aaaServicePubk                ed25519.PublicKey
+				aaaServicePrik                ed25519.PrivateKey
 
-			// a caller that can make fleet requests without signature
-			callerSeedFile, callerJWTFile string
+				// aaa signer service
+				aaaSignerSeedFile, aaaSignerJWTFile string
+				aaaSignerPubk                       ed25519.PublicKey
+				aaaSignerPrik                       ed25519.PrivateKey
 
-			// a provisioner token
-			provJWTFile string
+				// caller that needs a signer to authorize it
+				delegatedCallerSeedFile, delegatedCallerJWTFile string
 
-			// a server purpose token
-			serverSeedFile, serverJWTFile string
+				// correctly signed but without fleet access
+				nonFleetSeedFile, nonFleetJWTFile string
+				nonFleetPubk                      ed25519.PublicKey
+				nonFleetPrik                      ed25519.PrivateKey
 
-			// signs all the jwt files
-			signerSeedFile string
+				// a correctly signed client with fleet access
+				callerSeedFile, callerJWTFile string
+				callerPubk                    ed25519.PublicKey
+				callerPrik                    ed25519.PrivateKey
 
-			delegatePrik, callerPrik, serverPrik ed25519.PrivateKey
-			delegatePubk, callerPubk, serverPubk ed25519.PublicKey
-		)
+				// server signed by the issuer
+				serverSeedFile, serverJWTFile string
+				serverPubk                    ed25519.PublicKey
+				serverPrik                    ed25519.PrivateKey
 
-		BeforeEach(func() {
-			td, err := os.MkdirTemp("", "")
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() { os.RemoveAll(td) })
+				// provisioner.jwt
+				provJWTFile string
+			)
 
-			signerSeedFile = filepath.Join(td, "signer.seed")
-			delegateSeedFile = filepath.Join(td, "delegate.seed")
-			delegateWTFile = filepath.Join(td, "delegate.jwt")
-			delegatedCallerSeedFile = filepath.Join(td, "delegated_caller.seed")
-			delegatedCallerJWTFile = filepath.Join(td, "delegated_caller.jwt")
-			callerSeedFile = filepath.Join(td, "caller.seed")
-			callerJWTFile = filepath.Join(td, "caller.jwt")
-			serverSeedFile = filepath.Join(td, "server.seed")
-			serverJWTFile = filepath.Join(td, "server.jwt")
-			provJWTFile = filepath.Join(td, "provisioner.jwt")
+			BeforeEach(func() {
+				td, err := os.MkdirTemp("", "")
+				Expect(err).ToNot(HaveOccurred())
+				DeferCleanup(func() { os.RemoveAll(td) })
 
-			// signs all the jwt tokens
-			signerPubk, _, err := iu.Ed25519KeyPairToFile(signerSeedFile)
-			Expect(err).ToNot(HaveOccurred())
+				issuerSeedFile = filepath.Join(td, "issuer.seed")
+				aaaSvcSeedFile = filepath.Join(td, "aaa-login.seed")
+				aaaSvcJWTFile = filepath.Join(td, "aaa-login.jwt")
+				aaaSignerSeedFile = filepath.Join(td, "aaa-signer.seed")
+				aaaSignerJWTFile = filepath.Join(td, "aaa-signer.jwt")
+				delegatedCallerSeedFile = filepath.Join(td, "delegated.seed")
+				delegatedCallerJWTFile = filepath.Join(td, "delegated.jwt")
+				provJWTFile = filepath.Join(td, "provisioner.jwt")
+				nonFleetSeedFile = filepath.Join(td, "nonfleet.seed")
+				nonFleetJWTFile = filepath.Join(td, "nonfleet.jwt")
+				callerSeedFile = filepath.Join(td, "caller.seed")
+				callerJWTFile = filepath.Join(td, "caller.jwt")
+				serverSeedFile = filepath.Join(td, "server.seed")
+				serverJWTFile = filepath.Join(td, "server.jwt")
 
-			// some other seed just to test multi trusted signer feature
-			otherPubk, _, err := iu.Ed25519KeyPair()
-			Expect(err).ToNot(HaveOccurred())
+				// issuer mode org issuer
+				issuerPubk, issuerPrik, err = iu.Ed25519KeyPairToFile(issuerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
 
-			// just shuffle the trusted tokens to test multi signer support automatically
-			if rand.Intn(10) <= 5 {
-				cfg.TrustedTokenSigners = []ed25519.PublicKey{otherPubk, signerPubk}
-			} else {
-				cfg.TrustedTokenSigners = []ed25519.PublicKey{signerPubk, otherPubk}
-			}
+				// provisioner.jwt signed by the issuer directly
+				provToken, err := tokens.NewProvisioningClaims(true, true, "x", "x", "x", nil, "example.net", "", "", "ginkgo", "", time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provToken.Purpose).To(Equal(tokens.ProvisioningPurpose))
+				Expect(tokens.SaveAndSignTokenWithKeyFile(provToken, issuerSeedFile, provJWTFile, 0600)).To(Succeed())
 
-			// signs delegated requests
-			delegatePubk, delegatePrik, err = iu.Ed25519KeyPairToFile(delegateSeedFile)
-			Expect(err).ToNot(HaveOccurred())
-			delegateToken, err := tokens.NewClientIDClaims("delegate", nil, "choria", nil, "", "Ginkgo Tests", time.Minute, &tokens.ClientPermissions{AuthenticationDelegator: true}, signerPubk)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(delegateToken.Permissions.AuthenticationDelegator).To(BeTrue())
-			delegateToken.PublicKey = hex.EncodeToString(delegatePubk)
-			Expect(tokens.SaveAndSignTokenWithKeyFile(delegateToken, signerSeedFile, delegateWTFile, 0600)).To(Succeed())
+				// chain issuer for aaa service
+				aaaServicePubk, aaaServicePrik, err = iu.Ed25519KeyPairToFile(aaaSvcSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				aaaToken, err := tokens.NewClientIDClaims("aaasvc-login", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, nil, aaaServicePubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(aaaToken.AddOrgIssuerData(issuerPrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(aaaToken, issuerSeedFile, aaaSvcJWTFile, 0600)).To(Succeed())
 
-			// a caller that needs delegation
-			delegatedCallerPubk, _, err := iu.Ed25519KeyPairToFile(delegatedCallerSeedFile)
-			Expect(err).ToNot(HaveOccurred())
-			delegatedCallerToken, err := tokens.NewClientIDClaims("delegated_caller", nil, "choria", nil, "", "Ginkgo Tests", time.Minute, &tokens.ClientPermissions{SignedFleetManagement: true}, signerPubk)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(delegatedCallerToken.Permissions.SignedFleetManagement).To(BeTrue())
-			delegatedCallerToken.PublicKey = hex.EncodeToString(delegatedCallerPubk)
-			Expect(tokens.SaveAndSignTokenWithKeyFile(delegatedCallerToken, signerSeedFile, delegatedCallerJWTFile, 0600)).To(Succeed())
+				// aaa signer
+				aaaSignerPubk, aaaSignerPrik, err = iu.Ed25519KeyPairToFile(aaaSignerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				aaaSignerToken, err := tokens.NewClientIDClaims("aaasvc-signer", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{AuthenticationDelegator: true}, aaaSignerPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(aaaSignerToken.Permissions.AuthenticationDelegator).To(BeTrue())
+				Expect(aaaSignerToken.AddOrgIssuerData(issuerPrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(aaaSignerToken, issuerSeedFile, aaaSignerJWTFile, 0600)).To(Succeed())
 
-			// caller that can sign itself
-			callerPubk, callerPrik, err = iu.Ed25519KeyPairToFile(callerSeedFile)
-			Expect(err).ToNot(HaveOccurred())
-			callerToken, err := tokens.NewClientIDClaims("caller", nil, "choria", nil, "", "Ginkgo Tests", time.Minute, &tokens.ClientPermissions{FleetManagement: true}, signerPubk)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(callerToken.Permissions.FleetManagement).To(BeTrue())
-			callerToken.PublicKey = hex.EncodeToString(callerPubk)
-			Expect(tokens.SaveAndSignTokenWithKeyFile(callerToken, signerSeedFile, callerJWTFile, 0600)).To(Succeed())
+				// clients thats correctly signed etc, but cant access the fleet
+				nonFleetPubk, nonFleetPrik, err = iu.Ed25519KeyPairToFile(nonFleetSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				nonFleetToken, err := tokens.NewClientIDClaims("delegated_caller", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, nil, nonFleetPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(nonFleetToken.AddOrgIssuerData(issuerPrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(nonFleetToken, issuerSeedFile, nonFleetJWTFile, 0600)).To(Succeed())
 
-			// server token
-			serverPubk, serverPrik, err = iu.Ed25519KeyPairToFile(serverSeedFile)
-			Expect(err).ToNot(HaveOccurred())
-			serverToken, err := tokens.NewServerClaims("example.net", []string{"choria"}, "choria", nil, nil, serverPubk, "ginkgo", time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(serverToken.Purpose).To(Equal(tokens.ServerPurpose))
-			serverToken.PublicKey = hex.EncodeToString(serverPubk)
-			Expect(tokens.SaveAndSignTokenWithKeyFile(serverToken, signerSeedFile, serverJWTFile, 0600)).To(Succeed())
+				// a valid non delegated caller with fleet access
+				callerPubk, callerPrik, err = iu.Ed25519KeyPairToFile(callerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				callerToken, err := tokens.NewClientIDClaims("caller", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{FleetManagement: true}, callerPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(callerToken.AddOrgIssuerData(issuerPrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(callerToken, issuerSeedFile, callerJWTFile, 0600)).To(Succeed())
 
-			// a provisioner purpose token
-			provToken, err := tokens.NewProvisioningClaims(true, true, "x", "x", "x", nil, "example.net", "", "", "ginkgo", "", time.Minute)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(provToken.Purpose).To(Equal(tokens.ProvisioningPurpose))
-			Expect(tokens.SaveAndSignTokenWithKeyFile(provToken, signerSeedFile, provJWTFile, 0600)).To(Succeed())
+				// client that requires delegated signer
+				delegatedCallerPubk, _, err := iu.Ed25519KeyPairToFile(delegatedCallerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				delegatedCallerToken, err := tokens.NewClientIDClaims("delegated_caller", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{SignedFleetManagement: true}, delegatedCallerPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(delegatedCallerToken.Permissions.SignedFleetManagement).To(BeTrue())
+				Expect(delegatedCallerToken.AddChainIssuerData(aaaToken, aaaServicePrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(delegatedCallerToken, aaaSvcSeedFile, delegatedCallerJWTFile, 0600)).To(Succeed())
+
+				// server token
+				serverPubk, serverPrik, err = iu.Ed25519KeyPairToFile(serverSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				serverToken, err := tokens.NewServerClaims("example.net", []string{"choria"}, "choria", nil, nil, serverPubk, "ginkgo", time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(serverToken.Purpose).To(Equal(tokens.ServerPurpose))
+				Expect(serverToken.AddChainIssuerData(aaaToken, aaaServicePrik)).To(Succeed())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(serverToken, aaaSvcSeedFile, serverJWTFile, 0600)).To(Succeed())
+
+				cfg.TrustedTokenSigners = []ed25519.PublicKey{}
+				cfg.Issuers = map[string]ed25519.PublicKey{
+					"choria": issuerPubk,
+				}
+			})
+
+			It("Should fail for no public parts", func() {
+				should, signer := prov.VerifySignatureBytes(nil, nil)
+				Expect(should).To(BeFalse())
+				Expect(signer).To(Equal(""))
+				Expect(logbuf).To(gbytes.Say("Received a signature verification request with no public parts"))
+			})
+
+			Describe("Caller signatures", func() {
+				It("Should detect invalid token purposes", func() {
+					pub, err := os.ReadFile(provJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
+				})
+
+				It("Should deny client tokens that require a delegator to sign requests", func() {
+					pub, err := os.ReadFile(delegatedCallerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("access denied: requires authority delegation"))
+				})
+
+				It("Should deny client tokens that does not have fleet management access", func() {
+					pub, err := os.ReadFile(nonFleetJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("access denied: does not have fleet management access"))
+				})
+
+				It("Should support client tokens", func() {
+					sig, err := iu.Ed25519Sign(callerPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					pub, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("caller"))
+				})
+
+				It("Should support server tokens", func() {
+					sig, err := iu.Ed25519Sign(serverPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					pub, err := os.ReadFile(serverJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("example.net"))
+				})
+			})
+
+			Describe("Delegated signatures", func() {
+				It("Should detect invalid token purposes", func() {
+					pub, err := os.ReadFile(provJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
+				})
+
+				It("Should ensure that the signer has delegated signature permissions", func() {
+					pub, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("token attempted to sign a request as delegator without required delegator permission"))
+				})
+
+				It("Should ensure the caller has fleet access", func() {
+					nonFleet, err := os.ReadFile(nonFleetJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					signerToken, err := os.ReadFile(aaaSignerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					sig, err := iu.Ed25519Sign(nonFleetPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, nonFleet, signerToken)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("caller token cannot be used without fleet management access"))
+				})
+
+				It("Should fail for server tokens", func() {
+					signerToken, err := os.ReadFile(aaaSignerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					server, err := os.ReadFile(serverJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					sig, err := iu.Ed25519Sign(aaaSignerPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, server, signerToken)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("could not load caller token using the same signer as the delegator: not a client token"))
+				})
+
+				It("Should support client tokens", func() {
+					signerToken, err := os.ReadFile(aaaSignerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					caller, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					sig, err := iu.Ed25519Sign(aaaSignerPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, caller, signerToken)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("aaasvc-signer"))
+				})
+			})
 		})
 
-		It("Should fail for no public parts", func() {
-			should, signer := prov.VerifySignatureBytes(nil, nil)
-			Expect(should).To(BeFalse())
-			Expect(signer).To(Equal(""))
-			Expect(logbuf).To(gbytes.Say("Received a signature verification request with no public parts"))
-		})
+		Describe("Trusted Signers Based", func() {
+			var (
+				// a delegator that signs other users requests, has no fleet management feature access
+				delegateSeedFile, delegateJWTFile string
 
-		Describe("Caller signatures", func() {
-			It("Should detect invalid token purposes", func() {
-				pub, err := os.ReadFile(provJWTFile)
+				// a caller that may only access the fleet via delegator signature
+				delegatedCallerSeedFile, delegatedCallerJWTFile string
+
+				// a caller that can make fleet requests without signature
+				callerSeedFile, callerJWTFile string
+
+				// a provisioner token
+				provJWTFile string
+
+				// a server purpose token
+				serverSeedFile, serverJWTFile string
+
+				// signs all the jwt files
+				signerSeedFile string
+
+				delegatePrik, callerPrik, serverPrik ed25519.PrivateKey
+				delegatePubk, callerPubk, serverPubk ed25519.PublicKey
+			)
+
+			BeforeEach(func() {
+				td, err := os.MkdirTemp("", "")
 				Expect(err).ToNot(HaveOccurred())
-				should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+				DeferCleanup(func() { os.RemoveAll(td) })
+
+				signerSeedFile = filepath.Join(td, "signer.seed")
+				delegateSeedFile = filepath.Join(td, "delegate.seed")
+				delegateJWTFile = filepath.Join(td, "delegate.jwt")
+				delegatedCallerSeedFile = filepath.Join(td, "delegated_caller.seed")
+				delegatedCallerJWTFile = filepath.Join(td, "delegated_caller.jwt")
+				callerSeedFile = filepath.Join(td, "caller.seed")
+				callerJWTFile = filepath.Join(td, "caller.jwt")
+				serverSeedFile = filepath.Join(td, "server.seed")
+				serverJWTFile = filepath.Join(td, "server.jwt")
+				provJWTFile = filepath.Join(td, "provisioner.jwt")
+
+				// signs all the jwt tokens
+				signerPubk, _, err := iu.Ed25519KeyPairToFile(signerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+
+				// some other seed just to test multi trusted signer feature
+				otherPubk, _, err := iu.Ed25519KeyPair()
+				Expect(err).ToNot(HaveOccurred())
+
+				// just shuffle the trusted tokens to test multi signer support automatically
+				if rand.Intn(10) <= 5 {
+					cfg.TrustedTokenSigners = []ed25519.PublicKey{otherPubk, signerPubk}
+				} else {
+					cfg.TrustedTokenSigners = []ed25519.PublicKey{signerPubk, otherPubk}
+				}
+
+				// signs delegated requests
+				delegatePubk, delegatePrik, err = iu.Ed25519KeyPairToFile(delegateSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				delegateToken, err := tokens.NewClientIDClaims("delegate", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{AuthenticationDelegator: true}, delegatePubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(delegateToken.Permissions.AuthenticationDelegator).To(BeTrue())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(delegateToken, signerSeedFile, delegateJWTFile, 0600)).To(Succeed())
+
+				// a caller that needs delegation
+				delegatedCallerPubk, _, err := iu.Ed25519KeyPairToFile(delegatedCallerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				delegatedCallerToken, err := tokens.NewClientIDClaims("delegated_caller", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{SignedFleetManagement: true}, delegatedCallerPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(delegatedCallerToken.Permissions.SignedFleetManagement).To(BeTrue())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(delegatedCallerToken, signerSeedFile, delegatedCallerJWTFile, 0600)).To(Succeed())
+
+				// caller that can sign itself
+				callerPubk, callerPrik, err = iu.Ed25519KeyPairToFile(callerSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				callerToken, err := tokens.NewClientIDClaims("caller", nil, "choria", nil, "", "Ginkgo Tests", time.Hour, &tokens.ClientPermissions{FleetManagement: true}, callerPubk)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(callerToken.Permissions.FleetManagement).To(BeTrue())
+				Expect(tokens.SaveAndSignTokenWithKeyFile(callerToken, signerSeedFile, callerJWTFile, 0600)).To(Succeed())
+
+				// server token
+				serverPubk, serverPrik, err = iu.Ed25519KeyPairToFile(serverSeedFile)
+				Expect(err).ToNot(HaveOccurred())
+				serverToken, err := tokens.NewServerClaims("example.net", []string{"choria"}, "choria", nil, nil, serverPubk, "ginkgo", time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(serverToken.Purpose).To(Equal(tokens.ServerPurpose))
+				Expect(tokens.SaveAndSignTokenWithKeyFile(serverToken, signerSeedFile, serverJWTFile, 0600)).To(Succeed())
+
+				// a provisioner purpose token
+				provToken, err := tokens.NewProvisioningClaims(true, true, "x", "x", "x", nil, "example.net", "", "", "ginkgo", "", time.Hour)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(provToken.Purpose).To(Equal(tokens.ProvisioningPurpose))
+				Expect(tokens.SaveAndSignTokenWithKeyFile(provToken, signerSeedFile, provJWTFile, 0600)).To(Succeed())
+			})
+
+			It("Should fail for no public parts", func() {
+				should, signer := prov.VerifySignatureBytes(nil, nil)
 				Expect(should).To(BeFalse())
 				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
+				Expect(logbuf).To(gbytes.Say("Received a signature verification request with no public parts"))
 			})
 
-			It("Should deny client tokens that require a delegator to sign requests", func() {
-				pub, err := os.ReadFile(delegatedCallerJWTFile)
-				Expect(err).ToNot(HaveOccurred())
-				should, signer := prov.VerifySignatureBytes(nil, nil, pub)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Could not verify signature by caller which requires authority delegation"))
+			Describe("Caller signatures", func() {
+				It("Should detect invalid token purposes", func() {
+					pub, err := os.ReadFile(provJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
+				})
+
+				It("Should deny client tokens that require a delegator to sign requests", func() {
+					pub, err := os.ReadFile(delegatedCallerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Could not verify signature by caller: access denied: requires authority delegation"))
+				})
+
+				It("Should deny client tokens that does not have fleet management access", func() {
+					pub, err := os.ReadFile(delegateJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Could not verify signature by caller: access denied: does not have fleet management access"))
+				})
+
+				It("Should support client tokens", func() {
+					sig, err := iu.Ed25519Sign(callerPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					pub, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("caller"))
+				})
+
+				It("Should support server tokens", func() {
+					sig, err := iu.Ed25519Sign(serverPrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
+
+					pub, err := os.ReadFile(serverJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("example.net"))
+				})
 			})
 
-			It("Should deny client tokens that does not have fleet management access", func() {
-				pub, err := os.ReadFile(delegateWTFile)
-				Expect(err).ToNot(HaveOccurred())
-				should, signer := prov.VerifySignatureBytes(nil, nil, pub)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Could not verify signature by caller which does not have fleet management access"))
-			})
+			Describe("Delegated signatures", func() {
+				It("Should detect invalid token purposes", func() {
+					pub, err := os.ReadFile(provJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
+				})
 
-			It("Should support client tokens", func() {
-				sig, err := iu.Ed25519Sign(callerPrik, []byte("too many secrets"))
-				Expect(err).ToNot(HaveOccurred())
+				It("Should ensure that the signer has delegated signature permissions", func() {
+					pub, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes(nil, nil, nil, pub)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("token attempted to sign a request as delegator without required delegator permission"))
+				})
 
-				pub, err := os.ReadFile(callerJWTFile)
-				Expect(err).ToNot(HaveOccurred())
+				It("Should ensure the caller has fleet access", func() {
+					delegate, err := os.ReadFile(delegateJWTFile)
+					Expect(err).ToNot(HaveOccurred())
 
-				should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
-				Expect(should).To(BeTrue())
-				Expect(signer).To(Equal("caller"))
-			})
+					sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
 
-			It("Should support server tokens", func() {
-				sig, err := iu.Ed25519Sign(serverPrik, []byte("too many secrets"))
-				Expect(err).ToNot(HaveOccurred())
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, delegate, delegate)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("caller token cannot be used without fleet management access"))
+				})
 
-				pub, err := os.ReadFile(serverJWTFile)
-				Expect(err).ToNot(HaveOccurred())
+				It("Should fail for server tokens", func() {
+					delegate, err := os.ReadFile(delegateJWTFile)
+					Expect(err).ToNot(HaveOccurred())
 
-				should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, pub)
-				Expect(should).To(BeTrue())
-				Expect(signer).To(Equal("example.net"))
-			})
-		})
+					server, err := os.ReadFile(serverJWTFile)
+					Expect(err).ToNot(HaveOccurred())
 
-		Describe("Delegated signatures", func() {
-			It("Should detect invalid token purposes", func() {
-				pub, err := os.ReadFile(provJWTFile)
-				Expect(err).ToNot(HaveOccurred())
-				should, signer := prov.VerifySignatureBytes(nil, nil, pub)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Cannot verify byte signatures using a choria_provisioning token"))
-			})
+					sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
 
-			It("Should ensure that the signer has delegated signature permissions", func() {
-				pub, err := os.ReadFile(callerJWTFile)
-				Expect(err).ToNot(HaveOccurred())
-				should, signer := prov.VerifySignatureBytes(nil, nil, nil, pub)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Token attempted to sign a request as delegator without required delegator permission"))
-			})
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, server, delegate)
+					Expect(should).To(BeFalse())
+					Expect(signer).To(Equal(""))
+					Expect(logbuf).To(gbytes.Say("could not load caller token using the same signer as the delegator: not a client token"))
+				})
 
-			It("Should ensure the caller has fleet access", func() {
-				delegate, err := os.ReadFile(delegateWTFile)
-				Expect(err).ToNot(HaveOccurred())
+				It("Should support client tokens", func() {
+					delegate, err := os.ReadFile(delegateJWTFile)
+					Expect(err).ToNot(HaveOccurred())
 
-				sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
-				Expect(err).ToNot(HaveOccurred())
+					caller, err := os.ReadFile(callerJWTFile)
+					Expect(err).ToNot(HaveOccurred())
 
-				should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, delegate, delegate)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Caller token can not be used without fleet management access"))
-			})
+					sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
+					Expect(err).ToNot(HaveOccurred())
 
-			It("Should fail for server tokens", func() {
-				delegate, err := os.ReadFile(delegateWTFile)
-				Expect(err).ToNot(HaveOccurred())
-
-				server, err := os.ReadFile(serverJWTFile)
-				Expect(err).ToNot(HaveOccurred())
-
-				sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
-				Expect(err).ToNot(HaveOccurred())
-
-				should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, server, delegate)
-				Expect(should).To(BeFalse())
-				Expect(signer).To(Equal(""))
-				Expect(logbuf).To(gbytes.Say("Could not load caller token using the same signer as the delegator: not a client token"))
-			})
-
-			It("Should support client tokens", func() {
-				delegate, err := os.ReadFile(delegateWTFile)
-				Expect(err).ToNot(HaveOccurred())
-
-				caller, err := os.ReadFile(callerJWTFile)
-				Expect(err).ToNot(HaveOccurred())
-
-				sig, err := iu.Ed25519Sign(delegatePrik, []byte("too many secrets"))
-				Expect(err).ToNot(HaveOccurred())
-
-				should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, caller, delegate)
-				Expect(should).To(BeTrue())
-				Expect(signer).To(Equal("delegate"))
+					should, signer := prov.VerifySignatureBytes([]byte("too many secrets"), sig, caller, delegate)
+					Expect(should).To(BeTrue())
+					Expect(signer).To(Equal("delegate"))
+				})
 			})
 		})
 	})

--- a/tokens/client_id.go
+++ b/tokens/client_id.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -195,8 +196,10 @@ func ParseClientIDToken(token string, pk any, verifyPurpose bool) (*ClientIDClai
 	}
 
 	// if we have a tcs we require an issuer expiry to be set and it to not have expired
-	if !claims.StandardClaims.verifyIssuerExpiry(claims.TrustChainSignature != "") {
-		return nil, jwt.ErrTokenExpired
+	if claims.TrustChainSignature != "" && strings.HasPrefix(claims.Issuer, ChainIssuerPrefix) {
+		if !claims.StandardClaims.verifyIssuerExpiry(true) {
+			return nil, jwt.ErrTokenExpired
+		}
 	}
 
 	return claims, nil

--- a/tokens/server.go
+++ b/tokens/server.go
@@ -51,7 +51,8 @@ type ServerClaims struct {
 }
 
 var (
-	ErrNotAServerToken = errors.New("not a server token")
+	ErrNotAServerToken  = errors.New("not a server token")
+	ErrChainIssuerToken = errors.New("chain issuers may not access servers")
 )
 
 // UniqueID returns the identity and unique id used to generate private inboxes
@@ -217,9 +218,11 @@ func ParseServerToken(token string, pk any) (*ServerClaims, error) {
 		return nil, ErrNotAServerToken
 	}
 
-	// if we have a tcs we require an issuer expiry to be set and it to not have expired
-	if !claims.StandardClaims.verifyIssuerExpiry(claims.TrustChainSignature != "") {
-		return nil, jwt.ErrTokenExpired
+	if claims.TrustChainSignature != "" {
+		// if we have a tcs we require an issuer expiry to be set and it to not have expired
+		if !claims.StandardClaims.verifyIssuerExpiry(true) {
+			return nil, jwt.ErrTokenExpired
+		}
 	}
 
 	return claims, nil

--- a/tokens/standard_test.go
+++ b/tokens/standard_test.go
@@ -129,22 +129,22 @@ var _ = Describe("StandardClaims", func() {
 				c.TrustChainSignature = "x"
 				c.ID = "ID"
 
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, _, err := c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid issuer content"))
 				Expect(ok).To(BeFalse())
 
 				c.Issuer = "C-.x"
-				ok, err = c.IsSignedByIssuer(pubK)
+				ok, _, err = c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid id in issuer"))
 				Expect(ok).To(BeFalse())
 
 				c.Issuer = "C-y."
-				ok, err = c.IsSignedByIssuer(pubK)
+				ok, _, err = c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid public key in issuer"))
 				Expect(ok).To(BeFalse())
 
 				c.Issuer = "C-!.y"
-				ok, err = c.IsSignedByIssuer(pubK)
+				ok, _, err = c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid public key in issuer data"))
 				Expect(ok).To(BeFalse())
 			})
@@ -155,17 +155,17 @@ var _ = Describe("StandardClaims", func() {
 				c.ID = iu.UniqueID()
 				c.TrustChainSignature = "X"
 
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, _, err := c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid trust chain signature"))
 				Expect(ok).To(BeFalse())
 
 				c.TrustChainSignature = "."
-				ok, err = c.IsSignedByIssuer(pubK)
+				ok, _, err = c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid trust chain signature"))
 				Expect(ok).To(BeFalse())
 
 				c.TrustChainSignature = "foo.!!"
-				ok, err = c.IsSignedByIssuer(pubK)
+				ok, _, err = c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid signature in chain signature: encoding/hex: invalid byte: U+0021 '!'"))
 				Expect(ok).To(BeFalse())
 			})
@@ -206,7 +206,7 @@ var _ = Describe("StandardClaims", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(user.SetChainIssuer(handler)).To(Succeed())
 				user.SetChainUserTrustSignature(handler, []byte("invalid sig"))
-				ok, err := user.IsSignedByIssuer(issuePubK)
+				ok, _, err := user.IsSignedByIssuer(issuePubK)
 				Expect(err).To(MatchError("invalid chain signature"))
 				Expect(ok).To(BeFalse())
 			})
@@ -241,7 +241,7 @@ var _ = Describe("StandardClaims", func() {
 				usig, err := iu.Ed25519Sign(handlerPrik, udat)
 				Expect(err).ToNot(HaveOccurred())
 				user.SetChainUserTrustSignature(handler, usig)
-				ok, err := user.IsSignedByIssuer(issuePubK)
+				ok, _, err := user.IsSignedByIssuer(issuePubK)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
@@ -252,7 +252,7 @@ var _ = Describe("StandardClaims", func() {
 		Describe("IsSignedByIssuer", func() {
 			It("Should expect minimally correct data", func() {
 				check := func(pk ed25519.PublicKey, expect error) {
-					ok, err := c.IsSignedByIssuer(pk)
+					ok, _, err := c.IsSignedByIssuer(pk)
 					if expect == nil && !ok {
 						Fail(fmt.Sprintf("Expected to be ok but got %v", err))
 					}
@@ -279,7 +279,7 @@ var _ = Describe("StandardClaims", func() {
 				c.TrustChainSignature = "x"
 				c.ID = "ID"
 
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, _, err := c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("unsupported issuer format"))
 				Expect(ok).To(BeFalse())
 			})
@@ -289,7 +289,7 @@ var _ = Describe("StandardClaims", func() {
 				c.Issuer = fmt.Sprintf("I-%s", c.PublicKey)
 				c.TrustChainSignature = "X"
 				c.ID = "ID"
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, _, err := c.IsSignedByIssuer(pubK)
 				Expect(err).To(MatchError("invalid trust chain signature: encoding/hex: invalid byte: U+0058 'X'"))
 				Expect(ok).To(BeFalse())
 			})
@@ -303,7 +303,7 @@ var _ = Describe("StandardClaims", func() {
 				Expect(err).ToNot(HaveOccurred())
 				c.TrustChainSignature = hex.EncodeToString(sig)
 
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, _, err := c.IsSignedByIssuer(pubK)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeFalse())
 			})
@@ -320,8 +320,9 @@ var _ = Describe("StandardClaims", func() {
 				Expect(err).ToNot(HaveOccurred())
 				c.TrustChainSignature = hex.EncodeToString(sig)
 
-				ok, err := c.IsSignedByIssuer(pubK)
+				ok, pk, err := c.IsSignedByIssuer(pubK)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(pk).To(Equal(pubK))
 				Expect(ok).To(BeTrue())
 			})
 		})


### PR DESCRIPTION
This supports fully creating and signing chained clients and servers via chained issuers.

The server and broker all validate the chain correctly via a new configuration setting plugin.security.issuer.names

At the moment we still support the older trusted signer mode we'll revisit later if removing that is the right choice

Signed-off-by: R.I.Pienaar <rip@devco.net>