### PR TITLE
(#2057) Avoid calling the nats in process provider to test if it exists

### DIFF
--- a/broker/network/choria_auth.go
+++ b/broker/network/choria_auth.go
@@ -95,7 +95,8 @@ func (a *ChoriaAuth) Check(c server.ClientAuthentication) bool {
 		tlsVerified = len(tlsc.VerifiedChains) > 0
 	}
 
-	if a.isTLS && tlsc == nil {
+	// no tls over pipes
+	if !pipeConnection && a.isTLS && tlsc == nil {
 		a.log.Warnf("Did not receive TLS Connection State for connection %s, rejecting", remote)
 		return false
 	}

--- a/choria/connection.go
+++ b/choria/connection.go
@@ -147,7 +147,7 @@ func (fw *Framework) NewConnector(ctx context.Context, servers func() (srvcache.
 		ctx:               ctx,
 	}
 
-	prov, _ := conn.fw.InProcessConn()
+	prov := conn.fw.InProcessConnProvider()
 	conn.ipc = prov != nil
 
 	if !conn.ipc && conn.isJwtAuth() {
@@ -682,8 +682,8 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 	switch {
 	case conn.ipc:
 		conn.log.Warnf("Using in-process connection to connect to NATS")
-		options = append(options, nats.InProcessServer(conn.fw))
-		options = append(options, nats.Secure(conn.anonTLSc()))
+		options = append(options, nats.InProcessServer(conn.fw.InProcessConnProvider()))
+		tlsc = conn.anonTLSc()
 
 	case conn.fw.ProvisionMode():
 		if util.FileExist(conn.fw.bi.ProvisionJWTFile()) {

--- a/choria/framework.go
+++ b/choria/framework.go
@@ -125,17 +125,12 @@ func (fw *Framework) SetInProcessConnProvider(p nats.InProcessConnProvider) {
 	fw.mu.Unlock()
 }
 
-// InProcessConn provides an in-process connection for nats if configured using SetInProcessConnProvider()
-func (fw *Framework) InProcessConn() (net.Conn, error) {
+// InProcessConnProvider provides an in-process connection for nats if configured using SetInProcessConnProvider(), nil when not set
+func (fw *Framework) InProcessConnProvider() nats.InProcessConnProvider {
 	fw.mu.Lock()
-	ipc := fw.inProcessConnection
-	fw.mu.Unlock()
+	defer fw.mu.Unlock()
 
-	if ipc == nil {
-		return nil, fmt.Errorf("invalid connection")
-	}
-
-	return ipc.InProcessConn()
+	return fw.inProcessConnection
 }
 
 // BuildInfo retrieves build information

--- a/cmd/broker_run.go
+++ b/cmd/broker_run.go
@@ -119,7 +119,13 @@ func (r *brokerRunCommand) Run(wg *sync.WaitGroup) (err error) {
 func (r *brokerRunCommand) runAdapters(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	fw, err := choria.New(cfg.ConfigFile)
+	cfg, err := config.NewSystemConfig(cfg.ConfigFile, true)
+	if err != nil {
+		log.Errorf("Failed to configure Protocol Adapters: %v", err)
+		return
+	}
+
+	fw, err := choria.NewWithConfig(cfg)
 	if err != nil {
 		log.Errorf("Failed to run Protocol Adapters: %v", err)
 		return


### PR DESCRIPTION
We would call InProcessConn() and then check if its nil to determine if the feature was enabled then later we would call again to create the connection.

Problem is this first call actually made a client in the server but we never attached a client to it on the other side so eventually it would be detected as dead and discarded.  The real connection would continue to work as normal.

This would log a bunch of slow consumer errors etc that was hard to debug, we fix this now by checking if the provider was set rather than calling it