### PR TITLE
(#2076) Add plugin.nats.connect_timeout / MCOLLECTIVE_NATS_CONNECT_TIMEOUT option

### DIFF
--- a/choria/connection.go
+++ b/choria/connection.go
@@ -751,6 +751,9 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 		options = append(options, nats.UserCredentials(conn.config.Choria.NatsCredentials))
 	}
 
+	conn.log.Warnf("Setting NATS connect timeout to %v", conn.config.Choria.NatsConnectTimeout)
+	options = append(options, nats.Timeout(conn.config.Choria.NatsConnectTimeout))
+
 	return backoff.Default.For(ctx, func(try int) error {
 		servers, err := conn.servers()
 		if err != nil {

--- a/choria/connection.go
+++ b/choria/connection.go
@@ -751,7 +751,7 @@ func (conn *Connection) Connect(ctx context.Context) (err error) {
 		options = append(options, nats.UserCredentials(conn.config.Choria.NatsCredentials))
 	}
 
-	conn.log.Warnf("Setting NATS connect timeout to %v", conn.config.Choria.NatsConnectTimeout)
+	conn.log.Infof("Setting NATS connect timeout to %v", conn.config.Choria.NatsConnectTimeout)
 	options = append(options, nats.Timeout(conn.config.Choria.NatsConnectTimeout))
 
 	return backoff.Default.For(ctx, func(try int) error {

--- a/config/choria.go
+++ b/config/choria.go
@@ -39,10 +39,11 @@ type ChoriaPluginConfig struct {
 	StatsPort             int    `confkey:"plugin.choria.stats_port" default:"0"`              // The port to listen on for HTTP requests for statistics, setting to 0 disables it
 	LegacyLifeCycleFormat bool   `confkey:"plugin.choria.legacy_lifecycle_format" default:"0"` // When enabled will publish lifecycle events in the legacy format, else Cloud Events format is used
 
-	NatsUser        string   `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`           // The user to connect to the NATS server as. When unset no username is used.
-	NatsPass        string   `confkey:"plugin.nats.pass" environment:"MCOLLECTIVE_NATS_PASSWORD"`           // The password to use when connecting to the NATS server
-	NatsCredentials string   `confkey:"plugin.nats.credentials" environment:"MCOLLECTIVE_NATS_CREDENTIALS"` // The NATS 2.0 credentials to use, required for accessing NGS
-	MiddlewareHosts []string `confkey:"plugin.choria.middleware_hosts" type:"comma_split"`                  // Set specific middleware hosts in the format host:port, if unset uses SRV
+	NatsUser           string          `confkey:"plugin.nats.user" environment:"MCOLLECTIVE_NATS_USERNAME"`                                                 // The user to connect to the NATS server as. When unset no username is used.
+	NatsPass           string          `confkey:"plugin.nats.pass" environment:"MCOLLECTIVE_NATS_PASSWORD"`                                                 // The password to use when connecting to the NATS server
+	NatsCredentials    string          `confkey:"plugin.nats.credentials" environment:"MCOLLECTIVE_NATS_CREDENTIALS"`                                       // The NATS 2.0 credentials to use, required for accessing NGS
+	NatsConnectTimeout time.Duration   `confkey:"plugin.nats.connect_timeout" default:"2s" type:"duration" environment:"MCOLLECTIVE_NATS_CONNECT_TIMEOUT"`  // The NATS 2.0 connect timeout
+	MiddlewareHosts    []string        `confkey:"plugin.choria.middleware_hosts" type:"comma_split"`                                                        // Set specific middleware hosts in the format host:port, if unset uses SRV
 
 	NetworkAllowedClientHosts          []string      `confkey:"plugin.choria.network.client_hosts" type:"comma_split"`                                             // CIDRs to limit client connections from, appropriate ACLs are added based on this
 	NetworkClientAdvertiseName         string        `confkey:"plugin.choria.network.public_url"`                                                                  // Name:Port to advertise to clients, useful when fronted by a proxy


### PR DESCRIPTION
Added to support choria servers connecting to a broker cluster which takes a long time to establish a connection, greater than the NATS default of 2 seconds.  Accepts a duration as a parameter, but will apply the default value if none is specified.