### PR TITLE
(#2029) Extract some common code and reuse in CLI

### DIFF
--- a/aagent/watchers/pluginswatcher/plugins.go
+++ b/aagent/watchers/pluginswatcher/plugins.go
@@ -54,11 +54,6 @@ var stateNames = map[State]string{
 	Unchanged: "unchanged",
 }
 
-type Specification struct {
-	Plugins   []byte `json:"plugins"`
-	Signature string `json:"signature,omitempty"`
-}
-
 type ManagedPlugin struct {
 	Name                     string `json:"name" yaml:"name"`
 	NamePrefix               string `json:"-" yaml:"-"`
@@ -253,7 +248,7 @@ func (w *Watcher) watch(ctx context.Context) (state State, err error) {
 			}
 		}
 
-		w.Warnf("Deploying Choria Autonomous Agent %s from %s", m.Name, m.Source)
+		w.Warnf("Deploying plugin %s from %s info %s", m.Name, m.Source, targetDir)
 
 		err = os.MkdirAll(targetDir, 0700)
 		if err != nil {

--- a/aagent/watchers/pluginswatcher/specification.go
+++ b/aagent/watchers/pluginswatcher/specification.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package machines
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+
+	iu "github.com/choria-io/go-choria/internal/util"
+)
+
+// Specification holds []ManagedPlugin marshaled to JSON with an optional ed25519 signature
+type Specification struct {
+	Plugins   []byte `json:"plugins"`
+	Signature string `json:"signature,omitempty"`
+}
+
+// Encode sets the signature and Marshals the specification to JSON, if key is empty signature is not made
+func (s *Specification) Encode(key string) ([]byte, error) {
+	var pk ed25519.PrivateKey
+	var err error
+
+	data, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if key != "" {
+		if iu.IsEncodedEd25519KeyString(key) {
+			pk, err = hex.DecodeString(key)
+		} else {
+			_, pk, err = iu.Ed25519KeyPairFromSeedFile(key)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		sig, err := iu.Ed25519Sign(pk, data)
+		if err != nil {
+			return nil, err
+		}
+
+		s.Signature = hex.EncodeToString(sig)
+	}
+
+	return json.Marshal(s)
+}

--- a/broker/network/choria_auth.go
+++ b/broker/network/choria_auth.go
@@ -663,7 +663,7 @@ func (a *ChoriaAuth) cachedEd25519Token(token string) (ed25519.PublicKey, error)
 func (a *ChoriaAuth) parseServerJWTWithSigners(jwts string) (claims *tokens.ServerClaims, err error) {
 	for _, s := range a.serverJwtSigners {
 		// its a token
-		if tokens.IsEncodedEd25519Key([]byte(s)) {
+		if util.IsEncodedEd25519KeyString(s) {
 			var pk ed25519.PublicKey
 			pk, err = a.cachedEd25519Token(s)
 			if err != nil {
@@ -765,7 +765,7 @@ func (a *ChoriaAuth) parseServerJWT(jwts string) (claims *tokens.ServerClaims, e
 func (a *ChoriaAuth) parseClientJWTWithSigners(jwts string) (claims *tokens.ClientIDClaims, err error) {
 	for _, s := range a.clientJwtSigners {
 		// its a token
-		if tokens.IsEncodedEd25519Key([]byte(s)) {
+		if util.IsEncodedEd25519KeyString(s) {
 			var pk ed25519.PublicKey
 			pk, err = a.cachedEd25519Token(s)
 			if err != nil {

--- a/cmd/machine_plugins.go
+++ b/cmd/machine_plugins.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2023, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"sync"
+)
+
+type machinePluginsCommand struct {
+	command
+}
+
+func (p *machinePluginsCommand) Setup() (err error) {
+	if machine, ok := cmdWithFullCommand("machine"); ok {
+		p.cmd = machine.Cmd().Command("plugins", "Manage specifications for the plugins watcher")
+	}
+	return nil
+}
+
+func (p *machinePluginsCommand) Configure() error {
+	return nil
+}
+
+func (p *machinePluginsCommand) Run(wg *sync.WaitGroup) (err error) {
+	defer wg.Done()
+
+	return nil
+}
+
+func init() {
+	cli.commands = append(cli.commands, &machinePluginsCommand{})
+}

--- a/internal/util/ed25519.go
+++ b/internal/util/ed25519.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+
+	"github.com/choria-io/tokens"
 )
 
 func Ed25519SignWithSeedFile(f string, msg []byte) ([]byte, error) {
@@ -77,4 +79,12 @@ func Ed25519KeyPairToFile(f string) (ed25519.PublicKey, ed25519.PrivateKey, erro
 	}
 
 	return pubK, priK, nil
+}
+
+func IsEncodedEd25519Key(k []byte) bool {
+	return tokens.IsEncodedEd25519Key(k)
+}
+
+func IsEncodedEd25519KeyString(k string) bool {
+	return tokens.IsEncodedEd25519Key([]byte(k))
 }


### PR DESCRIPTION
Also improve the plugins pack cli.

The external agents provider will check frequently at first for new agents then settle into a 30s kind of interval, with jitter.  This optimise bootup to deliver agents quickly but with a more relaxed settled state