### PR TITLE
(#2029) Allow target for machines manager to be set

### DIFF
--- a/integration/suites/broker_auth/broker_auth_test.go
+++ b/integration/suites/broker_auth/broker_auth_test.go
@@ -362,7 +362,7 @@ var _ = Describe("Authentication", func() {
 		})
 	})
 
-	Describe("mTLS Connections", FlakeAttempts(3), func() {
+	Describe("mTLS Connections", FlakeAttempts(5), func() {
 		BeforeEach(func() {
 			_, err := testbroker.StartNetworkBrokerWithConfigFile(ctx, &wg, "testdata/mtls.conf", logger)
 			Expect(err).ToNot(HaveOccurred())

--- a/providers/agent/mcorpc/external/agent.go
+++ b/providers/agent/mcorpc/external/agent.go
@@ -95,11 +95,15 @@ func (p *Provider) agentPath(name string, dir string) string {
 
 	agentNameOrDir := filepath.Join(base, name)
 
-	if !util.FileIsDir(agentNameOrDir) {
+	if util.FileIsRegular(agentNameOrDir) {
+		p.log.Debugf("Using %s as path to agent binary", agentNameOrDir)
 		return agentNameOrDir
 	}
 
-	return filepath.Join(agentNameOrDir, fmt.Sprintf("%s-%s_%s", name, runtime.GOOS, runtime.GOARCH))
+	agentNameOrDir = filepath.Join(agentNameOrDir, fmt.Sprintf("%s-%s_%s", name, runtime.GOOS, runtime.GOARCH))
+	p.log.Debugf("Using %s as path to agent binary", agentNameOrDir)
+
+	return agentNameOrDir
 }
 
 func (p *Provider) externalActivationCheck(ddl *agentddl.DDL) (mcorpc.ActivationChecker, error) {
@@ -157,7 +161,7 @@ func (p *Provider) externalAction(ctx context.Context, req *mcorpc.Request, repl
 
 	agentPath := p.agentPath(agent.Metadata().Name, ddlpath)
 	if agentPath == "" || !util.FileExist(agentPath) {
-		p.abortAction(fmt.Sprintf("Cannot call external agent %s: agent executable %s was not found", action, agentPath), agent, reply)
+		p.abortAction(fmt.Sprintf("Cannot call external agent %s: agent executable was not found", action), agent, reply)
 		return
 	}
 	agent.Log.Debugf("Attempting to call external agent %s (%s) with a timeout %d", action, agentPath, agent.Metadata().Timeout)

--- a/providers/agent/mcorpc/external/agent_test.go
+++ b/providers/agent/mcorpc/external/agent_test.go
@@ -218,7 +218,7 @@ var _ = Describe("McoRPC/External", func() {
 			}
 
 			prov.externalAction(ctx, req, rep, agent, nil)
-			Expect(rep.Statusmsg).To(MatchRegexp("Cannot call.+ginkgo_missing#ping.+ginkgo_missing was not found"))
+			Expect(rep.Statusmsg).To(MatchRegexp("Cannot call.+ginkgo_missing#ping.+agent executable was not found"))
 			Expect(rep.Statuscode).To(Equal(mcorpc.Aborted))
 		})
 

--- a/providers/agent/mcorpc/external/provider.go
+++ b/providers/agent/mcorpc/external/provider.go
@@ -277,6 +277,10 @@ func (p *Provider) eachAgent(cb func(ddl *agent.DDL)) {
 			// either x.json or x in the case of a directory holding a ddl
 			fname := info.Name()
 
+			if fname == "tmp" {
+				return retErr
+			}
+
 			// full path, which in the case of a directory holding a ddl will be adjusted to the nested one
 			ddlPath := path
 


### PR DESCRIPTION
This essentially makes machines manager generic so it can manage anything but we have a few other improvements to make, for example to allow a machine and agent with the same name.

Also a few other random improvements