### PR TITLE
(#2362) feat: Add openvox 9 support

### DIFF
--- a/puppet/puppetwrapper.go
+++ b/puppet/puppetwrapper.go
@@ -107,9 +107,9 @@ func (p *Wrapper) AIOCmd(command string, def string) string {
 	return path
 }
 
-// Setting retrieves a config setting by shelling out to puppet apply --configprint
+// Setting retrieves a config setting by shelling out to puppet config print
 func (p *Wrapper) Setting(setting string) (string, error) {
-	args := []string{"apply", "--environment", "production", "--configprint", setting}
+	args := []string{"config", "print", "--section", "user", setting}
 
 	out, err := exec.Command(p.AIOCmd("puppet", "puppet"), args...).Output()
 	if err != nil {


### PR DESCRIPTION
openvox 9 removed the `--configprint` option. it was deprecated in the source code for ages. `puppet config print` is the successor and available in *every* openvox agent. So this is an enhancment by adding openvox 9 support, it's not a breaking change.