### PR TITLE
(misc) EL: Remove command_prefix from systemd unit

### DIFF
--- a/packager/templates/el/generic/server.service
+++ b/packager/templates/el/generic/server.service
@@ -7,7 +7,7 @@ SyslogIdentifier=choria-server
 EnvironmentFile=/etc/sysconfig/{{cpkg_name}}-server
 User=root
 Group=root
-ExecStart=/bin/sh -c "${COMMAND_PREFIX} {{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf"
+ExecStart={{cpkg_bindir}}/{{cpkg_name}} server --config={{cpkg_etcdir}}/server.conf
 KillMode=process
 Restart=on-failure
 RestartSec=5s

--- a/packager/templates/el/global/server.sysconfig
+++ b/packager/templates/el/global/server.sysconfig
@@ -1,6 +1,2 @@
 # These are additional flags to pass to the choria server invocation
 EXTRA_OPTS=""
-
-# This is a prefix command to invoke the server, use this is perhaps you want
-# to run choria in a namespace and wish to invoke nsenter or ip netns exec
-COMMAND_PREFIX=""


### PR DESCRIPTION
Previously, it was possible to set COMMAND_PREFIX in the sysconfig file. This was rarely used and never implemented in Debian. We are removing this.