### PR TITLE
(#1913) allow provisioning over non tls connections with a issuer jwt

### DIFF
--- a/patch
+++ b/patch
@@ -1,0 +1,289 @@
+diff --git a/broker/network/choria_auth.go b/broker/network/choria_auth.go
+index 8c08648c..215809c8 100644
+--- a/broker/network/choria_auth.go
++++ b/broker/network/choria_auth.go
+@@ -407,7 +407,51 @@ func (a *ChoriaAuth) handleVerifiedSystemAccount(c server.ClientAuthentication,
+ 	return true, nil
+ }
+ 
+-func (a *ChoriaAuth) handleProvisioningUserConnection(c server.ClientAuthentication, tlsVerified bool) (bool, error) {
++func (a *ChoriaAuth) handleProvisioningUserConnectionWithIssuer(c server.ClientAuthentication) (bool, error) {
++	if a.provPass == emptyString {
++		return false, fmt.Errorf("provisioning user password not enabled")
++	}
++
++	if a.provisioningAccount == nil {
++		return false, fmt.Errorf("provisioning account is not set")
++	}
++
++	opts := c.GetOpts()
++
++	if opts.Token == "" {
++		return false, fmt.Errorf("no token provided in connection")
++	}
++
++	claims, err := a.parseClientIDJWTWithIssuer(opts.Token)
++	if err != nil {
++		return false, err
++	}
++
++	if claims.TrustChainSignature != "" {
++		return false, fmt.Errorf("provisioner tokens must be signed by an issuer")
++	}
++	if claims.Permissions == nil || !claims.Permissions.ServerProvisioner {
++		return false, fmt.Errorf("provisioner claim is false in token with caller id '%s'", claims.CallerID)
++	}
++
++	if opts.Password == emptyString {
++		return false, fmt.Errorf("password required")
++	}
++
++	if a.provPass != opts.Password {
++		return false, fmt.Errorf("invalid provisioner password supplied")
++	}
++
++	user := a.createUser(c)
++	user.Account = a.provisioningAccount
++
++	a.log.Debugf("Registering user '%s' in account '%s' from claims with identity %s", user.Username, user.Account.Name, claims.CallerID)
++	c.RegisterUser(user)
++
++	return true, nil
++}
++
++func (a *ChoriaAuth) handleProvisioningUserConnectionWithTLS(c server.ClientAuthentication, tlsVerified bool) (bool, error) {
+ 	if !tlsVerified {
+ 		return false, fmt.Errorf("provisioning user is only allowed over verified TLS connections")
+ 	}
+@@ -447,6 +491,14 @@ func (a *ChoriaAuth) handleProvisioningUserConnection(c server.ClientAuthenticat
+ 	return true, nil
+ }
+ 
++func (a *ChoriaAuth) handleProvisioningUserConnection(c server.ClientAuthentication, tlsVerified bool) (bool, error) {
++	if len(a.issuerTokens) > 0 {
++		return a.handleProvisioningUserConnectionWithIssuer(c)
++	}
++
++	return a.handleProvisioningUserConnectionWithTLS(c, tlsVerified)
++}
++
+ func (a *ChoriaAuth) handleUnverifiedProvisioningConnection(c server.ClientAuthentication) (bool, error) {
+ 	if a.provisioningTokenSigner == emptyString {
+ 		return false, fmt.Errorf("provisioning is not enabled")
+diff --git a/broker/network/choria_auth_test.go b/broker/network/choria_auth_test.go
+index e058f606..1124d40c 100644
+--- a/broker/network/choria_auth_test.go
++++ b/broker/network/choria_auth_test.go
+@@ -46,6 +46,7 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
+ 			clientAllowList: []string{},
+ 			log:             log,
+ 			choriaAccount:   &server.Account{Name: "choria"},
++			issuerTokens:    map[string]string{},
+ 		}
+ 		user = &server.User{
+ 			Username:    "bob",
+@@ -867,46 +868,171 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
+ 			Expect(verified).To(BeFalse())
+ 		})
+ 
+-		It("Should fail when server not in TLS mode", func() {
+-			auth.provPass = "s3cret"
+-			auth.isTLS = false
+-			auth.provisioningAccount = &server.Account{Name: provisioningUser}
++		Context("Using Issuers", func() {
++			var td string
++			var err error
++			var issuerPubk ed25519.PublicKey
++			var issuerPrik ed25519.PrivateKey
+ 
+-			verified, err := auth.handleProvisioningUserConnection(mockClient, true)
+-			Expect(err).To(MatchError("provisioning user access requires TLS"))
+-			Expect(verified).To(BeFalse())
+-		})
++			BeforeEach(func() {
++				td, err = os.MkdirTemp("", "")
++				Expect(err).ToNot(HaveOccurred())
+ 
+-		It("Should fail when client is not using TLS", func() {
+-			auth.provPass = "s3cret"
+-			auth.isTLS = true
+-			auth.provisioningAccount = &server.Account{Name: provisioningUser}
+-			mockClient.EXPECT().GetTLSConnectionState().Return(nil).AnyTimes()
++				issuerPubk, issuerPrik, err = iu.Ed25519KeyPair()
++				Expect(err).ToNot(HaveOccurred())
+ 
+-			verified, err := auth.handleProvisioningUserConnection(mockClient, false)
+-			Expect(err).To(MatchError("provisioning user is only allowed over verified TLS connections"))
+-			Expect(verified).To(BeFalse())
++				auth.issuerTokens = map[string]string{"choria": hex.EncodeToString(issuerPubk)}
++
++				DeferCleanup(func() {
++					os.RemoveAll(td)
++				})
++			})
++
++			It("Should require a token", func() {
++				auth.provPass = "s3cret"
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret"}).AnyTimes()
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err).To(MatchError("no token provided in connection"))
++				Expect(verified).To(BeFalse())
++			})
++
++			It("Should not accept any chained token", func() {
++				auth.provPass = "s3cret"
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				provPubk, _, err := iu.Ed25519KeyPair()
++				Expect(err).ToNot(HaveOccurred())
++
++				provClaims, err := tokens.NewClientIDClaims("provisioner", nil, "choria", nil, "", "", time.Hour, &tokens.ClientPermissions{ServerProvisioner: true}, provPubk)
++				Expect(err).ToNot(HaveOccurred())
++
++				Expect(provClaims.AddOrgIssuerData(issuerPrik)).To(Succeed())
++
++				signed, err := tokens.SignToken(provClaims, issuerPrik)
++				Expect(err).ToNot(HaveOccurred())
++
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret", Token: signed}).AnyTimes()
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err.Error()).To(MatchRegexp("provisioner tokens must be signed by an issuer"))
++				Expect(verified).To(BeFalse())
++			})
++
++			It("Should handle tokens that do not pass validation", func() {
++				auth.provPass = "s3cret"
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				provPubk, _, err := iu.Ed25519KeyPair()
++				Expect(err).ToNot(HaveOccurred())
++
++				provClaims, err := tokens.NewClientIDClaims("provisioner", nil, "choria", nil, "", "", time.Hour, nil, provPubk)
++				Expect(err).ToNot(HaveOccurred())
++
++				// make sure its expired
++				provClaims.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-time.Hour))
++				signed, err := tokens.SignToken(provClaims, issuerPrik)
++				Expect(err).ToNot(HaveOccurred())
++
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret", Token: signed}).AnyTimes()
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err.Error()).To(MatchRegexp("token is expired by 1h"))
++				Expect(verified).To(BeFalse())
++			})
++
++			It("Should require the provisioner permission", func() {
++				auth.provPass = "s3cret"
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				provPubk, _, err := iu.Ed25519KeyPair()
++				Expect(err).ToNot(HaveOccurred())
++
++				provClaims, err := tokens.NewClientIDClaims("provisioner", nil, "choria", nil, "", "", time.Hour, nil, provPubk)
++				Expect(err).ToNot(HaveOccurred())
++				signed, err := tokens.SignToken(provClaims, issuerPrik)
++				Expect(err).ToNot(HaveOccurred())
++
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret", Token: signed}).AnyTimes()
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err).To(MatchError("provisioner claim is false in token with caller id 'provisioner'"))
++				Expect(verified).To(BeFalse())
++			})
++
++			It("Should correctly verify the password and register the user", func() {
++				auth.provPass = "s3cret"
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				provPubk, _, err := iu.Ed25519KeyPair()
++				Expect(err).ToNot(HaveOccurred())
++
++				provClaims, err := tokens.NewClientIDClaims("provisioner", nil, "choria", nil, "", "", time.Hour, &tokens.ClientPermissions{ServerProvisioner: true}, provPubk)
++				Expect(err).ToNot(HaveOccurred())
++				signed, err := tokens.SignToken(provClaims, issuerPrik)
++				Expect(err).ToNot(HaveOccurred())
++
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret", Token: signed}).AnyTimes()
++				mockClient.EXPECT().RegisterUser(gomock.Any()).Do(func(user *server.User) {
++					Expect(user.Username).To(Equal(provisioningUser))
++					Expect(user.Password).To(Equal("s3cret"))
++					Expect(user.Account).To(Equal(auth.provisioningAccount))
++					Expect(user.Permissions).To(Not(BeNil()))
++					Expect(user.Permissions.Publish).To(BeNil())
++					Expect(user.Permissions.Subscribe).To(BeNil())
++					Expect(user.Permissions.Response).To(BeNil())
++				})
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err).ToNot(HaveOccurred())
++				Expect(verified).To(BeTrue())
++			})
+ 		})
+ 
+-		It("Should correctly verify the password and register the user", func() {
+-			auth.provPass = "s3cret"
+-			auth.isTLS = true
+-			auth.provisioningAccount = &server.Account{Name: provisioningUser}
+-			mockClient.EXPECT().GetTLSConnectionState().Return(&tls.ConnectionState{}).AnyTimes()
+-			mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret"}).AnyTimes()
+-			mockClient.EXPECT().RegisterUser(gomock.Any()).Do(func(user *server.User) {
+-				Expect(user.Username).To(Equal(provisioningUser))
+-				Expect(user.Password).To(Equal("s3cret"))
+-				Expect(user.Account).To(Equal(auth.provisioningAccount))
+-				Expect(user.Permissions).To(Not(BeNil()))
+-				Expect(user.Permissions.Publish).To(BeNil())
+-				Expect(user.Permissions.Subscribe).To(BeNil())
+-				Expect(user.Permissions.Response).To(BeNil())
++		Context("Using mTLS", func() {
++			It("Should fail when server not in TLS mode", func() {
++				auth.provPass = "s3cret"
++				auth.isTLS = false
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err).To(MatchError("provisioning user access requires TLS"))
++				Expect(verified).To(BeFalse())
+ 			})
+ 
+-			verified, err := auth.handleProvisioningUserConnection(mockClient, true)
+-			Expect(err).ToNot(HaveOccurred())
+-			Expect(verified).To(BeTrue())
++			It("Should fail when client is not using TLS", func() {
++				auth.provPass = "s3cret"
++				auth.isTLS = true
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++				mockClient.EXPECT().GetTLSConnectionState().Return(nil).AnyTimes()
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, false)
++				Expect(err).To(MatchError("provisioning user is only allowed over verified TLS connections"))
++				Expect(verified).To(BeFalse())
++			})
++
++			It("Should correctly verify the password and register the user", func() {
++				auth.provPass = "s3cret"
++				auth.isTLS = true
++				auth.provisioningAccount = &server.Account{Name: provisioningUser}
++				mockClient.EXPECT().GetTLSConnectionState().Return(&tls.ConnectionState{}).AnyTimes()
++				mockClient.EXPECT().GetOpts().Return(&server.ClientOpts{Username: provisioningUser, Password: "s3cret"}).AnyTimes()
++				mockClient.EXPECT().RegisterUser(gomock.Any()).Do(func(user *server.User) {
++					Expect(user.Username).To(Equal(provisioningUser))
++					Expect(user.Password).To(Equal("s3cret"))
++					Expect(user.Account).To(Equal(auth.provisioningAccount))
++					Expect(user.Permissions).To(Not(BeNil()))
++					Expect(user.Permissions.Publish).To(BeNil())
++					Expect(user.Permissions.Subscribe).To(BeNil())
++					Expect(user.Permissions.Response).To(BeNil())
++				})
++
++				verified, err := auth.handleProvisioningUserConnection(mockClient, true)
++				Expect(err).ToNot(HaveOccurred())
++				Expect(verified).To(BeTrue())
++			})
+ 		})
+ 	})
+ 


### PR DESCRIPTION
Previously Choria Provisioner had a hard requirement for mTLS, now we detect the scenario when an issuer is used and require the Choria Provisioner to present a Issuer signed JWT with the ServerProvisioner claim set.

Signed-off-by: R.I.Pienaar <rip@devco.net>