### PR TITLE
(#1916) Support provisioning server connections

### DIFF
--- a/broker/network/network.go
+++ b/broker/network/network.go
@@ -170,6 +170,10 @@ func NewServer(c inter.Framework, bi BuildInfoProvider, debug bool) (s *Server, 
 			s.log.Warnf("Loaded Organization Issuer %s with public key %s", issuer, pk)
 			choriaAuth.issuerTokens[issuer] = pk
 		}
+
+		if s.config.Choria.NetworkProvisioningClientPassword != "" {
+			s.log.Warnf("Allowing Provisioner connections subject to JWT claims")
+		}
 	}
 
 	if choriaAuth.isTLS {

--- a/broker/network/network_accounts.go
+++ b/broker/network/network_accounts.go
@@ -22,7 +22,7 @@ func (s *Server) setupAccounts() (err error) {
 		return fmt.Errorf("choria account creation failed")
 	}
 
-	if s.config.Choria.NetworkProvisioningTokenSignerFile != "" {
+	if s.config.Choria.NetworkProvisioningClientPassword != "" {
 		s.provisioningAccount, _ = s.gnatsd.LookupOrRegisterAccount("provisioning")
 		if s.provisioningAccount == nil {
 			return fmt.Errorf("provisioning account creation failed")

--- a/build/build.go
+++ b/build/build.go
@@ -65,6 +65,9 @@ var ProvisioningBrokerUsername = ""
 // ProvisioningBrokerPassword is the password used to connect to the middleware with
 var ProvisioningBrokerPassword = ""
 
+// ProvisioningUsesProtocolV2 indicates if provisioning should use v2 protocol
+var ProvisioningUsesProtocolV2 = "false"
+
 // AgentProviders are registered systems capable of extending choria with new agents
 var AgentProviders = []string{}
 

--- a/build/info.go
+++ b/build/info.go
@@ -150,6 +150,13 @@ func (i *Info) ProvisionStatusFile() string {
 	return ProvisionStatusFile
 }
 
+func (i *Info) ProvisionUsingVersion2() bool {
+	mu.Lock()
+	defer mu.Unlock()
+
+	return ProvisioningUsesProtocolV2 == "true"
+}
+
 func (i *Info) AgentProviders() []string {
 	mu.Lock()
 	defer mu.Unlock()
@@ -257,6 +264,17 @@ func (i *Info) SetProvisionToken(t string) {
 	defer mu.Unlock()
 
 	ProvisionToken = t
+}
+
+func (i *Info) SetProvisionUsingVersion2(v2 bool) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if v2 {
+		ProvisioningUsesProtocolV2 = "true"
+	} else {
+		ProvisioningUsesProtocolV2 = "false"
+	}
 }
 
 func (i *Info) SetProvisionBrokerSRVDomain(d string) {

--- a/choria/connection.go
+++ b/choria/connection.go
@@ -586,14 +586,14 @@ func (conn *Connection) anonTLSc() *tls.Config {
 	}
 }
 
-// TODO: rather than these checks we should just say do we have a seed and jwt regardless of that was set (1740)
 func (conn *Connection) isJwtAuth() bool {
-	return conn.config.Choria.ServerAnonTLS || conn.config.Choria.ClientAnonTLS || conn.fw.security.BackingTechnology() == inter.SecurityTechnologyED25519JWT
+	// in provisioning mode servers do not have seed files and the security is set to insecure, so we skip nonce signing etc for those
+	return (conn.config.Choria.ServerAnonTLS || conn.config.Choria.ClientAnonTLS || conn.fw.security.BackingTechnology() == inter.SecurityTechnologyED25519JWT) && !conn.fw.ProvisionMode()
 }
 
 // Connect creates a new connection to NATS.
 //
-// This will block until connected - basically forever should it never work.  Due to short comings
+// This will block until connected - basically forever should it never work.  Due to shortcomings
 // in the NATS library logging about failures is not optimal
 func (conn *Connection) Connect(ctx context.Context) (err error) {
 	obs := prometheus.NewTimer(connInitialConnectTime)

--- a/cmd/buildinfo.go
+++ b/cmd/buildinfo.go
@@ -117,7 +117,9 @@ func (b *buildinfoCommand) Run(wg *sync.WaitGroup) (err error) {
 		if bi.ProvisioningBrokerUsername() != "" {
 			fmt.Println("    Provisioning Broker Password: ******")
 		}
-
+		if bi.ProvisionUsingVersion2() {
+			fmt.Println("  Provisioning Using Protocol v2: true")
+		}
 	}
 
 	fmt.Println()

--- a/cmd/jwt_client.go
+++ b/cmd/jwt_client.go
@@ -72,7 +72,7 @@ func (cl *jWTCreateClientCommand) Setup() (err error) {
 		cl.cmd.Flag("publish", "Additional subjects the user can publish to").StringsVar(&cl.additionalPub)
 		cl.cmd.Flag("subscribe", "Additional subjects the user can subscribe to").StringsVar(&cl.additionalSub)
 		cl.cmd.Flag("issuer", "Allow this user to sign other users in a chain of trust").UnNegatableBoolVar(&cl.chain)
-		cl.cmd.Flag("server-provisioner", "Allows the client to provision servers").BoolVar(&cl.serverProvisioner)
+		cl.cmd.Flag("server-provisioner", "Allows the client to provision servers").UnNegatableBoolVar(&cl.serverProvisioner)
 		cl.cmd.Flag("vault", "Use Hashicorp Vault to sign the JWT").UnNegatableBoolVar(&cl.useVault)
 
 	}

--- a/cmd/jwt_provisioner.go
+++ b/cmd/jwt_provisioner.go
@@ -32,6 +32,7 @@ type jWTCreateProvCommand struct {
 	urls        []string
 	org         string
 	useVault    bool
+	v2          bool
 
 	command
 }
@@ -53,6 +54,7 @@ func (p *jWTCreateProvCommand) Setup() (err error) {
 		p.cmd.Flag("extensions", "Adds additional extensions to the token, accepts JSON data").PlaceHolder("JSON").StringVar(&p.extensions)
 		p.cmd.Flag("org", "Adds the node to a specific organization for trust validation").Default("choria").StringVar(&p.org)
 		p.cmd.Flag("vault", "Use Hashicorp Vault to sign the JWT").UnNegatableBoolVar(&p.useVault)
+		p.cmd.Flag("protocol-v2", "Use version 2 network protocol and security").UnNegatableBoolVar(&p.v2)
 	}
 
 	return nil
@@ -101,6 +103,10 @@ func (p *jWTCreateProvCommand) createJWT() error {
 			return fmt.Errorf("invalid extensions: %v", err)
 		}
 		claims.Extensions = ext
+	}
+
+	if p.v2 {
+		claims.ProtoV2 = true
 	}
 
 	if p.useVault {

--- a/cmd/jwt_view.go
+++ b/cmd/jwt_view.go
@@ -182,6 +182,9 @@ func (v *tJWTViewCommand) validateProvisionToken(token string) error {
 	if claims.ProvNatsPass != "" {
 		fmt.Println("               Broker Password: *****")
 	}
+	if claims.ProtoV2 {
+		fmt.Println("      Using version 2 Protocol: true")
+	}
 	if len(claims.Extensions) > 0 {
 		ext, err := json.MarshalIndent(claims.Extensions, "                                ", "  ")
 		if err != nil {

--- a/cmd/server_run.go
+++ b/cmd/server_run.go
@@ -67,6 +67,12 @@ func (r *serverRunCommand) Configure() error {
 			if cfg.Choria.ServerTokenFile != "" {
 				os.Remove(cfg.Choria.ServerTokenFile)
 			}
+			if cfg.Choria.ChoriaSecuritySeedFile != "" {
+				os.Remove(cfg.Choria.ChoriaSecuritySeedFile)
+			}
+			if cfg.Choria.ChoriaSecurityTokenFile != "" {
+				os.Remove(cfg.Choria.ChoriaSecurityTokenFile)
+			}
 
 			log.Warnf("Switching to provisioning configuration due to build defaults and server.provision configuration setting")
 			cfg, err = r.provisionConfig(configFile)
@@ -103,6 +109,12 @@ func (r *serverRunCommand) Configure() error {
 		}
 		if cfg.Choria.ServerTokenFile != "" {
 			os.Remove(cfg.Choria.ServerTokenFile)
+		}
+		if cfg.Choria.ChoriaSecuritySeedFile != "" {
+			os.Remove(cfg.Choria.ChoriaSecuritySeedFile)
+		}
+		if cfg.Choria.ChoriaSecurityTokenFile != "" {
+			os.Remove(cfg.Choria.ChoriaSecurityTokenFile)
 		}
 
 		cfg, err = r.provisionConfig(configFile)

--- a/providers/provtarget/builddefaults/default.go
+++ b/providers/provtarget/builddefaults/default.go
@@ -142,6 +142,7 @@ func (b *Resolver) setBuildBasedOnJWT() (*tokens.ProvisioningClaims, error) {
 	bi.SetProvisionBrokerURLs(claims.URLs)
 	bi.SetProvisionToken(claims.Token)
 	bi.SetProvisionBrokerSRVDomain(claims.SRVDomain)
+	bi.SetProvisionUsingVersion2(claims.ProtoV2)
 
 	if claims.ProvDefault {
 		bi.EnableProvisionModeAsDefault()

--- a/tokens/provisioning.go
+++ b/tokens/provisioning.go
@@ -25,6 +25,7 @@ type ProvisioningClaims struct {
 	ProvNatsPass     string    `json:"chpwd,omitempty"`
 	Extensions       MapClaims `json:"extensions"`
 	OrganizationUnit string    `json:"ou,omitempty"`
+	ProtoV2          bool      `json:"v2,omitempty"`
 
 	StandardClaims
 }
@@ -114,7 +115,7 @@ func ParseProvisioningTokenWithKeyfile(token string, pkFile string) (*Provisioni
 // ParseProvisionTokenUnverified parses the provisioning token in an unverified manner.
 //
 // This is intended to be used for nodes to figure out their settings, they will go try them
-// and if nothings there no biggie.  The broker and provisioner WILL validate this token so
+// and if nothing's there no biggie.  The broker and provisioner WILL validate this token so
 // parsing it unverified there is about equivalent to just a configuration file, which is the
 // intended purpose of this token and function.
 func ParseProvisionTokenUnverified(token string) (*ProvisioningClaims, error) {


### PR DESCRIPTION
This allows provisioning servers to connect when they use v2 protocol by adding a new claim to provisioning to activate v2 protocol and then various updates to broker, cli and more to handle that scenario right

Signed-off-by: R.I.Pienaar <rip@devco.net>