### PR TITLE
(#2019) support relocating agents at runtime

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -284,28 +284,24 @@ func StrToBool(s string) (bool, error) {
 
 func FileIsRegular(path string) bool {
 	stat, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 
-	if !stat.Mode().IsRegular() {
-		return false
-	}
-
-	return true
+	return stat.Mode().IsRegular()
 }
 
 func FileIsDir(path string) bool {
+	if path == "" {
+		return false
+	}
+
 	stat, err := os.Stat(path)
-	if os.IsNotExist(err) {
+	if err != nil {
 		return false
 	}
 
-	if !stat.IsDir() {
-		return false
-	}
-
-	return true
+	return stat.IsDir()
 }
 
 func UniqueStrings(items []string, shouldSort bool) []string {

--- a/providers/agent/mcorpc/external/provider_test.go
+++ b/providers/agent/mcorpc/external/provider_test.go
@@ -7,21 +7,22 @@ package external
 import (
 	"bytes"
 	"context"
-	"github.com/choria-io/go-choria/server/agents"
-	"github.com/onsi/gomega/gbytes"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/sirupsen/logrus"
 
 	"github.com/choria-io/go-choria/build"
 	"github.com/choria-io/go-choria/config"
 	imock "github.com/choria-io/go-choria/inter/imocks"
 	addl "github.com/choria-io/go-choria/providers/agent/mcorpc/ddl/agent"
 	"github.com/choria-io/go-choria/server"
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/choria-io/go-choria/server/agents"
 )
 
 var _ = Describe("McoRPC/External", func() {


### PR DESCRIPTION
Also fixes a panic in util when checking path related errors.

Also adjusts when recently modified ddls are excxluded so that they are not considered orphaned and removed before being added again on next reconcile