### PR TITLE
(#1976) Do not connect or initialize config by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 | Date       | Issue | Description                                                                                                        |
 |------------|-------|--------------------------------------------------------------------------------------------------------------------|
+| 2023/02/02 | 1976  | Allow `choria machine run` to be used without a valid Choria install                                               |
+| 2023/02/02 | 1974  | Fix validation of Autonomous Agents that use timer watchers                                                        |
+| 2023/01/26 | 1972  | Create a tool to monitor JWT token health and contents                                                             |
 | 2023/01/23 | 1968  | Improve handling of governors on slow nodes and during critical failures                                           |
 | 2023/01/19 | 1966  | Improve `plugin generate ddl` UX                                                                                   |
 | 2023/01/18 | 1964  | Improve DDL schema validation                                                                                      |

--- a/aagent/machine/machine.go
+++ b/aagent/machine/machine.go
@@ -561,7 +561,7 @@ func (m *Machine) Start(ctx context.Context, wg *sync.WaitGroup) (started chan s
 			}
 		}
 
-		m.Infof(m.MachineName, "Starting Choria Machine %s version %s from %s", m.MachineName, m.MachineVersion, m.directory)
+		m.Infof(m.MachineName, "Starting Choria Machine %s version %s from %s in state %s", m.MachineName, m.MachineVersion, m.directory, m.InitialState)
 
 		err := m.manager.Run(m.ctx, wg)
 		if err != nil {

--- a/aagent/watchers/gossipwatcher/gossip.go
+++ b/aagent/watchers/gossipwatcher/gossip.go
@@ -163,6 +163,11 @@ func (w *Watcher) startGossip() {
 		}
 
 		publish := func() {
+			if !w.ShouldWatch() {
+				return
+			}
+
+			w.Infof("Gossiping while in state %v", w.machine.State())
 			nc, err := w.getConn()
 			if err != nil {
 				w.Errorf("Could not get NATS connection: %v", err)


### PR DESCRIPTION
This enables "choria machine run" to be used in more cases locally without requiring a full working choria setup

Watchers like KV that require network connections will fail with errors logged. To test those a network connection is unavoidable.

Signed-off-by: R.I.Pienaar <rip@devco.net>