### PR TITLE
(#2077) Support setting audit log group and mode

### DIFF
--- a/providers/agent/mcorpc/audit/choria_test_unix.go
+++ b/providers/agent/mcorpc/audit/choria_test_unix.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//go:build !windows
+// +build !windows
+
+package audit
+
+import (
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+
+	"github.com/onsi/gomega"
+)
+
+func checkFileGid(stat os.FileInfo, group string) {
+	gid := stat.Sys().(*syscall.Stat_t).Gid
+	grp, err := user.LookupGroup(group)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	expectedGid, err := strconv.Atoi(grp.Gid)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+	gomega.Expect(int(gid)).To(gomega.Equal(int(expectedGid)))
+}

--- a/providers/agent/mcorpc/audit/choria_test_windows.go
+++ b/providers/agent/mcorpc/audit/choria_test_windows.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2020-2021, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//go:build windows
+// +build windows
+
+package audit
+
+import (
+	"os"
+)
+
+func checkFileGid(stat os.FileInfo, group string) {}

--- a/providers/agent/mcorpc/audit/testdata/audit-group-mode.cfg
+++ b/providers/agent/mcorpc/audit/testdata/audit-group-mode.cfg
@@ -1,0 +1,4 @@
+rpcaudit = 1
+plugin.rpcaudit.logfile = /tmp/rpc_audit.log
+plugin.rpcaudit.logfile.group = adm
+plugin.rpcaudit.logfile.mode = 0640


### PR DESCRIPTION
Allows tools like Splunk Forwarder or Vector to access the audit log without elevated privileges such as running as root
Fixes #2077