### PR TITLE
(#1924) evaluate aaasvc rego policies on servers

### DIFF
--- a/cmd/jwt_provisioner.go
+++ b/cmd/jwt_provisioner.go
@@ -43,7 +43,7 @@ func (p *jWTCreateProvCommand) Setup() (err error) {
 		p.cmd = jwt.Cmd().Command("provisioning", "Create a Provisioning JWT token").Alias("prov").Alias("provision").Alias("p")
 		p.cmd.Arg("file", "The JWT file to act on").Required().StringVar(&p.file)
 		p.cmd.Arg("signing-key", "Path to a private key used to sign the JWT").Required().StringVar(&p.signingKey)
-		p.cmd.Flag("insecure", "Disable TLS security during provisioning").UnNegatableBoolVar(&p.insecure)
+		p.cmd.Flag("insecure", "Disable TLS security during provisioning").Default("true").BoolVar(&p.insecure)
 		p.cmd.Flag("token", "Token used to secure access to the provisioning agent").StringVar(&p.token)
 		p.cmd.Flag("urls", "URLs to connect to for provisioning").StringsVar(&p.urls)
 		p.cmd.Flag("srv", "Domain to query for SRV records to find provisioning urls").StringVar(&p.srvDomain)

--- a/cmd/jwt_view.go
+++ b/cmd/jwt_view.go
@@ -90,10 +90,10 @@ func (v *tJWTViewCommand) validateServerToken(token string) error {
 		return err
 	}
 	if tcm != "" {
-		fmt.Printf("      Trust Chain: %s\n", tcm)
+		fmt.Printf("          Trust Chain: %s\n", tcm)
 
 		if claims.IssuerExpiresAt != nil {
-			fmt.Printf("   Issuer Expires: %s (%s)\n", claims.IssuerExpiresAt.Time, iu.RenderDuration(time.Until(claims.IssuerExpiresAt.Time)))
+			fmt.Printf("       Issuer Expires: %s (%s)\n", claims.IssuerExpiresAt.Time, iu.RenderDuration(time.Until(claims.IssuerExpiresAt.Time)))
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -96,7 +96,7 @@ type Config struct {
 	// The type of logging to use, unused in Go based programs
 	LoggerType string `confkey:"logger_type" default:"file" validate:"enum=console,file,syslog" deprecated:"true"`
 
-	// Enables multi threaded mode in the Ruby client, generally a bad idea
+	// Enables multithreaded mode in the Ruby client, generally a bad idea
 	Threaded bool `confkey:"threaded" default:"false" deprecated:"true"`
 
 	// How long published messages are allowed to linger on the network, lower numbers have a higher reliance on clocks being in sync

--- a/providers/agent/mcorpc/authz_actionpolicy.go
+++ b/providers/agent/mcorpc/authz_actionpolicy.go
@@ -21,16 +21,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type policyMatcher interface {
-	Set(caller string, actions string, facts string, classes string, groups map[string][]string)
-	MatchesFacts(cfg *config.Config, log *logrus.Entry) (bool, error)
-	MatchesClasses(classesFile string, log *logrus.Entry) (bool, error)
-	MatchesAction(act string) bool
-	MatchesCallerID(id string) bool
-	IsCompound(line string) bool
-	SetFile(f string)
-}
-
 func actionPolicyAuthorize(req *Request, agent *Agent, log *logrus.Entry) bool {
 	logger := log.WithFields(logrus.Fields{
 		"authorizer": "actionpolicy",
@@ -60,7 +50,7 @@ type actionPolicy struct {
 	req     *Request
 	agent   *Agent
 	log     *logrus.Entry
-	matcher policyMatcher
+	matcher *actionPolicyPolicy
 	groups  map[string][]string
 }
 
@@ -192,7 +182,7 @@ func (a *actionPolicy) checkRequestAgainstPolicy() (bool, error) {
 }
 
 func (a *actionPolicy) allowUnconfigured() bool {
-	unconfigured, err := util.StrToBool(a.cfg.Option("plugin.actionpolicy.allow_unconfiguredt", "n"))
+	unconfigured, err := util.StrToBool(a.cfg.Option("plugin.actionpolicy.allow_unconfigured", "n"))
 	if err != nil {
 		return false
 	}

--- a/providers/agent/mcorpc/authz_jwt.go
+++ b/providers/agent/mcorpc/authz_jwt.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mcorpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/choria-io/go-choria/client/client"
+	"github.com/choria-io/go-choria/config"
+	"github.com/choria-io/go-choria/opa"
+	"github.com/choria-io/go-choria/tokens"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/types"
+	"github.com/sirupsen/logrus"
+)
+
+type aaasvcPolicy struct {
+	cfg   *config.Config
+	req   *Request
+	agent *Agent
+	log   *logrus.Entry
+}
+
+func aaasvcPolicyAuthorize(req *Request, agent *Agent, log *logrus.Entry) (bool, error) {
+	logger := log.WithFields(logrus.Fields{
+		"authorizer": "aaasvc",
+		"agent":      agent.Name(),
+		"request":    req.RequestID,
+	})
+
+	authz := &aaasvcPolicy{
+		cfg:   agent.Config,
+		req:   req,
+		agent: agent,
+		log:   logger,
+	}
+
+	return authz.authorize()
+}
+
+func (r *aaasvcPolicy) authorize() (bool, error) {
+	if r.req.CallerPublicData == "" {
+		return false, fmt.Errorf("no policy received in request")
+	}
+
+	claims, err := tokens.ParseClientIDTokenUnverified(r.req.CallerPublicData)
+	if err != nil {
+		return false, fmt.Errorf("invalid token in request: %v", err)
+	}
+
+	if r.req.Agent == "discovery" {
+		r.log.Debugf("Allowing discovery request")
+		return true, nil
+	}
+
+	allowed := false
+	hasAgents := len(claims.AllowedAgents) > 0
+	hasOpa := claims.OPAPolicy != ""
+
+	switch {
+	case !(hasAgents || hasOpa):
+		return false, fmt.Errorf("no policy received in token")
+	case hasAgents && hasOpa:
+		return false, fmt.Errorf("received agent list and rego policy")
+	case hasAgents:
+		r.log.Debugf("Processing using agent list")
+
+		allowed, err = EvaluateAgentListPolicy(r.req.Agent, r.req.Action, claims.AllowedAgents, r.log)
+	case hasOpa:
+		r.log.Debugf("Processing using opa policy")
+
+		allowed, err = EvaluateOpenPolicyAgentPolicy(r.req, claims.OPAPolicy, claims, "server", r.log)
+	}
+
+	return allowed, err
+}
+
+func EvaluateAgentListPolicy(agent string, action string, policy []string, _ *logrus.Entry) (bool, error) {
+	if len(policy) == 0 {
+		return false, nil
+	}
+
+	for _, allow := range policy {
+		// all things are allowed
+		if allow == "*" {
+			return true, nil
+		}
+
+		parts := strings.Split(allow, ".")
+		if len(parts) != 2 {
+			return false, fmt.Errorf("invalid agent policy: %s", allow)
+		}
+
+		// it's a claim for a different agent so pass, no need to check it here
+		if agent != parts[0] {
+			continue
+		}
+
+		// agent matches, action is * so allow it
+		if parts[1] == "*" {
+			return true, nil
+		}
+
+		// agent matches, action matches, allow it
+		if action == parts[1] {
+			return true, nil
+		}
+	}
+
+	return false, nil
+
+}
+
+// EvaluateOpenPolicyAgentPolicy evaluates a rego policy document, typically embedded in a JWT token, against a request.  Shared by Choria and AAA Service
+func EvaluateOpenPolicyAgentPolicy(req *Request, policy string, claims *tokens.ClientIDClaims, site string, log *logrus.Entry) (allowed bool, err error) {
+	if policy == "" {
+		return false, fmt.Errorf("invalid policy given")
+	}
+
+	eopts := []opa.Option{
+		opa.Logger(log),
+		opa.Policy([]byte(policy)),
+		opa.Function(opaFunctionsMap(req)...),
+	}
+
+	if log.Logger.GetLevel() == logrus.DebugLevel {
+		eopts = append(eopts, opa.Trace())
+	}
+
+	evaluator, err := opa.New("io.choria.aaasvc", "data.io.choria.aaasvc.allow", eopts...)
+	if err != nil {
+		return false, fmt.Errorf("could not initialize opa evaluator: %v", err)
+	}
+
+	inputs, err := opaInputs(req, req.Data, site, claims)
+	if err != nil {
+		return false, err
+	}
+
+	allowed, err = evaluator.Evaluate(context.Background(), inputs)
+	if err != nil {
+		return false, err
+	}
+
+	return allowed, nil
+}
+
+func opaInputs(req *Request, data json.RawMessage, site string, claims *tokens.ClientIDClaims) (map[string]any, error) {
+	dat := map[string]any{}
+	err := json.Unmarshal(data, &dat)
+	if err != nil {
+		return nil, err
+	}
+
+	// lame deep copy/data convert thing happening here
+	jclaims, err := json.Marshal(claims)
+	if err != nil {
+		return nil, fmt.Errorf("could not JSON encode claims")
+	}
+
+	cdat := new(map[string]any)
+	err = json.Unmarshal(jclaims, &cdat)
+	if err != nil {
+		return nil, fmt.Errorf("could not JSON encode claims")
+	}
+
+	return map[string]any{
+		"agent":      req.Agent,
+		"action":     req.Action,
+		"data":       data,
+		"sender":     req.SenderID,
+		"collective": req.Collective,
+		"ttl":        req.TTL,
+		"time":       req.Time,
+		"site":       site,
+		"claims":     cdat,
+	}, nil
+}
+
+func opaFunctionsMap(req *Request) []func(r *rego.Rego) {
+	return []func(r *rego.Rego){
+		rego.Function1(&rego.Function{Name: "requires_filter", Decl: types.NewFunction(types.Args(), types.B)}, opaFuncRequiresFilter(req)),
+		rego.Function1(&rego.Function{Name: "requires_fact_filter", Decl: types.NewFunction(types.Args(types.S), types.B)}, opaFuncRequiresFactFilter(req)),
+		rego.Function1(&rego.Function{Name: "requires_class_filter", Decl: types.NewFunction(types.Args(types.S), types.B)}, opaFuncRequiresClassFilter(req)),
+		rego.Function1(&rego.Function{Name: "requires_identity_filter", Decl: types.NewFunction(types.Args(types.S), types.B)}, opaFuncRequiresIdentityFilter(req)),
+	}
+}
+
+func opaFuncRequiresFilter(req *Request) func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	return func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+		// agent is always set, so we don't check it else it will always be true
+		if len(req.Filter.ClassFilters()) > 0 || len(req.Filter.IdentityFilters()) > 0 || len(req.Filter.FactFilters()) > 0 || len(req.Filter.CompoundFilters()) > 0 {
+			return ast.BooleanTerm(true), nil
+		}
+
+		return ast.BooleanTerm(false), nil
+	}
+
+}
+
+func opaFuncRequiresIdentityFilter(req *Request) func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	return func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+		str, ok := a.Value.(ast.String)
+		if !ok {
+			return ast.BooleanTerm(false), fmt.Errorf("invalid identity matcher received")
+		}
+
+		want := string(str)
+		for _, f := range req.Filter.IdentityFilters() {
+			if f == want {
+				return ast.BooleanTerm(true), nil
+			}
+		}
+
+		return ast.BooleanTerm(false), nil
+	}
+}
+
+func opaFuncRequiresClassFilter(req *Request) func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	return func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+		str, ok := a.Value.(ast.String)
+		if !ok {
+			return ast.BooleanTerm(false), fmt.Errorf("invalid class matcher received")
+		}
+
+		want := string(str)
+
+		for _, f := range req.Filter.ClassFilters() {
+			if f == want {
+				return ast.BooleanTerm(true), nil
+			}
+		}
+
+		return ast.BooleanTerm(false), nil
+	}
+}
+
+func opaFuncRequiresFactFilter(req *Request) func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+	return func(_ rego.BuiltinContext, a *ast.Term) (*ast.Term, error) {
+		str, ok := a.Value.(ast.String)
+		if !ok {
+			return ast.BooleanTerm(false), fmt.Errorf("invalid fact matcher received")
+		}
+
+		want, err := client.ParseFactFilterString(string(str))
+		if err != nil {
+			return ast.BooleanTerm(false), fmt.Errorf("invalid fact matcher received: %s", err)
+		}
+
+		for _, f := range req.Filter.Fact {
+			if want.Fact == f.Fact && want.Operator == f.Operator && want.Value == f.Value {
+				return ast.BooleanTerm(true), nil
+			}
+		}
+
+		return ast.BooleanTerm(false), nil
+	}
+}

--- a/providers/agent/mcorpc/authz_jwt_test.go
+++ b/providers/agent/mcorpc/authz_jwt_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2022, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mcorpc
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	imock "github.com/choria-io/go-choria/inter/imocks"
+	iu "github.com/choria-io/go-choria/internal/util"
+	"github.com/choria-io/go-choria/protocol"
+	"github.com/choria-io/go-choria/server/agents"
+	"github.com/choria-io/go-choria/tokens"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("McoRPC/JWTAuthorizer", func() {
+	var log *logrus.Entry
+	var req *Request
+	var claims *tokens.ClientIDClaims
+
+	readFixture := func(f string) string {
+		c, err := os.ReadFile(f)
+		if err != nil {
+			panic(err)
+		}
+
+		return string(c)
+	}
+
+	BeforeEach(func() {
+		logger := logrus.New()
+		logger.Out = GinkgoWriter
+		logger.Level = logrus.DebugLevel
+		log = logrus.NewEntry(logger)
+		claims = &tokens.ClientIDClaims{}
+
+		req = &Request{
+			Agent:      "myco",
+			Action:     "deploy",
+			Data:       json.RawMessage(`{"component":"frontend"}`),
+			SenderID:   "some.node",
+			Collective: "ginkgo",
+			TTL:        60,
+			Time:       time.Now(),
+			Filter:     protocol.NewFilter(),
+		}
+	})
+
+	Describe("aaasvcPolicyAuthorize", func() {
+		var agent *Agent
+		var logBuff *gbytes.Buffer
+		var pubk ed25519.PublicKey
+		var prik ed25519.PrivateKey
+		var err error
+
+		BeforeEach(func() {
+			logBuff = gbytes.NewBuffer()
+			mockctl := gomock.NewController(GinkgoT())
+			DeferCleanup(func() {
+				mockctl.Finish()
+			})
+
+			fw, cfg := imock.NewFrameworkForTests(mockctl, logBuff)
+			log = fw.Logger("ginkgo")
+			log.Logger.SetLevel(logrus.DebugLevel)
+
+			agent = &Agent{
+				meta:   &agents.Metadata{Name: "myco"},
+				Log:    log,
+				Config: cfg,
+				Choria: fw,
+			}
+
+			pubk, prik, err = iu.Ed25519KeyPair()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should fail for no caller public data", func() {
+			allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+			Expect(err).To(MatchError("no policy received in request"))
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("Should handle invalid tokens", func() {
+			req.CallerPublicData = "blah"
+			allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+			Expect(err).To(MatchError("invalid token in request: token contains an invalid number of segments"))
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("Should allow discovery agent", func() {
+			claims, err = tokens.NewClientIDClaims("ginkgo", nil, "choria", nil, "", "", time.Hour, nil, pubk)
+			Expect(err).ToNot(HaveOccurred())
+			req.CallerPublicData, err = tokens.SignToken(claims, prik)
+			Expect(err).ToNot(HaveOccurred())
+
+			req.Agent = "discovery"
+			allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+			Expect(logBuff).To(gbytes.Say("Allowing discovery request"))
+		})
+
+		It("Should require a policy", func() {
+			claims, err = tokens.NewClientIDClaims("ginkgo", nil, "choria", nil, "", "", time.Hour, nil, pubk)
+			Expect(err).ToNot(HaveOccurred())
+			req.CallerPublicData, err = tokens.SignToken(claims, prik)
+			Expect(err).ToNot(HaveOccurred())
+
+			allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+			Expect(err).To(MatchError("no policy received in token"))
+			Expect(allowed).To(BeFalse())
+		})
+
+		Context("Allowed Agents", func() {
+			It("Should handle failures", func() {
+				claims, err = tokens.NewClientIDClaims("ginkgo", []string{"fail"}, "choria", nil, "", "", time.Hour, nil, pubk)
+				Expect(err).ToNot(HaveOccurred())
+				req.CallerPublicData, err = tokens.SignToken(claims, prik)
+				Expect(err).ToNot(HaveOccurred())
+
+				allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+				Expect(err).To(MatchError("invalid agent policy: fail"))
+				Expect(allowed).To(BeFalse())
+			})
+
+			It("Should allow valid requests", func() {
+				claims, err = tokens.NewClientIDClaims("ginkgo", []string{"myco.deploy"}, "choria", nil, "", "", time.Hour, nil, pubk)
+				Expect(err).ToNot(HaveOccurred())
+				req.CallerPublicData, err = tokens.SignToken(claims, prik)
+				Expect(err).ToNot(HaveOccurred())
+
+				allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(allowed).To(BeTrue())
+			})
+		})
+
+		Context("OPA Policy", func() {
+			It("Should handle failures", func() {
+				claims, err = tokens.NewClientIDClaims("ginkgo", nil, "choria", nil, "invalid rego", "", time.Hour, nil, pubk)
+				Expect(err).ToNot(HaveOccurred())
+				req.CallerPublicData, err = tokens.SignToken(claims, prik)
+				Expect(err).ToNot(HaveOccurred())
+
+				allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(MatchRegexp("could not initialize opa evaluator"))
+				Expect(allowed).To(BeFalse())
+			})
+
+			It("Should allow valid requests", func() {
+				claims, err = tokens.NewClientIDClaims("ginkgo", nil, "choria", nil, readFixture("testdata/policies/rego/aaa_scenario1.rego"), "", time.Hour, nil, pubk)
+				Expect(err).ToNot(HaveOccurred())
+				req.CallerPublicData, err = tokens.SignToken(claims, prik)
+				Expect(err).ToNot(HaveOccurred())
+
+				allowed, err := aaasvcPolicyAuthorize(req, agent, log)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(allowed).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("EvaluateAgentListPolicy", func() {
+		It("Should support '*' agents", func() {
+			ok, err := EvaluateAgentListPolicy("agent", "action", []string{"*"}, log)
+			Expect(ok).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Should support action wildcards", func() {
+			ok, err := EvaluateAgentListPolicy("rpcutil", "action", []string{"rpcutil.*"}, log)
+			Expect(ok).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			ok, err = EvaluateAgentListPolicy("other", "action", []string{"rpcutil.*"}, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("Should support specific agent.action", func() {
+			ok, err := EvaluateAgentListPolicy("rpcutil", "ping", []string{"rpcutil.ping"}, log)
+			Expect(ok).To(BeTrue())
+			Expect(err).ToNot(HaveOccurred())
+
+			ok, err = EvaluateAgentListPolicy("rpcutil", "other", []string{"rpcutil.ping"}, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+
+			ok, err = EvaluateAgentListPolicy("other", "action", []string{"rpcutil.ping"}, log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("Should handle invalid policies", func() {
+			ok, err := EvaluateAgentListPolicy("rpcutil", "ping", []string{"rpcutil"}, log)
+			Expect(ok).To(BeFalse())
+			Expect(err).To(MatchError("invalid agent policy: rpcutil"))
+
+		})
+	})
+
+	Describe("EvaluateOpenPolicyAgentPolicy", func() {
+		It("Should allow common scenarios", func() {
+			req.Filter.AddClassFilter("apache")
+			req.Filter.AddIdentityFilter("some.node")
+			req.Filter.AddFactFilter("country", "==", "mt")
+
+			claims.CallerID = "up=bob"
+			claims.UserProperties = map[string]string{
+				"group": "admins",
+			}
+
+			for r := 1; r <= 5; r++ {
+				policy := readFixture(fmt.Sprintf("testdata/policies/rego/aaa_scenario%d.rego", r))
+				claims.OPAPolicy = policy
+
+				allowed, err := EvaluateOpenPolicyAgentPolicy(req, policy, claims, "ginkgo", log)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(allowed).To(BeTrue())
+			}
+		})
+
+		It("Should fail on all common scenarios", func() {
+			policy := readFixture("testdata/policies/rego/aaa_scenario5.rego")
+			claims.OPAPolicy = policy
+			claims.CallerID = "up=bob"
+			claims.UserProperties = map[string]string{
+				"group": "admins",
+			}
+
+			req.Filter.AddClassFilter("apache")
+			req.Filter.AddIdentityFilter("some.node")
+			req.Filter.AddFactFilter("country", "==", "mt")
+
+			allowed, err := EvaluateOpenPolicyAgentPolicy(req, policy, claims, "ginkgo", log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+
+			allowed, err = EvaluateOpenPolicyAgentPolicy(req, policy, claims, "x", log)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
+	})
+})

--- a/providers/agent/mcorpc/mcorpc.go
+++ b/providers/agent/mcorpc/mcorpc.go
@@ -88,6 +88,7 @@ type Request struct {
 	Time             time.Time        `json:"time"`
 	Filter           *protocol.Filter `json:"-"`
 	CallerPublicData string           `json:"-"`
+	SignerPublicData string           `json:"-"`
 }
 
 // ParseRequestData parses the request parameters received from the client into a target structure

--- a/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario1.rego
+++ b/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario1.rego
@@ -1,0 +1,7 @@
+package io.choria.aaasvc
+
+default allow = false
+
+allow {
+    input.agent == "myco"
+}

--- a/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario2.rego
+++ b/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario2.rego
@@ -1,0 +1,8 @@
+package io.choria.aaasvc
+
+default allow = false
+
+allow {
+    input.agent == "myco"
+    input.action == "deploy"
+}

--- a/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario3.rego
+++ b/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario3.rego
@@ -1,0 +1,9 @@
+package io.choria.aaasvc
+
+default allow = false
+
+allow {
+    input.agent == "myco"
+    input.action == "deploy"
+    input.data.component == "frontend"
+}

--- a/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario4.rego
+++ b/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario4.rego
@@ -1,0 +1,9 @@
+package io.choria.aaasvc
+
+default allow = false
+
+allow {
+    input.agent == "myco"
+    input.action == "deploy"
+    input.data.component == "frontend"
+}

--- a/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario5.rego
+++ b/providers/agent/mcorpc/testdata/policies/rego/aaa_scenario5.rego
@@ -1,0 +1,18 @@
+package io.choria.aaasvc
+
+default allow = false
+
+allow {
+    input.agent == "myco"
+    input.action == "deploy"
+    input.data.component == "frontend"
+    requires_class_filter("apache")
+    requires_identity_filter("some.node")
+    requires_fact_filter("country=mt")
+    input.collective == "ginkgo"
+    input.ttl == 60
+    input.sender == "some.node"
+    input.site == "ginkgo"
+    input.claims.callerid == "up=bob"
+    input.claims.user_properties.group == "admins"
+}


### PR DESCRIPTION
This pulls in the code from AAA Service and does a matching evaludation on servers.

The idea is to allow an entirely policy free server deployment where every JWT must set a policy and those policies are evaluated.

Signed-off-by: R.I.Pienaar <rip@devco.net>