### PR TITLE
(#2173) Load plugins configuration from the system directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,9 @@ type Config struct {
 	// ConfigFile is the main configuration that got parsed
 	ConfigFile string
 
+	// The system-wide configuration directory. Plugins are loaded from there
+	SystemConfigDirectory string
+
 	// ParsedFiles is a list of all files parsed to create the current config
 	ParsedFiles []string
 
@@ -408,23 +411,24 @@ func (c *Config) UnParsedOptions() map[string]string {
 }
 
 func (c *Config) dotdDir() string {
-	if !forceDotParse {
-		home, err := iu.HomeDir()
-		if err == nil {
-			if strings.HasPrefix(c.ConfigFile, home) {
-				return ""
-			}
-		}
-	}
-
-	return filepath.Join(filepath.Dir(c.ConfigFile), "plugin.d")
+	return filepath.Join(c.SystemConfigDirectory, "plugin.d")
 }
 
 func newConfig() *Config {
+	scd := ""
+	if iu.FileExist("/etc/choria") {
+		scd = "/etc/choria"
+	} else if iu.FileExist("/usr/local/etc/choria") {
+		scd = "/usr/local/etc/choria"
+	} else if iu.FileExist("C:\\ProgramData\\choria\\etc") {
+		scd = "C:\\ProgramData\\choria\\etc"
+	}
+
 	m := &Config{
-		Choria:  newChoria(),
-		rawOpts: make(map[string]string),
-		Puppet:  puppet.New(),
+		Choria:                newChoria(),
+		rawOpts:               make(map[string]string),
+		Puppet:                puppet.New(),
+		SystemConfigDirectory: scd,
 	}
 
 	err := confkey.SetStructDefaults(m)


### PR DESCRIPTION
Some plugins need to load configuration that is managed system-wide by Puppet even when the user is using their own configuration file. Regardless of the configuration file loaded (system one or user one), we want to load these plugins configuration from the system.

We previously inferred the plugins configuration directory relatively to the rest of the configuration, but ignored it if it was located in the user HOME directory.  This was not correct, and even caused more trouble when the HOME environment variable was '/' as it is commonly on some systems for services, because plugins configuration was never loaded on these systems.

Fix this by detecting the location of the system configuration and unconditionally loading plugins configuration from this directory.
