### PR TITLE
(#2110) Adds a provisioner lock held for the first caller

### DIFF
--- a/providers/agent/mcorpc/golang/provision/jwt_action.go
+++ b/providers/agent/mcorpc/golang/provision/jwt_action.go
@@ -25,6 +25,9 @@ type JWTReply struct {
 }
 
 func jwtAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn inter.ConnectorInfo) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if !agent.Choria.ProvisionMode() {
 		abort("Cannot reconfigure a server that is not in provisioning mode", reply)
 		return
@@ -54,9 +57,6 @@ func jwtAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, ag
 		abort(fmt.Sprintf("Could not read Provisioning JWT: %s", err), reply)
 		return
 	}
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	err = updateECDHLocked()
 	if err != nil {

--- a/providers/agent/mcorpc/golang/provision/release_update_action.go
+++ b/providers/agent/mcorpc/golang/provision/release_update_action.go
@@ -24,6 +24,9 @@ type ReleaseUpdateRequest struct {
 var updaterf func(...updater.Option) error
 
 func releaseUpdateAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc.Reply, agent *mcorpc.Agent, conn inter.ConnectorInfo) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if !agent.Choria.ProvisionMode() {
 		abort("Cannot update a server that is not in provisioning mode", reply)
 		return
@@ -33,9 +36,6 @@ func releaseUpdateAction(ctx context.Context, req *mcorpc.Request, reply *mcorpc
 		abort("Version updates is not enabled in the configuration", reply)
 		return
 	}
-
-	mu.Lock()
-	defer mu.Unlock()
 
 	args := ReleaseUpdateRequest{}
 	if !mcorpc.ParseRequestData(&args, req, reply) {


### PR DESCRIPTION
This will allow for active-active provisioners and ensure only one will be responsible for the node without state sharing in the provisioner side or elections