### PR TITLE
(#1978) Add --governor to choria jwt server

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: ["1.19", "1.20"]
 
     runs-on: ubuntu-latest
     steps:

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -92,8 +91,6 @@ func NewWithConfig(cfg *config.Config, opts ...Option) (*Framework, error) {
 		mu:     &sync.Mutex{},
 		bi:     BuildInfo(),
 	}
-
-	rand.Seed(time.Now().UnixNano())
 
 	for _, opt := range opts {
 		err := opt(&c)

--- a/cmd/jwt_server.go
+++ b/cmd/jwt_server.go
@@ -31,6 +31,7 @@ type jWTCreateServerCommand struct {
 	service     bool
 	pk          string
 	useVault    bool
+	useGovernor bool
 
 	command
 }
@@ -56,6 +57,7 @@ func (s *jWTCreateServerCommand) Setup() (err error) {
 		s.cmd.Flag("validity", "How long the token should be valid for").Default("8760h").DurationVar(&s.validity)
 		s.cmd.Flag("service", "Indicates that the user can have long validity tokens").UnNegatableBoolVar(&s.service)
 		s.cmd.Flag("vault", "Use Hashicorp Vault to sign the JWT").UnNegatableBoolVar(&s.useVault)
+		s.cmd.Flag("governor", "Allows access to all governors").UnNegatableBoolVar(&s.useGovernor)
 	}
 
 	return nil
@@ -91,6 +93,11 @@ func (s *jWTCreateServerCommand) createJWT() error {
 		Submission:  s.submission,
 		Streams:     s.streamUser,
 		ServiceHost: s.service,
+		Governor:    s.useGovernor,
+	}
+
+	if perms.Governor && !perms.Streams {
+		return fmt.Errorf("cannot set --governor unless --stream-user is also set ")
 	}
 
 	pk, err := hex.DecodeString(s.pk)

--- a/lifecycle/util.go
+++ b/lifecycle/util.go
@@ -5,7 +5,6 @@
 package lifecycle
 
 import (
-	"math/rand"
 	"time"
 
 	"github.com/choria-io/go-choria/internal/util"
@@ -13,10 +12,6 @@ import (
 
 var mockTime int64
 var mockID string
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 func timeStamp() int64 {
 	if mockTime != 0 {

--- a/providers/security/choria/choria_security_test.go
+++ b/providers/security/choria/choria_security_test.go
@@ -40,8 +40,6 @@ var _ = Describe("Providers/Security/Choria", func() {
 	)
 
 	BeforeEach(func() {
-		rand.Seed(time.Now().UnixNano())
-
 		cfg = &Config{}
 		mockCtl = gomock.NewController(GinkgoT())
 		logbuf = gbytes.NewBuffer()


### PR DESCRIPTION
Here we add --governor to the choria jwt server cli. Check if --stream-user is also set otherwise we exit with an error.