### PR TITLE
(#2275) add check for expired token on boot and put node in provisioning mode if it's true

### DIFF
--- a/cmd/server_run.go
+++ b/cmd/server_run.go
@@ -166,6 +166,11 @@ func (r *serverRunCommand) shouldProvisionTokenAndSeed(tokenFile string, seedFil
 		return true
 	}
 
+	if token.IsExpired() {
+		log.Warnf("The existing server token %s is expired, reprovisioning", tokenFile)
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
Added a simple check to see if a token is expired when a node runs through it's 'shouldProvision' checks on bootup. 

An example of some testing I did to validate the change worked as expected:

 Shut down node

```
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="Shutting down on terminated"
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="facts#gather_facts: Stopping on context interrupt" component=machine
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="check_choria#check: Stopping on context interrupt" component=machine
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="facts#maintenance_timeout: Stopping on context interrupt" component=machine
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="Request processor existing on interrupt" component=server identity=9dbac88c13eb.choria.local
server.choria-1       | time="2025-09-25T09:20:42Z" level=info msg="Setting forced shutdown to 2s"
```

 New logic to reprovision on expired token:

```
server.choria-1       | time="2025-09-25T09:20:52Z" level=warning msg="The existing token is currently expired. reprovisioning"
server.choria-1       | time="2025-09-25T09:20:52Z" level=warning msg="Switching to provisioning configuration due to build defaults and server.provision configuration setting"
server.choria-1       | time="2025-09-25T09:20:52Z" level=info msg="Setting build defaults to those found in /etc/choria/provisioning.jwt" component=provtarget
```

 Provisioner kicks in - I overwrote the default of 1 hour for testing

```
{"component":"hosts","level":"info","msg":"Adding 9dbac88c13eb.choria.local to the provision list after receiving an event","time":"2025-09-25T09:27:05Z"}
{"component":"hosts","level":"info","msg":"Provisioning 9dbac88c13eb.choria.local","time":"2025-09-25T09:27:05Z"}
{"component":"9dbac88c13eb.choria.local","level":"debug","msg":"Trying action choria_provision#jwt try 1/3","time":"2025-09-25T09:27:05Z"}
{"component":"9dbac88c13eb.choria.local","level":"info","msg":"Fetching JWT","time":"2025-09-25T09:27:05Z"}
{"component":"9dbac88c13eb.choria.local","level":"debug","msg":"Invoking choria_provision#jwt action with map[string]interface {}{\"token\":\"s3cret\"}","time":"2025-09-25T09:27:05Z"}
{"component":"rpc","level":"debug","msg":"Performing batched request 0 for 1/1 nodes","time":"2025-09-25T09:27:05Z"}
```

 Node restarted and provisioned

```
server.choria-1       | time="2025-09-25T09:20:55Z" level=info msg="Choria Server version 0.0.999 starting with config /etc/choria/server.conf using protocol version 2"
server.choria-1       | time="2025-09-25T09:20:55Z" level=info msg="Setting JWT token and unique reply queues based on JWT for \"9dbac88c13eb.choria.local\" (valid for 4m57.223808468s)" component=server connection=9dbac88c13eb.choria.local identity=9dbac88c13eb.choria.local jwtAuth=true
```