### PR TITLE
(misc) Debian: Add  option to prefix choria-server process

### DIFF
--- a/packager/templates/debian/generic/server.service
+++ b/packager/templates/debian/generic/server.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=root
 Group=root
-ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf
+ExecStart=/bin/sh -c "${COMMAND_PREFIX} {{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf"
 KillMode=process
 
 [Install]


### PR DESCRIPTION
For EL systems, we already have an option to prefix the process with another binary, for example ionice. This option was missing on Debian. To stay consistent, I added it for Debian as well.