### PR TITLE
(#1740) backwards compatability fix for remote signers

### DIFF
--- a/providers/security/filesec/file_security.go
+++ b/providers/security/filesec/file_security.go
@@ -145,6 +145,11 @@ func (s *FileSecurity) TokenBytes() ([]byte, error) {
 }
 
 func (s *FileSecurity) RemoteSignerSeedFile() (string, error) {
+	if s.conf.RemoteSignerTokenFile != "" && s.conf.RemoteSignerSeedFile == "" {
+		// copies the behavior from framework SignerSeedFile()
+		s.conf.RemoteSignerSeedFile = fmt.Sprintf("%s.key", strings.TrimSuffix(s.conf.RemoteSignerTokenFile, filepath.Ext(s.conf.RemoteSignerTokenFile)))
+	}
+
 	if s.conf.RemoteSignerSeedFile == "" {
 		return "", fmt.Errorf("no seed file defined")
 	}


### PR DESCRIPTION
We introduced signatures on signing requests which now requires the seed to be configured which was not required before.

Elsewhere we have a convention that if nothing is configured and the token is configured we base it off the token file name, so now we do the same here ensuring older configuration keeps working

Signed-off-by: R.I.Pienaar <rip@devco.net>