### PR TITLE
(#1968) only retry governor on governor full states

### DIFF
--- a/aagent/watchers/watcher/watcher.go
+++ b/aagent/watchers/watcher/watcher.go
@@ -148,7 +148,7 @@ func (w *Watcher) EnterGovernor(ctx context.Context, name string, timeout time.D
 	w.mu.Lock()
 	gCtx, w.govCancel = context.WithTimeout(ctx, timeout)
 	w.mu.Unlock()
-	defer w.govCancel()
+	defer w.CancelGovernor()
 
 	fin, seq, err := gov.Start(gCtx, fmt.Sprintf("Auto Agent  %s#%s @ %s", w.machine.Name(), w.name, w.machine.Identity()))
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Freman/eventloghook v0.0.0-20191003051739-e4d803b6b48b
 	github.com/Masterminds/semver v1.5.0
 	github.com/adrg/xdg v0.4.0
-	github.com/antonmedv/expr v1.10.2
+	github.com/antonmedv/expr v1.10.3
 	github.com/awesome-gocui/gocui v1.1.0
 	github.com/brutella/hc v1.2.5
 	github.com/choria-io/appbuilder v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRB
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
-github.com/antonmedv/expr v1.10.2 h1:gEoz4t77BAu/xI201nOa9YNmJMJdqs6As8mc9WBjsRA=
-github.com/antonmedv/expr v1.10.2/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
+github.com/antonmedv/expr v1.10.3 h1:rBYCeI1OHKtehK51+cwHNfhtui4k3o2U1X/hbD13NNw=
+github.com/antonmedv/expr v1.10.3/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/awesome-gocui/gocui v1.1.0 h1:db2j7yFEoHZjpQFeE2xqiatS8bm1lO3THeLwE6MzOII=


### PR DESCRIPTION
To avoid a situation where machine that is failing to process ok messages keep sending more and more gov election messages we now treat anything except a governor full as unretryable

The effect is that in watchers should there be a bad situation with the machine a watcher is on this will now try and fail fast then relying on the watcher intervals for retries which would typically align with governor bucket configuration

Signed-off-by: R.I.Pienaar <rip@devco.net>