### PR TITLE
(#1987) Export SetBuildBasedOnJWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Date       | Issue | Description                                                                                                        |
 |------------|-------|--------------------------------------------------------------------------------------------------------------------|
+| 2023/02/17 | 1987  | Export SetBuildBasedOnJWT in default proftarget plugin
 | 2023/02/15 | 1982  | Ensure multiple AAA Login URLs are parsed correctly                                                                | 
 | 2023/02/14 | 1980  | Correctly detect paths to ed25519 public keys that are 64 characters long as paths                                 |
 | 2023/02/13 | 1978  | Add the `--governor` permission to `choria jwt server`                                                             |

--- a/providers/provtarget/builddefaults/default_test.go
+++ b/providers/provtarget/builddefaults/default_test.go
@@ -22,9 +22,9 @@ func TestDefault(t *testing.T) {
 
 var _ = Describe("Default", func() {
 	var (
-		prov *Resolver
-		td   string
-		err  error
+		td  string
+		err error
+		bi  build.Info
 	)
 
 	createToken := func(claims *tokens.ProvisioningClaims, td string) string {
@@ -41,7 +41,6 @@ var _ = Describe("Default", func() {
 	BeforeEach(func() {
 		td, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
-		prov = &Resolver{}
 	})
 
 	AfterEach(func() {
@@ -51,7 +50,9 @@ var _ = Describe("Default", func() {
 	Describe("Configure", func() {
 		It("Should handle malformed jwt", func() {
 			build.ProvisionJWTFile = "testdata/invalid.jwt"
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).To(MatchError("token contains an invalid number of segments"))
 		})
 
@@ -61,7 +62,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).To(MatchError("no auth token"))
 		})
 
@@ -72,8 +75,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).To(MatchError("no srv domain or urls"))
 
 		})
@@ -87,7 +91,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).To(MatchError("both srv domain and URLs supplied"))
 		})
 
@@ -100,7 +106,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(build.ProvisionBrokerURLs).To(Equal("prov.example.net:4222"))
 			Expect(build.ProvisionBrokerSRVDomain).To(Equal(""))
@@ -118,7 +126,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(build.ProvisionBrokerURLs).To(Equal(""))
 			Expect(build.ProvisionBrokerSRVDomain).To(Equal("example.net"))
@@ -137,7 +147,9 @@ var _ = Describe("Default", func() {
 					Purpose: tokens.ProvisioningPurpose,
 				},
 			}, td)
-			_, err := prov.setBuildBasedOnJWT()
+			reader, _ := os.Open(build.ProvisionJWTFile)
+			defer reader.Close()
+			_, err := SetBuildBasedOnJWT(reader, &bi)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(build.ProvisionBrokerURLs).To(Equal("prov.example.net:4222"))
 			Expect(build.ProvisionBrokerSRVDomain).To(Equal(""))


### PR DESCRIPTION
resolver.setBuildBasedOnJWT is a method that other proftarget plugins often would like to use.

Here we decouple the SetBuildBasedOnJWT method from the resolver struct and export it as a function. To make the function usable outside of the resolver struct we add the target jwt file, build.info and reader function parameters.

Tests have also been updated to use the new function signature.