### PR TITLE
(misc) Add consistent syslog logging identifer

### DIFF
--- a/packager/templates/debian/generic/server.service
+++ b/packager/templates/debian/generic/server.service
@@ -3,6 +3,7 @@ Description=The Choria Orchestrator Server
 After=network.target
 
 [Service]
+SyslogIdentifier=choria-server
 User=root
 Group=root
 ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf

--- a/packager/templates/el/generic/server.service
+++ b/packager/templates/el/generic/server.service
@@ -3,6 +3,7 @@ Description=The Choria Orchestrator Server
 After=network.target
 
 [Service]
+SyslogIdentifier=choria-server
 EnvironmentFile=/etc/sysconfig/{{cpkg_name}}-server
 User=root
 Group=root


### PR DESCRIPTION
Previously, the server on EL logged like this into the systemd journal:

```
$ journalctl --unit choria-broker --no-hostname
Mai 17 12:09:02 sh[106359]: time="2026-05-17T12:09:02+02:00" level=info msg="Activated Data provider machine_state" component=data_manager
```

The systemd unit starts /bin/sh and systemd uses the binary name as identifer. Since `sh` isn't very helpful in the logs, we can set it explicitly.

Now it looks like this on all platforms:

```
Mai 17 12:09:02 choria-broker[106359]: time="2026-05-17T12:09:02+02:00" level=info msg="Activated Data provider machine_state" component=data_manager
```