### PR TITLE
(#1740) use ksuid for request ids in proto v2

### DIFF
--- a/choria/framework.go
+++ b/choria/framework.go
@@ -32,6 +32,7 @@ import (
 	"github.com/choria-io/go-choria/tokens"
 	"github.com/fatih/color"
 	"github.com/nats-io/nats.go"
+	"github.com/segmentio/ksuid"
 	"golang.org/x/term"
 
 	"github.com/choria-io/go-choria/internal/util"
@@ -647,7 +648,15 @@ func (fw *Framework) PuppetAIOCmd(command string, def string) string {
 
 // NewRequestID Creates a new RequestID
 func (fw *Framework) NewRequestID() (string, error) {
-	return NewRequestID()
+	if fw.RequestProtocol() == protocol.RequestV2 {
+		kid, err := ksuid.NewRandom()
+		if err != nil {
+			return "", err
+		}
+		return kid.String(), nil
+	}
+
+	return strings.Replace(util.UniqueID(), "-", "", -1), nil
 }
 
 // UniqueID creates a new unique ID, usually a v4 uuid, if that fails a random string based ID is made

--- a/choria/util.go
+++ b/choria/util.go
@@ -5,7 +5,6 @@
 package choria
 
 import (
-	"strings"
 	"time"
 
 	"github.com/choria-io/go-choria/build"
@@ -15,11 +14,6 @@ import (
 // UserConfig determines what is the active config file for a user
 func UserConfig() string {
 	return util.UserConfig()
-}
-
-// NewRequestID Creates a new RequestID
-func NewRequestID() (string, error) {
-	return strings.Replace(util.UniqueID(), "-", "", -1), nil
 }
 
 // BuildInfo retrieves build information

--- a/tokens/standard.go
+++ b/tokens/standard.go
@@ -185,8 +185,16 @@ func (c *StandardClaims) SetChainIssuer(ci *ClientIDClaims) error {
 		return fmt.Errorf("public key not set")
 	}
 
+	if ci.ExpiresAt == nil {
+		return fmt.Errorf("issuer has no expiry")
+	}
+
 	c.Issuer = fmt.Sprintf("%s%s.%s", ChainIssuerPrefix, ci.ID, ci.PublicKey)
 	c.IssuerExpiresAt = ci.ExpiresAt
+
+	if c.ExpiresAt == nil || c.IssuerExpiresAt.Before(c.ExpiresAt.Time) {
+		c.ExpiresAt = ci.ExpiresAt
+	}
 
 	return nil
 }

--- a/tokens/standard_test.go
+++ b/tokens/standard_test.go
@@ -121,6 +121,7 @@ var _ = Describe("StandardClaims", func() {
 				ci := &ClientIDClaims{}
 				ci.ID = ksuid.New().String()
 				ci.PublicKey = hex.EncodeToString(pubK[:])
+				ci.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour))
 				Expect(c.SetChainIssuer(ci)).To(Succeed())
 				Expect(c.Issuer).To(Equal(fmt.Sprintf("C-%s.%s", ci.ID, ci.PublicKey)))
 			})
@@ -150,6 +151,7 @@ var _ = Describe("StandardClaims", func() {
 				ci := &ClientIDClaims{}
 				ci.ID = ksuid.New().String()
 				ci.PublicKey = hex.EncodeToString(pubK[:])
+				ci.ExpiresAt = jwt.NewNumericDate(time.Now().Add(time.Hour))
 				Expect(c.SetChainIssuer(ci)).To(Succeed())
 
 				dat, err := c.ChainIssuerData("x")


### PR DESCRIPTION
Apart from being shorter these are sortable and automatically
sorts by creation time. This means when looking at a server
audit log you can know when the server received the request
but also, if there are doubts, figure out from the client perspective
which was created first even over multiple clients assuming
synced clocks.

Signed-off-by: R.I.Pienaar <rip@devco.net>