### PR TITLE
(#2029) allow the name of generated agents to be customised

### DIFF
--- a/aagent/watchers/machineswatcher/machine.yaml
+++ b/aagent/watchers/machineswatcher/machine.yaml
@@ -1,4 +1,4 @@
-name: "mm_{{ .Name }}"
+name: "{{ .NamePrefix }}_{{ .Name }}"
 version: 1.0.0
 initial_state: MANAGE
 
@@ -18,12 +18,12 @@ watchers:
     state_match:
       - MANAGE
     properties:
-      source: "{{.Source}}"
       checksum: "{{ .ArchiveChecksum }}"
-      verify: "SHA256SUMS"
-      verify_checksum: "{{ .ContentChecksumsChecksum }}"
       creates: "{{ .Name }}"
+      governor: "{{ .Governor }}"
+      password: "{{ .Password }}"
+      source: "{{.Source}}"
       target: "{{ .Target }}"
       username: "{{ .Username }}"
-      password: "{{ .Password }}"
-      governor: "{{ .Governor }}"
+      verify: "SHA256SUMS"
+      verify_checksum: "{{ .ContentChecksumsChecksum }}"


### PR DESCRIPTION
This to avoid clashes between machines managers and agent managers