### PR TITLE
Fix config load when HOME="/"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -410,7 +410,7 @@ func (c *Config) UnParsedOptions() map[string]string {
 func (c *Config) dotdDir() string {
 	if !forceDotParse {
 		home, err := iu.HomeDir()
-		if err == nil {
+		if err == nil && home != "/" {
 			if strings.HasPrefix(c.ConfigFile, home) {
 				return ""
 			}


### PR DESCRIPTION
There is an issue i found on FreeBSD systems with starting choria-server via "service choria-server start" command causing global configuration doesn`t load. Same problem occur after OS reboot. Moreover i discover that starting via /usr/local/etc/rc.d/choria-server work properly.
Problem is with env HOME set to "/" when starting with service command ( rc.d set HOME="/root" ).

There is an issue with logic discovering local "home" configuration that prevent global configs to load.
Matching $HOME as prefix to config path when $HOME is "/" will always be true preventing to load global configs - as a quick fix i propose to make an exception for that.