### PR TITLE
(#1972) create a jwt validation tool 

### DIFF
--- a/cmd/jwt_check.go
+++ b/cmd/jwt_check.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/antonmedv/expr"
+	"github.com/choria-io/fisk"
+	"github.com/choria-io/go-choria/config"
+	"github.com/choria-io/go-choria/internal/monitor"
+	iu "github.com/choria-io/go-choria/internal/util"
+	"github.com/choria-io/tokens"
+)
+
+type jwtCheckCommand struct {
+	file             string
+	kind             string
+	validityMin      time.Duration
+	validityMax      time.Duration
+	chainIssuerSet   bool
+	chainIssuer      bool
+	issuer           string
+	opa              bool
+	pub              []string
+	sub              []string
+	identity         string
+	queries          []string
+	renderFormatText string
+	renderFormat     monitor.RenderFormat
+
+	command
+}
+
+func (c *jwtCheckCommand) Setup() error {
+	if jwt, ok := cmdWithFullCommand("jwt"); ok {
+		c.cmd = jwt.Cmd().Command("check", "Checks validity of JWT tokens")
+		c.cmd.Arg("file", "The JWT file to act on").Required().StringVar(&c.file)
+		c.cmd.Flag("purpose", "Checks if a JWT is of a specific purpose (client, server, provisioner)").EnumVar(&c.kind, "client", "server", "provisioning")
+		c.cmd.Flag("validity-min", "Checks the validity of a token is more than DURATION").PlaceHolder("DURATION").DurationVar(&c.validityMin)
+		c.cmd.Flag("validity-max", "Checks the validity of a token is not more than DURATION").PlaceHolder("DURATION").DurationVar(&c.validityMax)
+		c.cmd.Flag("chain-issuer", "Checks if a token is a chain issuer or not").IsSetByUser(&c.chainIssuerSet).BoolVar(&c.chainIssuer)
+		c.cmd.Flag("issuer", "Checks if a specific issuer signed it, directly or via a chain").PlaceHolder("PUBK").StringVar(&c.issuer)
+		c.cmd.Flag("client-opa", "Checks if a client has a OPA policy").UnNegatableBoolVar(&c.opa)
+		c.cmd.Flag("sub", "Additional subjects that should be subscribable").PlaceHolder("SUBJECT").StringsVar(&c.sub)
+		c.cmd.Flag("pub", "Additional subjects that should be publishable").PlaceHolder("SUBJECT").StringsVar(&c.pub)
+		c.cmd.Flag("identity", "Checks the identity or caller id").StringVar(&c.identity)
+		c.cmd.Flag("query", "Performs a boolean expr query against the token").StringsVar(&c.queries)
+		c.cmd.Flag("format", "Render the check in a specific format (nagios, json, prometheus, text)").Default("nagios").EnumVar(&c.renderFormatText, "nagios", "json", "prometheus", "text")
+
+		c.cmd.PreAction(c.parseRenderFormat)
+	}
+
+	return nil
+}
+
+func init() {
+	cli.commands = append(cli.commands, &jwtCheckCommand{})
+}
+
+func (c *jwtCheckCommand) parseRenderFormat(_ *fisk.ParseContext) error {
+	switch c.renderFormatText {
+	case "prometheus":
+		c.renderFormat = monitor.PrometheusFormat
+	case "text":
+		c.renderFormat = monitor.TextFormat
+	case "json":
+		c.renderFormat = monitor.JSONFormat
+	}
+
+	return nil
+}
+
+func (c *jwtCheckCommand) Configure() error {
+	cfg, err = config.NewDefaultConfig()
+	if err != nil {
+		return fmt.Errorf("could not create default configuration: %s", err)
+	}
+
+	cfg.DisableSecurityProviderVerify = true
+	cfg.Choria.SecurityProvider = "file"
+
+	return nil
+}
+
+func (c *jwtCheckCommand) Run(wg *sync.WaitGroup) (err error) {
+	defer wg.Done()
+
+	result := &monitor.Result{Name: c.file, Check: "jwt", NameSpace: "choria", RenderFormat: c.renderFormat}
+	defer result.GenericExit()
+
+	c.check(result)
+
+	return nil
+}
+
+func (c *jwtCheckCommand) check(result *monitor.Result) {
+	if c.file == "" {
+		result.Critical("token file is required")
+		return
+	}
+
+	if !iu.FileExist(c.file) {
+		result.Critical("token not found")
+		return
+	}
+
+	token, err := os.ReadFile(c.file)
+	if result.CriticalIfErr(err, "token cannot be read: %v", err) {
+		return
+	}
+
+	var issuer ed25519.PublicKey
+	if c.issuer != "" {
+		issuer, err = hex.DecodeString(c.issuer)
+		if result.CriticalIfErr(err, "invalid issuer") {
+			return
+		}
+	}
+
+	purpose := tokens.TokenPurpose(string(token))
+
+	c.checkPurpose(purpose, result)
+
+	switch purpose {
+	case tokens.ClientIDPurpose:
+		c.checkClientToken(string(token), issuer, result)
+	case tokens.ServerPurpose:
+		c.checkServerToken(string(token), issuer, result)
+	case tokens.ProvisioningPurpose:
+		c.checkProvToken(string(token), issuer, result)
+	case tokens.UnknownPurpose:
+		result.Critical("unknown token purpose")
+	}
+}
+
+func (c *jwtCheckCommand) checkClientToken(token string, issuer ed25519.PublicKey, result *monitor.Result) {
+	var err error
+	var jwt *tokens.ClientIDClaims
+
+	if issuer == nil {
+		jwt, err = tokens.ParseClientIDTokenUnverified(token)
+	} else {
+		jwt, err = tokens.ParseClientIDToken(token, issuer, false)
+	}
+	if result.CriticalIfErr(err, "%s", err) {
+		return
+	}
+
+	if c.identity != "" && jwt.CallerID != c.identity {
+		result.Critical("identity %s", jwt.CallerID)
+	}
+
+	if jwt.PublicKey == "" {
+		result.Critical("no public key")
+	}
+
+	if c.chainIssuerSet {
+		isIssuer := jwt.IsChainedIssuer(true)
+
+		if isIssuer != c.chainIssuer {
+			result.Critical("chain issuer: %t", isIssuer)
+		}
+	}
+
+	if c.opa && jwt.OPAPolicy == "" {
+		result.Critical("no OPA policy")
+	}
+
+	for _, sub := range c.sub {
+		if !iu.StringInList(jwt.AdditionalSubscribeSubjects, sub) {
+			result.Critical("subscribe %v", sub)
+		}
+	}
+
+	for _, pub := range c.pub {
+		if !iu.StringInList(jwt.AdditionalPublishSubjects, pub) {
+			result.Critical("subscribe %v", pub)
+		}
+	}
+
+	c.commonChecks(jwt.StandardClaims, result)
+	c.checkQueries(jwt, result)
+
+	result.Ok("client token")
+}
+
+func (c *jwtCheckCommand) checkServerToken(token string, issuer ed25519.PublicKey, result *monitor.Result) {
+	var err error
+	var jwt *tokens.ServerClaims
+
+	if issuer == nil {
+		jwt, err = tokens.ParseServerTokenUnverified(token)
+	} else {
+		jwt, err = tokens.ParseServerToken(token, issuer)
+	}
+	if result.CriticalIfErr(err, "%s", err) {
+		return
+	}
+
+	if c.identity != "" && jwt.ChoriaIdentity != c.identity {
+		result.Critical("identity %s", jwt.ChoriaIdentity)
+	}
+
+	if jwt.PublicKey == "" {
+		result.Critical("no public key")
+	}
+
+	for _, pub := range c.pub {
+		if !iu.StringInList(jwt.AdditionalPublishSubjects, pub) {
+			result.Critical("publish %v", pub)
+		}
+	}
+
+	c.commonChecks(jwt.StandardClaims, result)
+	c.checkQueries(jwt, result)
+	result.Ok("server token")
+}
+
+func (c *jwtCheckCommand) checkProvToken(token string, issuer ed25519.PublicKey, result *monitor.Result) {
+	var err error
+	var jwt *tokens.ProvisioningClaims
+
+	if issuer == nil {
+		jwt, err = tokens.ParseProvisionTokenUnverified(token)
+	} else {
+		jwt, err = tokens.ParseProvisioningToken(token, issuer)
+	}
+	if result.CriticalIfErr(err, "%s", err) {
+		return
+	}
+
+	c.commonChecks(jwt.StandardClaims, result)
+	c.checkQueries(jwt, result)
+	result.Ok("provisioning token")
+}
+
+func (c *jwtCheckCommand) commonChecks(claims tokens.StandardClaims, result *monitor.Result) {
+	c.checkValidity(claims, result)
+
+	if claims.ID == "" {
+		result.Critical("no id")
+	}
+	if claims.ExpireTime().IsZero() {
+		result.Critical("no expiry")
+	}
+	if claims.NotBefore == nil || claims.NotBefore.IsZero() {
+		result.Critical("no not before")
+	}
+}
+
+func (c *jwtCheckCommand) checkValidity(claims tokens.StandardClaims, result *monitor.Result) {
+	exp := claims.ExpireTime()
+	untilExp := time.Until(exp)
+	if exp.IsZero() {
+		result.Critical("no expires time")
+		return
+	}
+
+	result.Pd(&monitor.PerfDataItem{Name: "expires", Value: untilExp.Seconds(), Unit: "s", Help: "Seconds until expiry"})
+
+	if claims.IsExpired() {
+		result.Critical("expired")
+		return
+	}
+
+	if c.validityMin > 0 {
+		if untilExp < c.validityMin {
+			result.Critical("expires in %v", iu.RenderDuration(untilExp))
+		}
+	}
+
+	if c.validityMax > 0 {
+		if untilExp > c.validityMax {
+			result.Critical("expires in %v", iu.RenderDuration(untilExp))
+		}
+	}
+}
+
+func (c *jwtCheckCommand) checkPurpose(purpose tokens.Purpose, result *monitor.Result) {
+	if c.kind != "" {
+		var should tokens.Purpose
+		switch c.kind {
+		case "client":
+			should = tokens.ClientIDPurpose
+		case "server":
+			should = tokens.ServerPurpose
+		case "provisioning":
+			should = tokens.ProvisioningPurpose
+		}
+		if purpose != should {
+			result.Critical("%s purpose", purpose)
+		}
+	}
+}
+
+func (c *jwtCheckCommand) checkQueries(token any, result *monitor.Result) {
+	for _, query := range c.queries {
+		var claims map[string]any
+
+		// not checking errors, query would fail anyway
+		dat, _ := json.Marshal(token)
+		json.Unmarshal(dat, &claims)
+
+		prog, err := expr.Compile(query, expr.AsBool())
+		if result.CriticalIfErr(err, "invalid query: %s: %v", query, err) {
+			return
+		}
+
+		res, err := expr.Run(prog, claims)
+		if result.CriticalIfErr(err, "invalid query: %s: %v", query, err) {
+			return
+		}
+
+		b, ok := res.(bool)
+		if !ok {
+			result.Critical("query not boolean")
+			return
+		}
+
+		if !b {
+			result.Critical(query)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Freman/eventloghook v0.0.0-20191003051739-e4d803b6b48b
 	github.com/Masterminds/semver v1.5.0
 	github.com/adrg/xdg v0.4.0
-	github.com/antonmedv/expr v1.10.3
+	github.com/antonmedv/expr v1.10.5
 	github.com/awesome-gocui/gocui v1.1.0
 	github.com/brutella/hc v1.2.5
 	github.com/choria-io/appbuilder v0.4.1
@@ -16,10 +16,10 @@ require (
 	github.com/choria-io/tokens v0.0.0-20230118103245-75e1631f856d
 	github.com/cloudevents/sdk-go/v2 v2.13.0
 	github.com/dustin/go-humanize v1.0.1
-	github.com/fatih/color v1.14.0
+	github.com/fatih/color v1.14.1
 	github.com/fatih/structtag v1.2.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/gofrs/uuid v4.3.1+incompatible
+	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
@@ -36,10 +36,11 @@ require (
 	github.com/nats-io/nats.go v1.23.0
 	github.com/nats-io/natscli v0.0.35
 	github.com/onsi/ginkgo/v2 v2.7.0
-	github.com/onsi/gomega v1.25.0
+	github.com/onsi/gomega v1.26.0
 	github.com/open-policy-agent/opa v0.48.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
+	github.com/prometheus/common v0.39.0
 	github.com/robfig/cron v1.2.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
 	github.com/segmentio/ksuid v1.0.4
@@ -112,7 +113,6 @@ require (
 	github.com/oleiade/reflections v1.0.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/common v0.39.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRB
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
-github.com/antonmedv/expr v1.10.3 h1:rBYCeI1OHKtehK51+cwHNfhtui4k3o2U1X/hbD13NNw=
-github.com/antonmedv/expr v1.10.3/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
+github.com/antonmedv/expr v1.10.5 h1:uzMxTbpHpOqV20RrNvBKHGojNwdRpcrgoFtgF4J8xtg=
+github.com/antonmedv/expr v1.10.5/go.mod h1:FPC8iWArxls7axbVLsW+kpg1mz29A1b2M6jt+hZfDkU=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/awesome-gocui/gocui v1.1.0 h1:db2j7yFEoHZjpQFeE2xqiatS8bm1lO3THeLwE6MzOII=
@@ -87,8 +87,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fatih/color v1.14.0 h1:AD//feEuOKJSzxN81txMW47CNX1EW6kMVEPt4lePhtE=
-github.com/fatih/color v1.14.0/go.mod h1:Ywr2WOhTEN4nsWMWU8I8GWIG5z8rhJEa0ukvJDOfSPY=
+github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
+github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
@@ -110,8 +110,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8Wd
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/gofrs/uuid v4.3.1+incompatible h1:0/KbAdpx3UXAx1kEOWHJeOkpbgRFGHVgv+CFIY7dBJI=
-github.com/gofrs/uuid v4.3.1+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
+github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
 github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -258,8 +258,8 @@ github.com/oleiade/reflections v1.0.1 h1:D1XO3LVEYroYskEsoSiGItp9RUxG6jWnCVvrqH0
 github.com/oleiade/reflections v1.0.1/go.mod h1:rdFxbxq4QXVZWj0F+e9jqjDkc7dbp97vkRixKo2JR60=
 github.com/onsi/ginkgo/v2 v2.7.0 h1:/XxtEV3I3Eif/HobnVx9YmJgk8ENdRsuUmM+fLCFNow=
 github.com/onsi/ginkgo/v2 v2.7.0/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
-github.com/onsi/gomega v1.25.0 h1:Vw7br2PCDYijJHSfBOWhov+8cAnUf8MfMaIOV323l6Y=
-github.com/onsi/gomega v1.25.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
+github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
+github.com/onsi/gomega v1.26.0/go.mod h1:r+zV744Re+DiYCIPRlYOTxn0YkOLcAnW8k1xXdMPGhM=
 github.com/open-policy-agent/opa v0.48.0 h1:s2K823yohAUu/HB4MOPWDhBh88JMKQv7uTr6S89fbM0=
 github.com/open-policy-agent/opa v0.48.0/go.mod h1:CsQcksP+qGBxO9oEBj1NnZqKcjgjmTJbRNTzjZB/DXQ=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -430,7 +430,6 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=

--- a/internal/monitor/monitor.go
+++ b/internal/monitor/monitor.go
@@ -1,0 +1,37 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"github.com/xlab/tablewriter"
+)
+
+type Status string
+
+var (
+	OKStatus       Status = "OK"
+	WarningStatus  Status = "WARNING"
+	CriticalStatus Status = "CRITICAL"
+	UnknownStatus  Status = "UNKNOWN"
+)
+
+func newTableWriter(title string) *tablewriter.Table {
+	table := tablewriter.CreateTable()
+	table.UTF8Box()
+	if title != "" {
+		table.AddTitle(title)
+	}
+
+	return table
+}

--- a/internal/monitor/perfdata.go
+++ b/internal/monitor/perfdata.go
@@ -1,0 +1,65 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PerfDataItem struct {
+	Help  string  `json:"-"`
+	Name  string  `json:"name"`
+	Value float64 `json:"value"`
+	Warn  float64 `json:"warning"`
+	Crit  float64 `json:"critical"`
+	Unit  string  `json:"unit,omitempty"`
+}
+
+type PerfData []*PerfDataItem
+
+func (p PerfData) String() string {
+	var res []string
+	for _, i := range p {
+		res = append(res, i.String())
+	}
+
+	return strings.TrimSpace(strings.Join(res, " "))
+}
+
+func (i *PerfDataItem) String() string {
+	valueFmt := "%0.0f"
+	if i.Unit == "s" {
+		valueFmt = "%0.4f"
+	}
+
+	pd := fmt.Sprintf("%s="+valueFmt, i.Name, i.Value)
+	if i.Unit != "" {
+		pd = pd + i.Unit
+	}
+
+	if i.Warn > 0 || i.Crit > 0 {
+		if i.Warn != 0 {
+			pd = fmt.Sprintf("%s;"+valueFmt, pd, i.Warn)
+		} else if i.Crit > 0 {
+			pd = fmt.Sprintf("%s;", pd)
+		}
+
+		if i.Crit != 0 {
+			pd = fmt.Sprintf("%s;"+valueFmt, pd, i.Crit)
+		}
+	}
+
+	return pd
+}

--- a/internal/monitor/result.go
+++ b/internal/monitor/result.go
@@ -1,0 +1,298 @@
+// Copyright 2023 The NATS Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+type RenderFormat int
+
+const (
+	NagiosFormat RenderFormat = iota
+	PrometheusFormat
+	TextFormat
+	JSONFormat
+)
+
+type Result struct {
+	Output       string       `json:"output,omitempty"`
+	Status       Status       `json:"status"`
+	Check        string       `json:"check_suite"`
+	Name         string       `json:"check_name"`
+	Warnings     []string     `json:"warning,omitempty"`
+	Criticals    []string     `json:"critical,omitempty"`
+	OKs          []string     `json:"ok,omitempty"`
+	PerfData     PerfData     `json:"perf_data"`
+	RenderFormat RenderFormat `json:"-"`
+	NameSpace    string       `json:"-"`
+	OutFile      string       `json:"-"`
+}
+
+func (r *Result) Pd(pd ...*PerfDataItem) {
+	r.PerfData = append(r.PerfData, pd...)
+}
+
+func (r *Result) CriticalExit(format string, a ...any) {
+	r.Critical(format, a...)
+	r.GenericExit()
+}
+
+func (r *Result) Critical(format string, a ...any) {
+	r.Criticals = append(r.Criticals, fmt.Sprintf(format, a...))
+}
+
+func (r *Result) Warn(format string, a ...any) {
+	r.Warnings = append(r.Warnings, fmt.Sprintf(format, a...))
+}
+
+func (r *Result) Ok(format string, a ...any) {
+	r.OKs = append(r.OKs, fmt.Sprintf(format, a...))
+}
+
+func (r *Result) CriticalIfErr(err error, format string, a ...any) bool {
+	if err == nil {
+		return false
+	}
+
+	r.CriticalExit(format, a...)
+
+	return true
+}
+
+func (r *Result) nagiosCode() int {
+	switch r.Status {
+	case OKStatus:
+		return 0
+	case WarningStatus:
+		return 1
+	case CriticalStatus:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func (r *Result) exitCode() int {
+	if r.RenderFormat == PrometheusFormat {
+		return 0
+	}
+
+	return r.nagiosCode()
+}
+
+func (r *Result) Exit() {
+	os.Exit(r.exitCode())
+}
+
+func (r *Result) renderHuman() string {
+	buf := bytes.NewBuffer([]byte{})
+
+	fmt.Fprintf(buf, "%s: %s\n\n", r.Name, r.Status)
+
+	table := newTableWriter("")
+	table.AddHeaders("Status", "Message")
+	lines := 0
+	for _, ok := range r.OKs {
+		table.AddRow("OK", ok)
+		lines++
+	}
+	for _, warn := range r.Warnings {
+		table.AddRow("Warning", warn)
+		lines++
+	}
+	for _, crit := range r.Criticals {
+		table.AddRow("Critical", crit)
+		lines++
+	}
+
+	if lines > 0 {
+		fmt.Fprintln(buf, "Status Detail")
+		fmt.Fprintln(buf)
+		fmt.Fprint(buf, table.Render())
+		fmt.Fprintln(buf)
+	}
+
+	table = newTableWriter("")
+	table.AddHeaders("Metric", "Value", "Unit", "Critical Threshold", "Warning Threshold", "Description")
+	lines = 0
+	for _, pd := range r.PerfData {
+		table.AddRow(pd.Name, pd.Value, pd.Unit, pd.Crit, pd.Warn, pd.Help)
+		lines++
+	}
+	if lines > 0 {
+		fmt.Fprintln(buf, "Check Metrics")
+		fmt.Fprintln(buf)
+		fmt.Fprint(buf, table.Render())
+		fmt.Fprintln(buf)
+	}
+
+	return buf.String()
+}
+
+func (r *Result) renderPrometheus() string {
+	if r.Check == "" {
+		r.Check = r.Name
+	}
+
+	registry := prometheus.NewRegistry()
+	prometheus.DefaultRegisterer = registry
+	prometheus.DefaultGatherer = registry
+
+	sname := strings.ReplaceAll(r.Name, `"`, `.`)
+	for _, pd := range r.PerfData {
+		help := fmt.Sprintf("Data about the NATS CLI check %s", r.Check)
+		if pd.Help != "" {
+			help = pd.Help
+		}
+
+		gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: prometheus.BuildFQName(r.NameSpace, r.Check, pd.Name),
+			Help: help,
+		}, []string{"item"})
+		prometheus.MustRegister(gauge)
+		gauge.WithLabelValues(sname).Set(pd.Value)
+	}
+
+	status := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName(r.NameSpace, r.Check, "status_code"),
+		Help: fmt.Sprintf("Nagios compatible status code for %s", r.Check),
+	}, []string{"item", "status"})
+	prometheus.MustRegister(status)
+
+	status.WithLabelValues(sname, string(r.Status)).Set(float64(r.nagiosCode()))
+
+	var buf bytes.Buffer
+
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, mf := range mfs {
+		_, err = expfmt.MetricFamilyToText(&buf, mf)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return buf.String()
+}
+
+func (r *Result) renderJSON() string {
+	res, _ := json.MarshalIndent(r, "", "  ")
+	return string(res)
+}
+
+func (r *Result) renderNagios() string {
+	res := []string{r.Name}
+	for _, c := range r.Criticals {
+		res = append(res, fmt.Sprintf("Crit:%s", c))
+	}
+
+	for _, w := range r.Warnings {
+		res = append(res, fmt.Sprintf("Warn:%s", w))
+	}
+
+	if r.Output != "" {
+		res = append(res, r.Output)
+	} else if len(r.OKs) > 0 {
+		for _, ok := range r.OKs {
+			res = append(res, fmt.Sprintf("OK:%s", ok))
+		}
+	}
+
+	if len(r.PerfData) == 0 {
+		return fmt.Sprintf("%s %s", r.Status, strings.Join(res, " "))
+	} else {
+		return fmt.Sprintf("%s %s | %s", r.Status, strings.Join(res, " "), r.PerfData)
+	}
+}
+
+func (r *Result) String() string {
+	if r.Status == "" {
+		r.Status = UnknownStatus
+	}
+	if r.PerfData == nil {
+		r.PerfData = PerfData{}
+	}
+
+	switch {
+	case len(r.Criticals) > 0:
+		r.Status = CriticalStatus
+	case len(r.Warnings) > 0:
+		r.Status = WarningStatus
+	default:
+		r.Status = OKStatus
+	}
+
+	switch r.RenderFormat {
+	case JSONFormat:
+		return r.renderJSON()
+	case PrometheusFormat:
+		return r.renderPrometheus()
+	case TextFormat:
+		return r.renderHuman()
+	default:
+		return r.renderNagios()
+	}
+}
+
+func (r *Result) GenericExit() {
+	if r.OutFile != "" {
+		f, err := os.CreateTemp(filepath.Dir(r.OutFile), "")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "temp file failed: %s", err)
+			os.Exit(1)
+		}
+		defer os.Remove(f.Name())
+
+		_, err = fmt.Fprintln(f, r.String())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "temp file write failed: %s", err)
+			os.Exit(1)
+		}
+
+		err = f.Close()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "temp file write failed: %s", err)
+			os.Exit(1)
+		}
+
+		err = os.Chmod(f.Name(), 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "temp file mode change failed: %s", err)
+			os.Exit(1)
+		}
+
+		err = os.Rename(f.Name(), r.OutFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "temp file rename failed: %s", err)
+		}
+
+		os.Exit(1)
+	}
+
+	fmt.Println(r.String())
+
+	r.Exit()
+}


### PR DESCRIPTION
This allows checks to be written with arbitrary checks on jwt content along with some choria specific / purpose specific validations:

```
$ choria jwt check client.jwt \
     --purpose client \
     --issuer 514969e316eb4a7146b8066feb6af5dbc05da0965ec57c9d3a7d3299d5d98fec \
     --validity-max=1d \
     --identity up=rip \
     --query 'agents[0]=="*"' \
     --query '!permissions.org_admin' \
     --format text 
Status Detail

╭──────────┬────────────────────────╮
│ Status   │ Message                │
├──────────┼────────────────────────┤
│ Critical │ !permissions.org_admin │
╰──────────┴────────────────────────╯

Check Metrics

╭─────────┬───────┬──────┬────────────────────┬───────────────────┬──────────────────────╮
│ Metric  │ Value │ Unit │ Critical Threshold │ Warning Threshold │ Description          │
├─────────┼───────┼──────┼────────────────────┼───────────────────┼──────────────────────┤
│ expires │ 29.32 │ s    │ 0.00               │ 0.00              │ Seconds until expiry │
╰─────────┴───────┴──────┴────────────────────┴───────────────────┴──────────────────────╯
```

Supports prometheus, json, nagios and text output.
