### PR TITLE
(#2133) Prepare the gossip service discovery system for nats 2.11

### DIFF
--- a/aagent/watchers/gossipwatcher/gossip_test.go
+++ b/aagent/watchers/gossipwatcher/gossip_test.go
@@ -73,21 +73,33 @@ var _ = Describe("ExecWatcher", func() {
 					"ip":       "192.168.1.1",
 					"port":     8080,
 					"priority": 1,
+					"annotations": map[string]string{
+						"test": "annotation",
+					},
 				},
 			}
 
+			stubUUID = "fakeuuid"
+
 			watch.properties = nil
 			Expect(watch.setProperties(prop)).To(Succeed())
-			Expect(watch.properties.Registration).To(Equal(&registration{
+			Expect(watch.properties.Registration).To(Equal(&Registration{
 				Cluster:  "lon",
 				Service:  "ginkgo",
 				Protocol: "http",
 				IP:       "192.168.1.1",
 				Port:     8080,
 				Priority: 1,
+				Annotations: map[string]string{
+					"test": "annotation",
+				},
 			}))
 
-			Expect(watch.properties.Subject).To(Equal("choria.hoist.lon.ginkgo.member.http.192.168.1.1.P.8080.1"))
+			rj, err := json.Marshal(watch.properties.Registration)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(watch.properties.Subject).To(Equal("$KV.CHORIA_SERVICES.lon.http.ginkgo.fakeuuid"))
+			Expect(watch.properties.Payload).To(Equal(string(rj)))
 		})
 
 		It("Should handle errors", func() {


### PR DESCRIPTION
We previously attempted to build a service discovery system in a KV bucket but we really wanted reads to be a single API call.  So we did what other systems like etcd suggest and crammed it all in the key name.

This is restrictive and annoying, but in nats 2.11 we will be able to do a direct get on a kv bucket that will return many matching values in a single API call, this means we can now improve our registration and add some adhoc data to it

So this adds annotations to the payload and simplify the subjects being published moving the meat of it into the message payload instead.