### PR TITLE
(#1740) improve deny rules for clients with no permissions

### DIFF
--- a/broker/network/choria_auth_test.go
+++ b/broker/network/choria_auth_test.go
@@ -719,7 +719,9 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 					Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
 						Allow: []string{"*.reply.e33bf0376d4accbb4a8fd24b2f840b2e.>"},
 					}))
-					Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
+					Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
+						Deny: allSubjects,
+					}))
 				})
 
 				verified, err := auth.handleDefaultConnection(mockClient, verifiedConn, true, log)
@@ -1917,6 +1919,7 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 				}))
 				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
 					Allow: minPub,
+					Deny:  allSubjects,
 				}))
 			})
 		})
@@ -2008,19 +2011,25 @@ var _ = Describe("Network Broker/ChoriaAuth", func() {
 
 		Describe("Minimal Permissions", func() {
 			It("Should support caller private reply subjects", func() {
+				user.Account = auth.choriaAccount
 				auth.setClientPermissions(user, "u=ginkgo", nil, log)
 				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
 					Allow: []string{"*.reply.0f47cbbd2accc01a51e57261d6e64b8b.>"},
 				}))
-				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
+				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
+					Deny: allSubjects,
+				}))
 			})
 
 			It("Should support standard reply subjects", func() {
+				user.Account = auth.choriaAccount
 				auth.setClientPermissions(user, "", nil, log)
 				Expect(user.Permissions.Subscribe).To(Equal(&server.SubjectPermission{
 					Allow: []string{"*.reply.>"},
 				}))
-				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{}))
+				Expect(user.Permissions.Publish).To(Equal(&server.SubjectPermission{
+					Deny: allSubjects,
+				}))
 			})
 		})
 	})

--- a/integration/suites/broker_auth/broker_auth_test.go
+++ b/integration/suites/broker_auth/broker_auth_test.go
@@ -29,7 +29,7 @@ import (
 // to connect to it, bypass restrictions and more
 func TestBrokerAuthentication(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Broker Authentication")
+	RunSpecs(t, "Integration/Broker Authentication")
 }
 
 var _ = Describe("Authentication", func() {
@@ -385,7 +385,7 @@ var _ = Describe("Authentication", func() {
 				nats.ClientCert(testutil.CertPath("two", "rip.mcollective"), testutil.KeyPath("two", "rip.mcollective")),
 				nats.RootCAs(testutil.CertPath("one", "ca")),
 			)
-			Eventually(logbuff, 5).Should(gbytes.Say("failed to verify client certificate: x509: certificate signed by unknown authority"))
+			Eventually(logbuff, 5).Should(gbytes.Say("failed to verify.+certificate: x509: certificate signed by unknown authority"))
 			Expect(err).To(MatchError("remote error: tls: bad certificate"))
 			Expect(nc).To(BeNil())
 			Expect(logbuff).ToNot(gbytes.Say("Registering user"))

--- a/integration/suites/broker_mappings/broker_mappings_test.go
+++ b/integration/suites/broker_mappings/broker_mappings_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestBrokerRemapping(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Broker Remapping")
+	RunSpecs(t, "Integration/Broker Remapping")
 }
 
 var _ = Describe("Authentication", func() {

--- a/integration/suites/harness/agent_test.go
+++ b/integration/suites/harness/agent_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestAgentHarnessAgent(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "agent testing harness")
+	RunSpecs(t, "Integration/Agent Testing Harness")
 }
 
 var _ = Describe("testing harness agent", func() {

--- a/integration/suites/leafnodes/leafnodes_test.go
+++ b/integration/suites/leafnodes/leafnodes_test.go
@@ -25,7 +25,7 @@ import (
 // TestBrokerLeafnode tests leafnode connections especially as relates to new auth behavior
 func TestBrokerLeafnode(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Leafnodes")
+	RunSpecs(t, "Integration/Leafnodes")
 }
 
 var _ = Describe("Leafnodes", func() {

--- a/integration/suites/protov2/v2_test.go
+++ b/integration/suites/protov2/v2_test.go
@@ -37,7 +37,7 @@ type remoteSignerFunc func(context.Context, []byte, inter.RequestSignerConfig) (
 
 func TestV2Protocol(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Protocol V2")
+	RunSpecs(t, "Integration/Protocol V2")
 }
 
 var _ = Describe("Protocol V2", func() {
@@ -266,7 +266,9 @@ var _ = Describe("Protocol V2", func() {
 
 			Eventually(clientLogbuff).Should(gbytes.Say("Setting JWT authentication with NONCE signatures for NATS connection"))
 			Eventually(clientLogbuff).Should(gbytes.Say("Signing nonce using seed file"))
-			Eventually(serverLogbuff).Should(gbytes.Say("access denied: does not have fleet management access"))
+
+			// without fleet access one cannot communicate with the signer even so this should fail
+			Eventually(brokerLogBuff).Should(gbytes.Say(`Publish Violation.+choria.node.srv-1.example.net`))
 
 			// second we allow it only when signed, and we're not signing here
 			clientLogbuff, client, _, _ = createRpcUtilClient(&tokens.ClientPermissions{SignedFleetManagement: true}, "", nil)

--- a/integration/suites/rpcutil/rpcutil_test.go
+++ b/integration/suites/rpcutil/rpcutil_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestRPCUtilAgent(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "rpcutil agent")
+	RunSpecs(t, "Integration/rpcutil Agent")
 }
 
 var _ = Describe("rpcutil agent", func() {


### PR DESCRIPTION
For clients with no permissions set today we have
a open publish ruleset with no allow or deny, this ensures we deny all when that is the intention.